### PR TITLE
Timekeeping update for Issue 42

### DIFF
--- a/firmware/Core/Inc/telecommands/timekeeping_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/timekeeping_telecommand_defs.h
@@ -1,0 +1,14 @@
+
+#ifndef __INCLUDE_GUARD__TIMEKEEPING_TELECOMMAND_DEFS_H__
+#define __INCLUDE_GUARD__TIMEKEEPING_TELECOMMAND_DEFS_H__
+
+#include <stdint.h>
+#include "telecommands/telecommand_definitions.h"
+
+uint8_t TCMDEXEC_get_system_time(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_set_system_time(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+#endif /* __INCLUDE_GUARD__FLASH_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Inc/timekeeping/timekeeping.h
+++ b/firmware/Core/Inc/timekeeping/timekeeping.h
@@ -1,0 +1,24 @@
+#ifndef __INCLUDE_GUARD__TIMEKEEPING_H_
+#define __INCLUDE_GUARD__TIMEKEEPING_H_
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#define TIM_EPOCH_DECIMAL_STRING_LEN 14
+
+typedef enum TIM_SYNC_SOURCE {
+    TIM_SOURCE_NONE = 0,
+    TIM_SOURCE_GNSS,
+    TIM_SOURCE_TELECOMMAND,
+} TIM_sync_source_t;
+
+uint32_t TIM_get_current_system_uptime_ms(void);
+void TIM_set_current_unix_epoch_time_ms(uint64_t current_unix_epoch_time_ms, TIM_sync_source_t source);
+uint64_t TIM_get_current_unix_epoch_time_ms();
+
+void TIM_get_timestamp_string(char *log_str, size_t max_len); 
+void TIM_get_timestamp_string_datetime(char *log_str, size_t max_len);
+char TIM_synchronization_source_letter(TIM_sync_source_t source);
+void TIM_epoch_ms_to_decimal_string(char *str, size_t len);
+
+#endif // __INCLUDE_GUARD__TIMEKEEPING_H_

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -3,10 +3,12 @@
 #include "telecommands/telecommand_args_helpers.h"
 #include "transforms/arrays.h"
 #include "unit_tests/unit_test_executor.h"
+#include "timekeeping/timekeeping.h"
 
 // Additional telecommand definitions files:
 #include "telecommands/flash_telecommand_defs.h"
 #include "telecommands/lfs_telecommand_defs.h"
+#include "telecommands/timekeeping_telecommand_defs.h"
 
 
 #include <stdio.h>
@@ -51,6 +53,16 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
     {
         .tcmd_name = "run_all_unit_tests",
         .tcmd_func = TCMDEXEC_run_all_unit_tests,
+        .number_of_args = 0,
+    },
+    {
+        .tcmd_name = "get_system_time",
+        .tcmd_func = TCMDEXEC_get_system_time,
+        .number_of_args = 0,
+    },
+    {
+        .tcmd_name = "set_system_time",
+        .tcmd_func = TCMDEXEC_set_system_time,
         .number_of_args = 0,
     },
     {

--- a/firmware/Core/Src/telecommands/timekeeping_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/timekeeping_telecommand_defs.c
@@ -1,0 +1,28 @@
+#include "telecommands/timekeeping_telecommand_defs.h"
+#include "telecommands/telecommand_args_helpers.h"
+
+#include "timekeeping/timekeeping.h"
+
+#include <stdio.h>
+#include <string.h>
+
+uint8_t TCMDEXEC_get_system_time(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+    TIM_get_timestamp_string(response_output_buf, response_output_buf_len);
+    return 0;
+}
+
+uint8_t TCMDEXEC_set_system_time(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+  
+    uint64_t ms = 0;
+
+    uint8_t result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 0, &ms);
+    if (result != 0) {
+        return 1;
+    }
+    TIM_set_current_unix_epoch_time_ms(ms, TIM_SOURCE_TELECOMMAND);
+    snprintf(response_output_buf, response_output_buf_len, "Updated system time");
+    return 0;
+}
+

--- a/firmware/Core/Src/timekeeping/timekeeping.c
+++ b/firmware/Core/Src/timekeeping/timekeeping.c
@@ -1,0 +1,178 @@
+#include "timekeeping/timekeeping.h"
+#include "debug_tools/debug_uart.h"
+#include "stm32l4xx_hal.h"
+
+#include <stdio.h>
+#include <inttypes.h>
+#include <string.h>
+#include <time.h>
+
+uint64_t TIM_unix_epoch_time_at_last_time_resync_ms = 0;
+uint32_t TIM_system_uptime_at_last_time_resync_ms = 0;
+TIM_sync_source_t TIM_last_synchronization_source = TIM_SOURCE_NONE;
+
+uint32_t TIM_get_current_system_uptime_ms(void) {
+    return HAL_GetTick();
+}
+
+/// @brief Use this function in a telecommand, or upon receiving a time update from the GPS. 
+void TIM_set_current_unix_epoch_time_ms(uint64_t current_unix_epoch_time_ms, TIM_sync_source_t source) {
+    TIM_unix_epoch_time_at_last_time_resync_ms = current_unix_epoch_time_ms;
+    TIM_system_uptime_at_last_time_resync_ms = HAL_GetTick();
+    TIM_last_synchronization_source = source;
+}
+
+/// @brief Returns the current unix timestamp, in milliseconds
+uint64_t TIM_get_current_unix_epoch_time_ms() {
+    return (HAL_GetTick() - TIM_system_uptime_at_last_time_resync_ms) + TIM_unix_epoch_time_at_last_time_resync_ms;
+}
+
+/// @brief Returns a computer-friendly timestamp string. 
+/// @param log_str - Pointer to buffer that stores the log string 
+/// @param max_len - Maximum length of log_str buffer
+/// @detail The string identifies the current Unix time, and the
+/// synchronization source (N - none; G - GNSS/GPS; T - telecommand), 
+/// and the time passed in ms since the last synchronization.
+/// Example: "1719169299720_G_0000042000"
+void TIM_get_timestamp_string(char *log_str, size_t max_len) {
+
+    if (max_len < TIM_EPOCH_DECIMAL_STRING_LEN) {
+        return;
+    }
+    char source = TIM_synchronization_source_letter(TIM_last_synchronization_source);
+    uint32_t delta_uptime = TIM_get_current_system_uptime_ms() - TIM_system_uptime_at_last_time_resync_ms;
+    TIM_epoch_ms_to_decimal_string(log_str, max_len);
+    snprintf(log_str + TIM_EPOCH_DECIMAL_STRING_LEN - 1, max_len - TIM_EPOCH_DECIMAL_STRING_LEN, "_%c_%010lu", source, delta_uptime); 
+
+    return;
+}
+
+
+/// @brief Returns a human-friendly timestamp string 
+/// @param log_str - Pointer to buffer that stores the log string 
+/// @param max_len - Maximum length of log_str buffer
+/// @detail The string identifies the current Unix time, and number of 
+/// milliseconds since the time was last synchronized to a reference source.
+/// String format:
+/// yyyymmddTHHMMSS.sss_X_rrr...
+///
+/// where
+/// 
+/// yyyy: year
+/// mm: month (01 to 12)
+/// dd: day of month (01 to 31)
+/// HH: hour (00 to 24)
+/// MM: minute (00 to 59)
+/// SS: second (00 to 60)
+/// sss: millisecond
+/// X: last synchronization source, one of N (none), G (GNSS/GPS), T (telecommand)
+/// rrr... milliseconds since last time synchronization
+/// Example output: 20240623T180132.142_T_420204
+void TIM_get_timestamp_string_datetime(char *log_str, size_t max_len) {
+    uint64_t epoch = TIM_get_current_unix_epoch_time_ms();
+    time_t seconds = (time_t)(epoch/ 1000U);
+    uint16_t ms = epoch - 1000U * seconds;
+    struct tm *time_info = gmtime(&seconds);
+
+    char source = TIM_synchronization_source_letter(TIM_last_synchronization_source);
+    uint32_t delta_uptime = TIM_get_current_system_uptime_ms() - TIM_system_uptime_at_last_time_resync_ms;
+    snprintf(
+        log_str, 
+        max_len, 
+        "%d%02d%02dT%02d%02d%02d.%03u_%c_%lu", 
+        time_info->tm_year + 1900, 
+        time_info->tm_mon + 1, 
+        time_info->tm_mday, 
+        time_info->tm_hour, 
+        time_info->tm_min, 
+        time_info->tm_sec, 
+        ms, 
+        source,
+        delta_uptime
+    );
+
+    return;
+}
+
+char TIM_synchronization_source_letter(TIM_sync_source_t source) {
+
+    char source_letter;
+    switch (TIM_last_synchronization_source) {
+        case TIM_SOURCE_GNSS:
+            source_letter = 'G';
+            break;
+        case TIM_SOURCE_TELECOMMAND:
+            source_letter = 'T';
+            break;
+        case TIM_SOURCE_NONE:
+            source_letter = 'N';
+            break;
+        default:
+            source_letter = 'E';
+            break;
+    }
+
+    return source_letter;
+}
+
+/// @brief Efficient conversion of the synchronized epoch in ms to a decimal
+/// string
+/// @param str - buffer to store result in 
+/// @param len - size of result buffer 
+/// @detail Strategy: Keep track of the previous large part of ms
+/// This will change rarely, and most of the time only the 9 least significant
+/// decimal digits need to be updated.
+///
+/// 100 years from 1 Jan 2024, the value of ms will be 2_019_686_400_000. 
+/// For the timestamp string, let's set aside 13 digits of the possible 20 for 
+/// an unsigned 64-bit number needed to store ms since the 1970 epoch. 
+///
+/// We use snprintf to print the least-significant digits of ms on every call.
+/// With the "%lu" format string, 32 bits can be printed in one go, i.e. up to
+/// the number 4_294_967_295. We will have to restrict printing the 9
+/// right-most digits with "%09lu", leaving the remaining digits to be
+/// calculated individually.
+///
+/// The remaining digits to the left will have to be printed only every 
+/// 3.4 days.
+///
+/// Characters of ms_digits[] in order of most significant to least:
+///      12 11 10  9        8  7  6  5  4  3  2  1  0 '\0'
+/// Array index
+///       0  1  2  3        4  5  6  7  8  9 10 11 12 13
+/// --  updated at sync  -- |  -- updated every call  -- 
+///      or typically 
+///     every 3.4 days
+void TIM_epoch_ms_to_decimal_string(char *str, size_t len) {
+
+    static uint64_t last_ms_large_part = 0;
+    static char ms_digits[TIM_EPOCH_DECIMAL_STRING_LEN] = "0000000000000";
+
+    uint64_t ms = TIM_get_current_unix_epoch_time_ms();
+    
+    uint32_t ms_small_part = ms % 1000000000;
+
+    // On every call to this function, update the right-most 9 digits
+    snprintf(ms_digits + 4, 10, "%09lu", ms_small_part);
+
+    // Return if there is nothing else to do
+    uint64_t ms_large_part = ms / 1000000000;
+    if (ms_large_part == last_ms_large_part) {
+        snprintf(str, len, "%s", ms_digits);
+        return;
+    }
+
+    // Update the large part, one digit at a time
+    uint8_t digit = 0;
+    uint64_t working_large_part = ms_large_part;
+    for (int8_t d = 3; d >= 0; d--) {
+        digit = working_large_part % 10;
+        // ASCII '0' is 48 (decimal)
+        ms_digits[d] = (char)(48 + digit);
+        working_large_part /= 10;
+    }
+    last_ms_large_part = ms_large_part;
+    snprintf(str, len, "%s", ms_digits);
+    return;
+
+}


### PR DESCRIPTION
A reliable timekeeping system will go a long way toward supporting the interpretation of MPI science observations, troubleshooting in-flight operations issues, and planning mission operations.

Setting up timekeeping based on the real-time clock (RTC) seems complicated, since the specific method is hardware dependent and somewhat elaborate.

As a first step to a simple timekeeping framework, this PR uses a `uint64_t` to store milliseconds since the UNIX epoch: midnight on 1 January 1970. 

A straightforward way to do this is to add a `volatile uint64_t uwTick64` global variable to `firmware/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal.c` and make it increment every millisecond whenever `HAL_IncTick()` runs. Editing that file is not ideal. But `HAL_IncTick` has attribute `__weak`, so maybe we can reimplement this function in timekeeping.c to avoid messing with the HAL driver source.

The heartbeat task has been updated to `osDelay` for slightly less than 1 second, such that the time can be printed precisely at the beginning of each second.

Two telecommands are provided for setting and reporting the system time.

This approach may suit the mission, as long as we have GPS timing; an IRQ timer, or the heartbeat task, could routinely set the system time from the GPS time when it is available, possibly taking into account GPS leap seconds (read from a file) to get UTC (coordinated universal time) onboard.

If the STM32 resets (temporary power loss, say), the system time can be reset once the GPS acquires satellites. But if the GPS has to be powered down by the OBC due to battery or power issues, the clock can be set by telecommand during a ground station overflight.

In the event of a GPS failure, sync'ing the system time during ground-station passes several times per week would likely provide timing to the nearest few seconds or so. That would be sufficient for logging, timestamping files, etc. An RTC solution might be moot.