### PR TITLE
Change `args_str` type from `uint8_t*` to `char*`

### DIFF
--- a/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
@@ -5,19 +5,19 @@
 #include <stdint.h>
 #include "telecommands/telecommand_definitions.h"
 
-uint8_t TCMDEXEC_flash_activate_each_cs(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_activate_each_cs(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_flash_each_is_reachable(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_each_is_reachable(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
                         
-uint8_t TCMDEXEC_flash_read_hex(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_flash_write_hex(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_flash_erase(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif /* __INCLUDE_GUARD__FLASH_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Inc/telecommands/lfs_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/lfs_telecommand_defs.h
@@ -5,22 +5,22 @@
 #include <stdint.h>
 #include "telecommands/telecommand_definitions.h"
 
-uint8_t TCMDEXEC_fs_format_storage(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_format_storage(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_fs_mount(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_mount(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_fs_unmount(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_unmount(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_fs_write_file(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_write_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
                         
-uint8_t TCMDEXEC_fs_read_file(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_read_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_fs_demo_write_then_read(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif /* __INCLUDE_GUARD__LFS_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Inc/telecommands/telecommand_definitions.h
+++ b/firmware/Core/Inc/telecommands/telecommand_definitions.h
@@ -9,7 +9,7 @@ typedef enum {
     TCMD_TelecommandChannel_RADIO1
 } TCMD_TelecommandChannel_enum_t;
 
-typedef uint8_t (*TCMD_TCMDEXEC_Function_Ptr)(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+typedef uint8_t (*TCMD_TCMDEXEC_Function_Ptr)(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                                          char *response_output_buf, uint16_t response_output_buf_len);
 
 typedef struct {
@@ -26,28 +26,28 @@ extern const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[];
 extern const int16_t TCMD_NUM_TELECOMMANDS;
 
 
-uint8_t TCMDEXEC_hello_world(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_hello_world(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_heartbeat_off(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_heartbeat_off(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_heartbeat_on(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_heartbeat_on(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_core_system_stats(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_core_system_stats(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_echo_back_args(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_echo_back_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_echo_back_uint32_args(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_echo_back_uint32_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_run_all_unit_tests(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_run_all_unit_tests(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_available_telecommands(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_available_telecommands(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif // __INCLUDE_GUARD__TELECOMMAND_DEFINITIONS_H

--- a/firmware/Core/Inc/telecommands/timekeeping_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/timekeeping_telecommand_defs.h
@@ -5,10 +5,10 @@
 #include <stdint.h>
 #include "telecommands/telecommand_definitions.h"
 
-uint8_t TCMDEXEC_get_system_time(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_get_system_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_set_system_time(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_set_system_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif /* __INCLUDE_GUARD__FLASH_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -72,6 +72,7 @@ void TASK_handle_uart_telecommands(void *argument) {
 			
 			// copy the buffer to the latest_tcmd buffer
 			latest_tcmd_len = UART_telecommand_buffer_write_idx;
+			// FIXME: rewrite the following memcpy/memset without the casts (which disregards the volatile qualifier)
 			memcpy(latest_tcmd, (uint8_t*) UART_telecommand_buffer, UART_telecommand_buffer_len); // copy the whole buffer to ensure nulls get copied too
 
 			// clear the buffer and reset the write pointer
@@ -141,7 +142,7 @@ void TASK_handle_uart_telecommands(void *argument) {
 			// TODO: maybe log/print args too
 			
 			const uint16_t arg_len = end_of_args_idx - start_of_args_idx - 1;
-			uint8_t args_str_no_parens[arg_len + 1];
+			char args_str_no_parens[arg_len + 1];
 			memcpy(args_str_no_parens, &latest_tcmd[start_of_args_idx + 1], arg_len);
 			args_str_no_parens[arg_len] = '\0';
 

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -11,7 +11,7 @@
 /// @brief Telecommand: Read bytes as hex from a flash address
 /// @param args_str No args.
 /// @return 0 always
-uint8_t TCMDEXEC_flash_activate_each_cs(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_activate_each_cs(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     const uint16_t delay_time_ms = 500;
 
@@ -37,7 +37,7 @@ uint8_t TCMDEXEC_flash_activate_each_cs(const uint8_t *args_str, TCMD_Telecomman
 /// @brief Telecommand: Read bytes as hex from a flash address
 /// @param args_str No args.
 /// @return 0 always
-uint8_t TCMDEXEC_flash_each_is_reachable(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_each_is_reachable(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint8_t fail_count = 0;
 
@@ -88,7 +88,7 @@ uint8_t TCMDEXEC_flash_each_is_reachable(const uint8_t *args_str, TCMD_Telecomma
 /// @param args_str Arg 0: Chip Number (CS number) as uint, Arg 1: Flash Address as uint,
 ///     Arg 2: Number of bytes to read as uint
 /// @return 0 on success, >0 on error // TODO: explain better
-uint8_t TCMDEXEC_flash_read_hex(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     const uint16_t max_num_bytes = 256;
     uint64_t chip_num, flash_addr, arg_num_bytes;
@@ -156,7 +156,7 @@ uint8_t TCMDEXEC_flash_read_hex(const uint8_t *args_str, TCMD_TelecommandChannel
 /// @param args_str Arg 0: Chip Number (CS number) as uint, Arg 1: Flash Address as uint,
 ///     Arg 2: Hex string of bytes to write, with no delimiters, in all lowercase
 /// @return 0 on success, >0 on error // TODO: explain better
-uint8_t TCMDEXEC_flash_write_hex(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     const uint16_t max_num_bytes = 256;
     uint16_t num_bytes;
@@ -228,7 +228,7 @@ uint8_t TCMDEXEC_flash_write_hex(const uint8_t *args_str, TCMD_TelecommandChanne
 /// @param args_str Arg 0: Chip Number (CS number) as uint, Arg 1: Flash Address as uint,
 ///     Arg 2: Number of bytes to erase as uint
 /// @return 0 on success, >0 on error // TODO: explain better
-uint8_t TCMDEXEC_flash_erase(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t chip_num, flash_addr;
 

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -93,9 +93,9 @@ uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_en
     const uint16_t max_num_bytes = 256;
     uint64_t chip_num, flash_addr, arg_num_bytes;
 
-    uint8_t arg0_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 0, &chip_num);
-    uint8_t arg1_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 1, &flash_addr);
-    uint8_t arg2_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 2, &arg_num_bytes);
+    uint8_t arg0_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &chip_num);
+    uint8_t arg1_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 1, &flash_addr);
+    uint8_t arg2_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 2, &arg_num_bytes);
     
     if (arg0_result != 0 || arg1_result != 0 || arg2_result != 0) {
         snprintf(
@@ -167,11 +167,11 @@ uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_e
 
     uint8_t bytes_to_write[max_num_bytes];
 
-    uint8_t arg0_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 0, &chip_num);
-    uint8_t arg1_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 1, &flash_addr_u64);
+    uint8_t arg0_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &chip_num);
+    uint8_t arg1_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 1, &flash_addr_u64);
     
     // FIXME: actually extract the hex from the string
-    // uint8_t arg2_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 2, &num_bytes);
+    // uint8_t arg2_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 2, &num_bytes);
     uint8_t arg2_result = 0; // temporary - fake success
 
     // FIXME: remove this next temp code, and write a string
@@ -232,8 +232,8 @@ uint8_t TCMDEXEC_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t chip_num, flash_addr;
 
-    uint8_t arg0_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 0, &chip_num);
-    uint8_t arg1_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 1, &flash_addr);
+    uint8_t arg0_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &chip_num);
+    uint8_t arg1_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 1, &flash_addr);
     
     if (arg0_result != 0 || arg1_result != 0) {
         snprintf(

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -7,7 +7,7 @@
 #include "telecommands/telecommand_args_helpers.h"
 
 
-uint8_t TCMDEXEC_fs_format_storage(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_format_storage(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     int8_t result = LFS_format();
     if (result < 0) {
@@ -19,7 +19,7 @@ uint8_t TCMDEXEC_fs_format_storage(const uint8_t *args_str, TCMD_TelecommandChan
     return 0;
 }
 
-uint8_t TCMDEXEC_fs_mount(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_mount(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     int8_t result = LFS_mount();
     if (result < 0) {
@@ -31,7 +31,7 @@ uint8_t TCMDEXEC_fs_mount(const uint8_t *args_str, TCMD_TelecommandChannel_enum_
     return 0;
 }
 
-uint8_t TCMDEXEC_fs_unmount(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_unmount(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     int8_t result = LFS_unmount();
     if (result < 0) {
@@ -45,7 +45,7 @@ uint8_t TCMDEXEC_fs_unmount(const uint8_t *args_str, TCMD_TelecommandChannel_enu
 
 /// @brief Telecommand: Write data to a file in LittleFS
 /// @param args_str Arg 0: File name, Arg 1: String to write to file
-uint8_t TCMDEXEC_fs_write_file(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_write_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
 
     char arg_file_name[64] = {0};
@@ -80,7 +80,7 @@ uint8_t TCMDEXEC_fs_write_file(const uint8_t *args_str, TCMD_TelecommandChannel_
     return 0;
 }
 
-uint8_t TCMDEXEC_fs_read_file(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_read_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint8_t rx_buffer[512] = {0};
 
@@ -106,7 +106,7 @@ uint8_t TCMDEXEC_fs_read_file(const uint8_t *args_str, TCMD_TelecommandChannel_e
 }
 
 
-uint8_t TCMDEXEC_fs_demo_write_then_read(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
 
     char file_name[] = "demo_test.txt";

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -49,7 +49,7 @@ uint8_t TCMDEXEC_fs_write_file(const char *args_str, TCMD_TelecommandChannel_enu
                         char *response_output_buf, uint16_t response_output_buf_len) {
 
     char arg_file_name[64] = {0};
-    const uint8_t parse_file_name_result = TCMD_extract_string_arg((char*)args_str, 0, arg_file_name, sizeof(arg_file_name));
+    const uint8_t parse_file_name_result = TCMD_extract_string_arg(args_str, 0, arg_file_name, sizeof(arg_file_name));
     if (parse_file_name_result != 0) {
         // error parsing
         snprintf(
@@ -60,7 +60,7 @@ uint8_t TCMDEXEC_fs_write_file(const char *args_str, TCMD_TelecommandChannel_enu
     }
 
     char arg_file_content[512] = {0};
-    const uint8_t parse_file_content_result = TCMD_extract_string_arg((char*)args_str, 1, arg_file_content, sizeof(arg_file_content));
+    const uint8_t parse_file_content_result = TCMD_extract_string_arg(args_str, 1, arg_file_content, sizeof(arg_file_content));
     if (parse_file_content_result != 0) {
         // error parsing
         snprintf(
@@ -85,7 +85,7 @@ uint8_t TCMDEXEC_fs_read_file(const char *args_str, TCMD_TelecommandChannel_enum
     uint8_t rx_buffer[512] = {0};
 
     char arg_file_name[64] = {0};
-    const uint8_t parse_file_name_result = TCMD_extract_string_arg((char*)args_str, 0, arg_file_name, sizeof(arg_file_name));
+    const uint8_t parse_file_name_result = TCMD_extract_string_arg(args_str, 0, arg_file_name, sizeof(arg_file_name));
     if (parse_file_name_result != 0) {
         // error parsing
         snprintf(

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -138,36 +138,36 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
 const int16_t TCMD_NUM_TELECOMMANDS = sizeof(TCMD_telecommand_definitions) / sizeof(TCMD_TelecommandDefinition_t);
 
 // each telecommand function must have the following signature:
-// uint8_t <function_name>(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+// uint8_t <function_name>(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
 //                          char *response_output_buf, uint16_t response_output_buf_len)
 
-uint8_t TCMDEXEC_hello_world(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_hello_world(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     snprintf(response_output_buf, response_output_buf_len, "Hello, world!\n");
     return 0;
 }
 
-uint8_t TCMDEXEC_heartbeat_off(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_heartbeat_off(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     TASK_heartbeat_is_on = 0;
     snprintf(response_output_buf, response_output_buf_len, "Heartbeat OFF");
     return 0;
 }
 
-uint8_t TCMDEXEC_heartbeat_on(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_heartbeat_on(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     TASK_heartbeat_is_on = 1;
     snprintf(response_output_buf, response_output_buf_len, "Heartbeat ON");
     return 0;
 }
 
-uint8_t TCMDEXEC_core_system_stats(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_core_system_stats(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     snprintf(response_output_buf, response_output_buf_len, "System stats: TODO\n");
     return 0;
 }
 
-uint8_t TCMDEXEC_echo_back_args(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_echo_back_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
 
     snprintf(response_output_buf, response_output_buf_len, "SUCCESS: Echo Args: '%s'\n", args_str);
@@ -175,7 +175,7 @@ uint8_t TCMDEXEC_echo_back_args(const uint8_t *args_str, TCMD_TelecommandChannel
     return 0;
 }
 
-uint8_t TCMDEXEC_echo_back_uint32_args(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_echo_back_uint32_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     response_output_buf[0] = '\0'; // clear the response buffer
 
@@ -203,13 +203,13 @@ uint8_t TCMDEXEC_echo_back_uint32_args(const uint8_t *args_str, TCMD_Telecommand
 }
 
 
-uint8_t TCMDEXEC_run_all_unit_tests(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_run_all_unit_tests(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     TEST_run_all_unit_tests_and_log(response_output_buf, response_output_buf_len);
     return 0;
 }
 
-uint8_t TCMDEXEC_available_telecommands(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_available_telecommands(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     
     char response[512] = {0};

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -182,7 +182,7 @@ uint8_t TCMDEXEC_echo_back_uint32_args(const char *args_str, TCMD_TelecommandCha
     for (uint8_t arg_num = 0; arg_num < 10; arg_num++) {
         uint64_t arg_uint64;
         uint8_t parse_result = TCMD_extract_uint64_arg(
-            (char*)args_str, strlen((char*)args_str), arg_num, &arg_uint64);
+            args_str, strlen(args_str), arg_num, &arg_uint64);
         if (parse_result > 0) {
             // error parsing
             snprintf(

--- a/firmware/Core/Src/telecommands/timekeeping_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/timekeeping_telecommand_defs.c
@@ -6,13 +6,13 @@
 #include <stdio.h>
 #include <string.h>
 
-uint8_t TCMDEXEC_get_system_time(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_get_system_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     TIM_get_timestamp_string(response_output_buf, response_output_buf_len);
     return 0;
 }
 
-uint8_t TCMDEXEC_set_system_time(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_set_system_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
   
     uint64_t ms = 0;

--- a/firmware/Core/Src/telecommands/timekeeping_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/timekeeping_telecommand_defs.c
@@ -17,7 +17,7 @@ uint8_t TCMDEXEC_set_system_time(const char *args_str, TCMD_TelecommandChannel_e
   
     uint64_t ms = 0;
 
-    uint8_t result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 0, &ms);
+    uint8_t result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &ms);
     if (result != 0) {
         return 1;
     }


### PR DESCRIPTION
In order to follow the accepted convention (`uint8_t *` denotes a byte array with a known length, while `char *` represents a null-terminated c-string), the telecommand `args_str` argument type is changed from `const uint8_t *` to `const char *`.

This is a change which affects lots of lines of code, but is ultimately a tiny semantic change.