### PR TITLE
Added loop timeouts and attended to other FIXME comments in `flash_driver.c` (Issue #46)

### DIFF
--- a/firmware/Core/Inc/littlefs/flash_driver.h
+++ b/firmware/Core/Inc/littlefs/flash_driver.h
@@ -20,26 +20,36 @@
 #define FLASH_CHIP_SIZE_BYTES 67108864 // 64MiB // TODO: update
 
 /*-----------------------------COMMAND VARIABLES-----------------------------*/
-// ---------------------------------------- S25FL512S 512Mb (64MB) Datasheet
-static const uint8_t FLASH_READ = 0x03;  // Read - Section 9.4.1
-static const uint8_t FLASH_4READ = 0x13;  // Read - Section 9.4.1
+// All comments in this section refer to the "S25FL512S 512Mb (64MB)" Datasheet by Infineon
 
-static const uint8_t FLASH_WRITE = 0x02; // Page Program - Section 9.5.2
-static const uint8_t FLASH_4WRITE = 0x12; // Page Program - Section 9.5.2
+static const uint8_t FLASH_CMD_READ_3_BYTE_ADDR = 0x03;  // Read - Section 9.4.1
+static const uint8_t FLASH_CMD_READ_4_BYTE_ADDR = 0x13;  // Read - Section 9.4.1
 
-static const uint8_t FLASH_SE = 0xD8;  // Sector Erase - Section 9.6.1
-static const uint8_t FLASH_4SE = 0xDC; // Sector Erase - Section 9.6.1
+static const uint8_t FLASH_CMD_WRITE_3_BYTE_ADDR = 0x02; // Page Program - Section 9.5.2
+static const uint8_t FLASH_CMD_WRITE_4_BYTE_ADDR = 0x12; // Page Program - Section 9.5.2
 
-static const uint8_t FLASH_WRDI = 0x04; // Write Disable - Section 9.3.9
-static const uint8_t FLASH_WREN = 0x06; // Write Enable - Section 9.3.8
+static const uint8_t FLASH_CMD_SECTOR_ERASE_3_BYTE_ADDR = 0xD8;  // Sector Erase - Section 9.6.1
+static const uint8_t FLASH_CMD_SECTOR_ERASE_4_BYTE_ADDR = 0xDC; // Sector Erase - Section 9.6.1
 
-static const uint8_t FLASH_RDSR1 = 0x05; // Read Status 1 - Section 9.3.1 / 7.6.1
-static const uint8_t FLASH_RDSR2 = 0x07; // Read Status 2 - Section 9.3.2
-static const uint8_t FLASH_CLSR = 0x30;  // Clear Status - Section 9.3.10
+static const uint8_t FLASH_CMD_WRITE_DISABLE = 0x04; // Write Disable - Section 9.3.9
+static const uint8_t FLASH_CMD_WRITE_ENABLE = 0x06; // Write Enable - Section 9.3.8
 
-static const uint8_t FLASH_RDCR = 0x35; // Read Config - Section 9.3.3
+static const uint8_t FLASH_CMD_READ_STATUS_REG_1 = 0x05; // Read Status 1 - Section 9.3.1, Byte Descriptions in 7.6.1
+static const uint8_t FLASH_CMD_READ_STATUS_REG_2 = 0x07; // Read Status 2 - Section 9.3.2
+static const uint8_t FLASH_CMD_CLEAR_STATUS = 0x30;  // Clear Status - Section 9.3.10
 
-static const uint8_t FLASH_RESET = 0xF0; // Software Reset - Section 9.9.1
+static const uint8_t FLASH_CMD_READ_CONFIG = 0x35; // Read Config - Section 9.3.3
+
+static const uint8_t FLASH_CMD_SOFTWARE_RESET = 0xF0; // Software Reset - Section 9.9.1
+
+static const uint8_t FLASH_CMD_READ_ID = 0x9F; // "RDID" - Read ID - Section 9.2.2
+
+// ------------------- Status Register 1 - Byte Masks -------------------
+// Source: Section 7.6.1
+static const uint8_t FLASH_SR1_WRITE_IN_PROGRESS_MASK = (1 << 0);
+static const uint8_t FLASH_SR1_WRITE_ENABLE_LATCH_MASK = (1 << 1);
+static const uint8_t FLASH_SR1_PROGRAMMING_ERROR_MASK = (1 << 6);
+static const uint8_t FLASH_SR1_ERASE_ERROR_MASK = (1 << 5);
 
 
 /*-----------------------------DRIVER FUNCTIONS-----------------------------*/

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -7,8 +7,24 @@
 /// Timeout duration for HAL_SPI_READ/WRITE operations.
 #define FLASH_HAL_TIMEOUT_MS 5
 
-/// Duration to wait for the status register to update before timing out.
-#define FLASH_LOOP_TIMEOUT_MS 10
+// The following timeout values are sourced from Section 11.3.1, Table 56: "CFI system interface string"
+// and are interpreted using: https://www.infineon.com/dgdl/Infineon-AN98488_Quick_Guide_to_Common_Flash_Interface-ApplicationNotes-v05_00-EN.pdf
+
+/// Duration to wait for the status register to show that Write Enable Latch changed status.
+// Assume this value is the same as the typical timeout for a register change.
+#define FLASH_LOOP_REGISTER_CHANGE_TIMEOUT_MS 10
+
+/// Duration to wait for the status register to show that Write In Progress bit changed status, for writes.
+// "Typical timeout for page program" = 2^(0x09) us = 0.5 ms
+// "Max timeout for page program" = 2^(0x02) * typical = 2 ms
+// With a safety factor of 5, we get 10 ms.
+#define FLASH_LOOP_WRITE_TIMEOUT_MS 10
+
+/// Duration to wait for the status register to show that Write In Progress bit changed status, for erases.
+// "Typical timeout for sector erase" = 2^(0x09) ms = 512 ms
+// "Max timeout for sector erase" = 2^(0x03) * typical = 4096 ms
+// 4 seconds is a very long time, so no safety factor is applied here (to avoid lockups).
+#define FLASH_LOOP_SECTOR_ERASE_TIMEOUT_MS 4096
 
 // -----------------------------FLASH DRIVER FUNCTIONS-----------------------------
 
@@ -74,7 +90,7 @@ void FLASH_deactivate_chip_select()
 uint8_t FLASH_read_status_register(SPI_HandleTypeDef *hspi, uint8_t chip_number, uint8_t *buf)
 {
     FLASH_activate_chip_select(chip_number);
-    const HAL_StatusTypeDef tx_result = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_RDSR1, 1, FLASH_HAL_TIMEOUT_MS);
+    const HAL_StatusTypeDef tx_result = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_READ_STATUS_REG_1, 1, FLASH_HAL_TIMEOUT_MS);
     if (tx_result != HAL_OK) {
         FLASH_deactivate_chip_select();
         return 1;
@@ -87,7 +103,6 @@ uint8_t FLASH_read_status_register(SPI_HandleTypeDef *hspi, uint8_t chip_number,
     }
 
     FLASH_deactivate_chip_select();
-
     return 0;
 }
 
@@ -99,39 +114,44 @@ uint8_t FLASH_read_status_register(SPI_HandleTypeDef *hspi, uint8_t chip_number,
  */
 uint8_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
 {
-    // Buffer to store status register values in
+    // Buffer to store status register value
     uint8_t status_reg_buffer[1] = {0};
 
     FLASH_activate_chip_select(chip_number);
-    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_WREN, 1, FLASH_HAL_TIMEOUT_MS);
+    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_WRITE_ENABLE, 1, FLASH_HAL_TIMEOUT_MS);
     FLASH_deactivate_chip_select();
     if (tx_result_1 != HAL_OK) {
         return 1;
     }
 
-    // Keep looping as long as device is busy (until the Write Enable Latch is set)
-    const uint32_t loop_limit = HAL_GetTick() + FLASH_LOOP_TIMEOUT_MS;
-    uint8_t wip = 1;
-    while (wip)
+    // Keep looping as long as device is busy (until the Write Enable Latch is active [1])
+    const uint32_t start_loop_time_ms = HAL_GetTick();
+    while (1)
     {
-        const uint32_t current_time = HAL_GetTick();
-        if (current_time > loop_limit) {
-            DEBUG_uart_print_str("Flash write enable timeout\n");
-            return 2;
-        }
-
         const uint8_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
         if (read_status_result != 0) {
             FLASH_deactivate_chip_select();
             return 3;
         }
-        wip = status_reg_buffer[0] & 0x01;
 
-        DEBUG_uart_print_str("DEBUG: status_reg = ");
+        if ((status_reg_buffer[0] & FLASH_SR1_WRITE_ENABLE_LATCH_MASK) > 0) {
+            // Success condition: write enabled.
+            return 0;
+        }
+
+        // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
+        if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_REGISTER_CHANGE_TIMEOUT_MS) {
+            DEBUG_uart_print_str("Flash write enable timeout\n");
+            return 2;
+        }
+
+        DEBUG_uart_print_str("DEBUG: status_reg = 0x");
         DEBUG_uart_print_array_hex(status_reg_buffer, 1);
         DEBUG_uart_print_str("\n");
     }
-    return 0;
+
+    // Should never be reached:
+    return 5;
 }
 
 /**
@@ -142,39 +162,44 @@ uint8_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
  */
 uint8_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
 {
-    // Buffer to store status register values in
+    // Buffer to store status register value
     uint8_t status_reg_buffer[1] = {0};
 
     FLASH_activate_chip_select(chip_number);
-    const HAL_StatusTypeDef tx_status = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_WRDI, 1, FLASH_HAL_TIMEOUT_MS);
+    const HAL_StatusTypeDef tx_status = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_WRITE_DISABLE, 1, FLASH_HAL_TIMEOUT_MS);
     FLASH_deactivate_chip_select();
     if (tx_status != HAL_OK) {
         return 1;
     }
 
-    // Keep looping as long as device is busy (until the Write Enable Latch is 0)
-    const uint32_t loop_limit = HAL_GetTick() + FLASH_LOOP_TIMEOUT_MS;
-    uint8_t write_enable_latch = 1;
-    while (write_enable_latch)
+    // Keep looping as long as device is busy (until the Write Enable Latch is inactive [0])
+    const uint32_t start_loop_time_ms = HAL_GetTick();
+    while (1)
     {
-        const uint32_t current_time = HAL_GetTick();
-        if (current_time > loop_limit) {
-            DEBUG_uart_print_str("Flash write disable timeout\n");
-            return 2;
-        }
-
         const uint8_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
         if (read_status_result != 0) {
             FLASH_deactivate_chip_select();
             return 3;
         }
-        write_enable_latch = status_reg_buffer[0] & 0x02;
-        
-        DEBUG_uart_print_str("DEBUG: status_reg = ");
+
+        if ((status_reg_buffer[0] & FLASH_SR1_WRITE_ENABLE_LATCH_MASK) == 0) {
+            // Success condition: write disabled.
+            return 0;
+        }
+
+        // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
+        if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_REGISTER_CHANGE_TIMEOUT_MS) {
+            DEBUG_uart_print_str("Flash write disable timeout\n");
+            return 2;
+        }
+
+        DEBUG_uart_print_str("DEBUG: status_reg = 0x");
         DEBUG_uart_print_array_hex(status_reg_buffer, 1);
         DEBUG_uart_print_str("\n");
     }
-    return 0;
+
+    // Should never be reached:
+    return 5;
 }
 
 /**
@@ -198,7 +223,7 @@ uint8_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
 
     // Send Sector Erase Command
     FLASH_activate_chip_select(chip_number);
-    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_4SE, 1, FLASH_HAL_TIMEOUT_MS);
+    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_SECTOR_ERASE_4_BYTE_ADDR, 1, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
         return 2;
@@ -210,33 +235,43 @@ uint8_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
     }
     FLASH_deactivate_chip_select();
 
-    // Buffer to store status register values in
+    // Buffer to store status register value
     uint8_t status_reg_buffer[1] = {0};
 
-    // Keep looping as long as device is busy
-    const uint32_t loop_limit = HAL_GetTick() + FLASH_LOOP_TIMEOUT_MS;
-    uint8_t wip = 1;
-    while (wip)
+    // Keep looping as long as device is busy (until the Write Enable Latch is active [1])
+    const uint32_t start_loop_time_ms = HAL_GetTick();
+    while (1)
     {
-        const uint32_t current_time = HAL_GetTick();
-        if (current_time > loop_limit) {
-            DEBUG_uart_print_str("Flash erase timeout\n");
+        const uint8_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
+        if (read_status_result != 0) {
+            FLASH_deactivate_chip_select();
+            return 3;
+        }
+
+        if ((status_reg_buffer[0] & FLASH_SR1_ERASE_ERROR_MASK) > 0) {
+            // Flash module returned "erase error" via the status register.
+            DEBUG_uart_print_str("Flash erase error\n");
             return 4;
         }
 
-        const uint8_t status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
-        if (status_result != 0) {
-            FLASH_deactivate_chip_select();
-            return 5;
+        if ((status_reg_buffer[0] & FLASH_SR1_WRITE_IN_PROGRESS_MASK) == 0) {
+            // Success condition: write in progress has completed.
+            return 0;
         }
-        wip = status_reg_buffer[0] & 0x01;
-        uint8_t err = status_reg_buffer[0] & 0b01000000;
-        if (err == 1) {
-            return 6;
+
+        // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
+        if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_SECTOR_ERASE_TIMEOUT_MS) {
+            DEBUG_uart_print_str("Flash erase timeout\n");
+            return 2;
         }
+
+        DEBUG_uart_print_str("DEBUG: status_reg = 0x");
+        DEBUG_uart_print_array_hex(status_reg_buffer, 1);
+        DEBUG_uart_print_str("\n");
     }
 
-    return 0;
+    // Should never be reached:
+    return 5;
 }
 
 /**
@@ -262,7 +297,7 @@ uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
 
     // Send WREN Command and the Data required with the command
     FLASH_activate_chip_select(chip_number);
-    const uint8_t tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_4WRITE, 1, FLASH_HAL_TIMEOUT_MS);
+    const uint8_t tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_WRITE_4_BYTE_ADDR, 1, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
         return 2;
@@ -277,41 +312,44 @@ uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
         FLASH_deactivate_chip_select();
         return 4;
     }
-    
-    // NOTE: The following line is now commented out. It was previously here though, weird.
-    // FLASH_deactivate_chip_select();
 
-    // Buffer to store status register values in
+    // Buffer to store status register value
     uint8_t status_reg_buffer[1] = {0};
 
-    // Keep looping as long as device is busy
-    const uint32_t loop_limit = HAL_GetTick() + FLASH_LOOP_TIMEOUT_MS;
-    uint8_t wip = 1;
-    uint8_t err = 0;
-    while (wip)
+    // Keep looping as long as device is busy (until the Write Enable Latch is active [1])
+    const uint32_t start_loop_time_ms = HAL_GetTick();
+    while (1)
     {
-        const uint32_t current_time = HAL_GetTick();
-        if (current_time > loop_limit) {
+        const uint8_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
+        if (read_status_result != 0) {
+            FLASH_deactivate_chip_select();
+            return 3;
+        }
+
+        if ((status_reg_buffer[0] & FLASH_SR1_PROGRAMMING_ERROR_MASK) > 0) {
+            // Flash module returned "programming error" via the status register.
+            DEBUG_uart_print_str("Flash programming error\n");
+            return 4;
+        }
+
+        if ((status_reg_buffer[0] & FLASH_SR1_WRITE_IN_PROGRESS_MASK) == 0) {
+            // Success condition: write in progress has completed.
+            return 0;
+        }
+
+        // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
+        if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_WRITE_TIMEOUT_MS) {
             DEBUG_uart_print_str("Flash write timeout\n");
             return 2;
         }
-        const uint8_t status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
-        if (status_result != 0) {
-            FLASH_deactivate_chip_select();
-            return 5;
-        }
-        
-        wip = status_reg_buffer[0] & 0x01;
-        err = status_reg_buffer[0] & 0b01000000;
-        if (err == 1) {
-            break;
-        }
+
+        DEBUG_uart_print_str("DEBUG: status_reg = 0x");
+        DEBUG_uart_print_array_hex(status_reg_buffer, 1);
+        DEBUG_uart_print_str("\n");
     }
-    if (err) {
-        return 10;
-    }
-    
-    return 0;
+
+    // Should never be reached:
+    return 5;
 }
 
 /**
@@ -330,7 +368,7 @@ uint8_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_
 
     // Send Read Command and the data required with it
     FLASH_activate_chip_select(chip_number);
-    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_4READ, 1, FLASH_HAL_TIMEOUT_MS);
+    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_READ_4_BYTE_ADDR, 1, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
         return 1;
@@ -355,22 +393,21 @@ uint8_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
 {
     // TODO: confirm if this works with the CS2 logical chip on each physical FLASH chip;
     // ^ Seems as though it only works for CS1.
-    const uint8_t READ_ID_CMD = 0x9F;
 
-    uint8_t tx_buffer[1] = {READ_ID_CMD};
+    uint8_t tx_buffer[1] = {FLASH_CMD_READ_ID};
     uint8_t rx_buffer[5];
     memset(rx_buffer, 0, 5);
 
     FLASH_activate_chip_select(chip_number);
 
     // Transmit the READ_ID_CMD
-    if (HAL_SPI_Transmit(&hspi1, tx_buffer, 1, FLASH_HAL_TIMEOUT_MS) != HAL_OK) {
+    if (HAL_SPI_Transmit(hspi, tx_buffer, 1, FLASH_HAL_TIMEOUT_MS) != HAL_OK) {
         FLASH_deactivate_chip_select();
         return 1;
     }
 
     // Receive the response
-    if (HAL_SPI_Receive(&hspi1, rx_buffer, 5, FLASH_HAL_TIMEOUT_MS) != HAL_OK) {
+    if (HAL_SPI_Receive(hspi, rx_buffer, 5, FLASH_HAL_TIMEOUT_MS) != HAL_OK) {
         FLASH_deactivate_chip_select();
         return 2;
     }

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -1,5 +1,4 @@
 /*-----------------------------INCLUDES-----------------------------*/
-#include <time.h>
 #include "main.h"
 
 #include "littlefs/flash_driver.h"

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -141,17 +141,13 @@ uint8_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
  */
 uint8_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
 {
-    // FIXME: THIS FUNCTIONS IS NOT USED. It doesn't activate a chip select line even.
-    return 30;
-
     // Buffer to store status register values in
     uint8_t status_reg_buffer[1] = {0};
 
-    FLASH_deactivate_chip_select(); // FIXME: activate?
+    FLASH_activate_chip_select(chip_number);
     const HAL_StatusTypeDef tx_status = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_WRDI, 1, FLASH_TIMEOUT_MS);
-
+    FLASH_deactivate_chip_select();
     if (tx_status != HAL_OK) {
-        FLASH_deactivate_chip_select();
         return 1;
     }
 
@@ -172,6 +168,10 @@ uint8_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
             return 3;
         }
         wel = status_reg_buffer[0] & 2;
+        
+        DEBUG_uart_print_str("DEBUG: status_reg = ");
+        DEBUG_uart_print_array_hex(status_reg_buffer, 1);
+        DEBUG_uart_print_str("\n");
     }
     return 0;
 }

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -6,7 +6,7 @@
 
 // TODO: check on timeout, maybe decrease a lot
 #define FLASH_TIMEOUT_MS 50
-#define FLASH_LOOP_TIMEOUT_MS 50
+#define FLASH_LOOP_TIMEOUT_MS 5000
 
 // -----------------------------FLASH DRIVER FUNCTIONS-----------------------------
 


### PR DESCRIPTION
## Issue #46
`LOOP_TIMEOUT_MS` defines the number of milliseconds to wait before we consider it a failed attempt or timeout.
Added timeout on all `// TODO:` sections with while loop. Fixed the bug where chip select would deactivate instead of activate in `FLASH_write_disable()`. 

### Possible next issues to consider:
1. For organizational purposes, we can create enum for errors as many errors are quite common in `flash_driver.c`
2. Go through the functions and compare them with the commands within the datasheet to make sure all errors are being handled and edge cases are being covered.