### PR TITLE
Print list of available telecommands

### DIFF
--- a/firmware/Core/Inc/telecommands/telecommand_definitions.h
+++ b/firmware/Core/Inc/telecommands/telecommand_definitions.h
@@ -3,7 +3,6 @@
 #define __INCLUDE_GUARD__TELECOMMAND_DEFINITIONS_H
 
 #include <stdint.h>
-#include "telecommands/telecommand_definitions.h"
 
 typedef enum {
     TCMD_TelecommandChannel_DEBUG_UART,
@@ -40,6 +39,9 @@ uint8_t TCMDEXEC_echo_back_uint32_args(const uint8_t *args_str, TCMD_Telecommand
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 uint8_t TCMDEXEC_run_all_unit_tests(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_available_telecommands(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif // __INCLUDE_GUARD__TELECOMMAND_DEFINITIONS_H

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -35,6 +35,11 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .tcmd_name = "run_all_unit_tests",
         .tcmd_func = TCMDEXEC_run_all_unit_tests,
         .number_of_args = 0,
+    },
+    {
+        .tcmd_name = "available_telecommands",
+        .tcmd_func = TCMDEXEC_available_telecommands,
+        .number_of_args = 0,
     }
 };
 
@@ -96,6 +101,32 @@ uint8_t TCMDEXEC_echo_back_uint32_args(const uint8_t *args_str, TCMD_Telecommand
 uint8_t TCMDEXEC_run_all_unit_tests(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     TEST_run_all_unit_tests_and_log(response_output_buf, response_output_buf_len);
+    return 0;
+}
+
+uint8_t TCMDEXEC_available_telecommands(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+    
+    char response[512] = {0};
+    char *p = response;
+    ssize_t left = sizeof(response);
+    size_t len = 0;
+    snprintf(p, left, "%s", "Available_telecommands\n");
+    p += 23;
+    left -= 23;
+    for (uint16_t i = 0; i < TCMD_NUM_TELECOMMANDS; i++) {
+        len = strlen(TCMD_telecommand_definitions[i].tcmd_name) + 6;
+        snprintf(p, left, "%3u) %s\n", i + 1, TCMD_telecommand_definitions[i].tcmd_name);
+        p += len;
+        if (left > len) {
+            left -= len;
+        }
+        else {
+            break;
+        }
+    }
+    snprintf(response_output_buf, response_output_buf_len, "%s", response);
+
     return 0;
 }
 


### PR DESCRIPTION
Send ```CTS1+available_telecommands()``` from your serial program to get a list of commands accepted by CTS-SAT-1.