### PR TITLE
Telecommands to disable and enable the heartbeat

### DIFF
--- a/firmware/Core/Inc/telecommands/telecommand_definitions.h
+++ b/firmware/Core/Inc/telecommands/telecommand_definitions.h
@@ -29,6 +29,12 @@ extern const int16_t TCMD_NUM_TELECOMMANDS;
 uint8_t TCMDEXEC_hello_world(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
+uint8_t TCMDEXEC_disable_heartbeat(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_enable_heartbeat(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
 uint8_t TCMDEXEC_core_system_stats(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 

--- a/firmware/Core/Inc/telecommands/telecommand_definitions.h
+++ b/firmware/Core/Inc/telecommands/telecommand_definitions.h
@@ -29,10 +29,10 @@ extern const int16_t TCMD_NUM_TELECOMMANDS;
 uint8_t TCMDEXEC_hello_world(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_disable_heartbeat(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_heartbeat_off(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_enable_heartbeat(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_heartbeat_on(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 uint8_t TCMDEXEC_core_system_stats(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <stdio.h>
 
-volatile int TASK_heartbeat_is_enabled = 1;
+volatile uint8_t TASK_heartbeat_is_on = 1;
 
 void TASK_debug_print_heartbeat(void *argument) {
 	TASK_HELP_start_of_task();
@@ -20,8 +20,7 @@ void TASK_debug_print_heartbeat(void *argument) {
 	debug_uart_print_str("TASK_debug_print_heartbeat() -> started (booted)\n");
 	osDelay(100);
 	while (1) {
-        if (TASK_heartbeat_is_enabled)
-        {
+        if (TASK_heartbeat_is_on) {
             debug_uart_print_str("TASK_debug_print_heartbeat() -> top of while(1)\n");
             HAL_GPIO_TogglePin(PIN_LED_DEVKIT_LD2_GPIO_Port, PIN_LED_DEVKIT_LD2_Pin);
         }

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -22,8 +22,8 @@ void TASK_debug_print_heartbeat(void *argument) {
 	while (1) {
         if (TASK_heartbeat_is_on) {
             debug_uart_print_str("TASK_debug_print_heartbeat() -> top of while(1)\n");
-            HAL_GPIO_TogglePin(PIN_LED_DEVKIT_LD2_GPIO_Port, PIN_LED_DEVKIT_LD2_Pin);
-        }
+		}
+		HAL_GPIO_TogglePin(PIN_LED_DEVKIT_LD2_GPIO_Port, PIN_LED_DEVKIT_LD2_Pin);
 		osDelay(1000);
 	}
 }

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -12,14 +12,19 @@
 #include <string.h>
 #include <stdio.h>
 
+volatile int TASK_heartbeat_is_enabled = 1;
+
 void TASK_debug_print_heartbeat(void *argument) {
 	TASK_HELP_start_of_task();
 
 	debug_uart_print_str("TASK_debug_print_heartbeat() -> started (booted)\n");
 	osDelay(100);
 	while (1) {
-		debug_uart_print_str("TASK_debug_print_heartbeat() -> top of while(1)\n");
-		HAL_GPIO_TogglePin(PIN_LED_DEVKIT_LD2_GPIO_Port, PIN_LED_DEVKIT_LD2_Pin);
+        if (TASK_heartbeat_is_enabled)
+        {
+            debug_uart_print_str("TASK_debug_print_heartbeat() -> top of while(1)\n");
+            HAL_GPIO_TogglePin(PIN_LED_DEVKIT_LD2_GPIO_Port, PIN_LED_DEVKIT_LD2_Pin);
+        }
 		osDelay(1000);
 	}
 }

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -9,11 +9,23 @@
 #include <string.h>
 #include <inttypes.h>
 
+extern volatile int TASK_heartbeat_is_enabled;
+
 // extern
 const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
     {
         .tcmd_name = "hello_world",
         .tcmd_func = TCMDEXEC_hello_world,
+        .number_of_args = 0,
+    },
+    {
+        .tcmd_name = "disable_heartbeat",
+        .tcmd_func = TCMDEXEC_disable_heartbeat,
+        .number_of_args = 0,
+    },
+    {
+        .tcmd_name = "enable_heartbeat",
+        .tcmd_func = TCMDEXEC_enable_heartbeat,
         .number_of_args = 0,
     },
     {
@@ -53,6 +65,20 @@ const int16_t TCMD_NUM_TELECOMMANDS = sizeof(TCMD_telecommand_definitions) / siz
 uint8_t TCMDEXEC_hello_world(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     snprintf(response_output_buf, response_output_buf_len, "Hello, world!\n");
+    return 0;
+}
+
+uint8_t TCMDEXEC_disable_heartbeat(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+    TASK_heartbeat_is_enabled = 0;
+    snprintf(response_output_buf, response_output_buf_len, "Heartbeat disabled");
+    return 0;
+}
+
+uint8_t TCMDEXEC_enable_heartbeat(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+    TASK_heartbeat_is_enabled = 1;
+    snprintf(response_output_buf, response_output_buf_len, "Heartbeat enabled");
     return 0;
 }
 

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <inttypes.h>
 
-extern volatile int TASK_heartbeat_is_enabled;
+extern volatile uint8_t TASK_heartbeat_is_on;
 
 // extern
 const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
@@ -19,13 +19,13 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .number_of_args = 0,
     },
     {
-        .tcmd_name = "disable_heartbeat",
-        .tcmd_func = TCMDEXEC_disable_heartbeat,
+        .tcmd_name = "heartbeat_off",
+        .tcmd_func = TCMDEXEC_heartbeat_off,
         .number_of_args = 0,
     },
     {
-        .tcmd_name = "enable_heartbeat",
-        .tcmd_func = TCMDEXEC_enable_heartbeat,
+        .tcmd_name = "heartbeat_on",
+        .tcmd_func = TCMDEXEC_heartbeat_on,
         .number_of_args = 0,
     },
     {
@@ -68,17 +68,17 @@ uint8_t TCMDEXEC_hello_world(const uint8_t *args_str, TCMD_TelecommandChannel_en
     return 0;
 }
 
-uint8_t TCMDEXEC_disable_heartbeat(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_heartbeat_off(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
-    TASK_heartbeat_is_enabled = 0;
-    snprintf(response_output_buf, response_output_buf_len, "Heartbeat disabled");
+    TASK_heartbeat_is_on = 0;
+    snprintf(response_output_buf, response_output_buf_len, "Heartbeat OFF");
     return 0;
 }
 
-uint8_t TCMDEXEC_enable_heartbeat(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_heartbeat_on(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
-    TASK_heartbeat_is_enabled = 1;
-    snprintf(response_output_buf, response_output_buf_len, "Heartbeat enabled");
+    TASK_heartbeat_is_on = 1;
+    snprintf(response_output_buf, response_output_buf_len, "Heartbeat ON");
     return 0;
 }
 


### PR DESCRIPTION
Two convenience telecommands for adjusting the verbosity of the heartbeat telemetry while developing firmware.