### PR TITLE
Added Enumeration for FLASH driver code to categorize errors

### DIFF
--- a/firmware/Core/Inc/littlefs/flash_driver.h
+++ b/firmware/Core/Inc/littlefs/flash_driver.h
@@ -48,25 +48,25 @@ static const uint8_t FLASH_SR1_PROGRAMMING_ERROR_MASK = (1 << 6);
 static const uint8_t FLASH_SR1_ERASE_ERROR_MASK = (1 << 5);
 
 /*-----------------------------FLASH ERROR CODES-----------------------------*/
-enum FLASH_ERRORS {
+typedef enum {
     FLASH_ERR_OK                    = 0,    // No error occurred
     FLASH_ERR_SPI_TRANSMIT_FAILED   = -3,   // Error occurred while transmitting SPI signal
     FLASH_ERR_SPI_RECEIVE_FAILED    = -4,   // Error occurred while receiving SPI signal
     FLASH_ERR_DEVICE_BUSY_TIMEOUT   = -6,   // Took too long for the device to be in standby
-    FLASH_ERR_UNKNOWN                = -7,   // Unknown error occurred (code reached where it shouldn't have been possible)
+    FLASH_ERR_UNKNOWN               = -7,   // Unknown error occurred (code reached where it shouldn't have been possible)
     FLASH_ERR_STATUS_REG_ERROR      = -8    // Error occurred which was indicated by one of the Status Register Bits.
-};
+} FLASH_error_enum_t;
 
 /*-----------------------------DRIVER FUNCTIONS-----------------------------*/
 void FLASH_activate_chip_select(uint8_t chip_number);
 void FLASH_deactivate_chip_select();
-uint8_t FLASH_read_status_register(SPI_HandleTypeDef *hspi, uint8_t chip_number, uint8_t *buf);
-uint8_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_number);
-uint8_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_number);
-uint8_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr);
-uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *packet_buffer, lfs_size_t packet_buffer_len);
-uint8_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *rx_buffer, lfs_size_t rx_buffer_len);
+FLASH_error_enum_t FLASH_read_status_register(SPI_HandleTypeDef *hspi, uint8_t chip_number, uint8_t *buf);
+FLASH_error_enum_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_number);
+FLASH_error_enum_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_number);
+FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr);
+FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *packet_buffer, lfs_size_t packet_buffer_len);
+FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *rx_buffer, lfs_size_t rx_buffer_len);
 
-uint8_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_number);
+FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_number);
 
 #endif /* __INCLUDE_GUARD__FLASH_DRIVER_H__ */

--- a/firmware/Core/Inc/littlefs/flash_driver.h
+++ b/firmware/Core/Inc/littlefs/flash_driver.h
@@ -1,7 +1,3 @@
-/**
- *     Author: Saksham Puri
- */
-
 #ifndef __INCLUDE_GUARD__FLASH_DRIVER_H__
 #define __INCLUDE_GUARD__FLASH_DRIVER_H__
 
@@ -12,31 +8,29 @@
 
 #include "littlefs/lfs.h"
 
-
 /*-----------------------------INCLUDES-----------------------------*/
-
-// number of CS pins available
+// Number of CS pins available
 #define FLASH_NUMBER_OF_FLASH_DEVICES 8 // TODO: update to 8, or 10 with FRAM maybe
-#define FLASH_CHIP_SIZE_BYTES 67108864 // 64MiB // TODO: update
+#define FLASH_CHIP_SIZE_BYTES 67108864  // 64MiB // TODO: update
 
 /*-----------------------------COMMAND VARIABLES-----------------------------*/
 // All comments in this section refer to the "S25FL512S 512Mb (64MB)" Datasheet by Infineon
 
-static const uint8_t FLASH_CMD_READ_3_BYTE_ADDR = 0x03;  // Read - Section 9.4.1
-static const uint8_t FLASH_CMD_READ_4_BYTE_ADDR = 0x13;  // Read - Section 9.4.1
+static const uint8_t FLASH_CMD_READ_3_BYTE_ADDR = 0x03; // Read - Section 9.4.1
+static const uint8_t FLASH_CMD_READ_4_BYTE_ADDR = 0x13; // Read - Section 9.4.1
 
 static const uint8_t FLASH_CMD_WRITE_3_BYTE_ADDR = 0x02; // Page Program - Section 9.5.2
 static const uint8_t FLASH_CMD_WRITE_4_BYTE_ADDR = 0x12; // Page Program - Section 9.5.2
 
-static const uint8_t FLASH_CMD_SECTOR_ERASE_3_BYTE_ADDR = 0xD8;  // Sector Erase - Section 9.6.1
+static const uint8_t FLASH_CMD_SECTOR_ERASE_3_BYTE_ADDR = 0xD8; // Sector Erase - Section 9.6.1
 static const uint8_t FLASH_CMD_SECTOR_ERASE_4_BYTE_ADDR = 0xDC; // Sector Erase - Section 9.6.1
 
 static const uint8_t FLASH_CMD_WRITE_DISABLE = 0x04; // Write Disable - Section 9.3.9
-static const uint8_t FLASH_CMD_WRITE_ENABLE = 0x06; // Write Enable - Section 9.3.8
+static const uint8_t FLASH_CMD_WRITE_ENABLE = 0x06;  // Write Enable - Section 9.3.8
 
 static const uint8_t FLASH_CMD_READ_STATUS_REG_1 = 0x05; // Read Status 1 - Section 9.3.1, Byte Descriptions in 7.6.1
 static const uint8_t FLASH_CMD_READ_STATUS_REG_2 = 0x07; // Read Status 2 - Section 9.3.2
-static const uint8_t FLASH_CMD_CLEAR_STATUS = 0x30;  // Clear Status - Section 9.3.10
+static const uint8_t FLASH_CMD_CLEAR_STATUS = 0x30;      // Clear Status - Section 9.3.10
 
 static const uint8_t FLASH_CMD_READ_CONFIG = 0x35; // Read Config - Section 9.3.3
 
@@ -51,6 +45,15 @@ static const uint8_t FLASH_SR1_WRITE_ENABLE_LATCH_MASK = (1 << 1);
 static const uint8_t FLASH_SR1_PROGRAMMING_ERROR_MASK = (1 << 6);
 static const uint8_t FLASH_SR1_ERASE_ERROR_MASK = (1 << 5);
 
+/*-----------------------------FLASH ERROR CODES-----------------------------*/
+enum FLASH_ERRORS {
+    FLASH_ERR_OK                    = 0,
+    FLASH_ERR_SPI_TRANSMIT_FAILED   = -3,
+    FLASH_ERR_SPI_RECEIVE_FAILED    = -4,
+    FLASH_ERR_DEVICE_BUSY_TIMEOUT   = -6,
+    FLASH_ERR_UNKOWN                = -7,
+    FLASH_ERR_STATUS_REG_ERROR      = -8
+};
 
 /*-----------------------------DRIVER FUNCTIONS-----------------------------*/
 void FLASH_activate_chip_select(uint8_t chip_number);

--- a/firmware/Core/Inc/littlefs/flash_driver.h
+++ b/firmware/Core/Inc/littlefs/flash_driver.h
@@ -54,7 +54,9 @@ typedef enum {
     FLASH_ERR_SPI_RECEIVE_FAILED    = -4,   // Error occurred while receiving SPI signal
     FLASH_ERR_DEVICE_BUSY_TIMEOUT   = -6,   // Took too long for the device to be in standby
     FLASH_ERR_UNKNOWN               = -7,   // Unknown error occurred (code reached where it shouldn't have been possible)
-    FLASH_ERR_STATUS_REG_ERROR      = -8    // Error occurred which was indicated by one of the Status Register Bits.
+    FLASH_ERR_STATUS_REG_ERROR      = -8,   // Error occurred which was indicated by one of the Status Register Bits.
+    FLASH_ERR_SPI_TRANSMIT_TIMEOUT  = -10,  // Timeout when transmitting SPI signal
+    FLASH_ERR_SPI_RECEIVE_TIMEOUT   = -11   // Timeout when receiving SPI signal
 } FLASH_error_enum_t;
 
 /*-----------------------------DRIVER FUNCTIONS-----------------------------*/

--- a/firmware/Core/Inc/littlefs/flash_driver.h
+++ b/firmware/Core/Inc/littlefs/flash_driver.h
@@ -47,12 +47,12 @@ static const uint8_t FLASH_SR1_ERASE_ERROR_MASK = (1 << 5);
 
 /*-----------------------------FLASH ERROR CODES-----------------------------*/
 enum FLASH_ERRORS {
-    FLASH_ERR_OK                    = 0,
-    FLASH_ERR_SPI_TRANSMIT_FAILED   = -3,
-    FLASH_ERR_SPI_RECEIVE_FAILED    = -4,
-    FLASH_ERR_DEVICE_BUSY_TIMEOUT   = -6,
-    FLASH_ERR_UNKOWN                = -7,
-    FLASH_ERR_STATUS_REG_ERROR      = -8
+    FLASH_ERR_OK                    = 0,    // No error occurred
+    FLASH_ERR_SPI_TRANSMIT_FAILED   = -3,   // Error occurred while transmitting SPI signal
+    FLASH_ERR_SPI_RECEIVE_FAILED    = -4,   // Error occurred while receiving SPI signal
+    FLASH_ERR_DEVICE_BUSY_TIMEOUT   = -6,   // Took too long for the device to be in standby
+    FLASH_ERR_UNKNOWN                = -7,   // Unknown error occurred (code reached where it shouldn't have been possible)
+    FLASH_ERR_STATUS_REG_ERROR      = -8    // Error occurred which was indicated by one of the Status Register Bits.
 };
 
 /*-----------------------------DRIVER FUNCTIONS-----------------------------*/

--- a/firmware/Core/Src/littlefs/flash_benchmark.c
+++ b/firmware/Core/Src/littlefs/flash_benchmark.c
@@ -22,7 +22,7 @@ uint8_t FLASH_benchmark_erase_write_read(uint8_t chip_num, uint32_t test_data_ad
 
     // Erase
     const uint32_t erase_start_time = HAL_GetTick();
-    const uint8_t erase_result = FLASH_erase(hspi_ptr, chip_num, 0);
+    const FLASH_error_enum_t erase_result = FLASH_erase(hspi_ptr, chip_num, 0);
     if (erase_result != 0) {
         snprintf(
             &response_str[strlen(response_str)],
@@ -45,7 +45,7 @@ uint8_t FLASH_benchmark_erase_write_read(uint8_t chip_num, uint32_t test_data_ad
     }
     // TODO: for very large writes, split into multiple writes (instead of allocating the whole amount on the stack)
     const uint32_t write_send_start_time = HAL_GetTick();
-    const uint8_t write_result = FLASH_write(hspi_ptr, chip_num, test_data_address, write_buffer, test_data_length);
+    const FLASH_error_enum_t write_result = FLASH_write(hspi_ptr, chip_num, test_data_address, write_buffer, test_data_length);
     if (write_result != 0) {
         snprintf(
             &response_str[strlen(response_str)],
@@ -63,7 +63,7 @@ uint8_t FLASH_benchmark_erase_write_read(uint8_t chip_num, uint32_t test_data_ad
     // Read
     const uint32_t read_start_time = HAL_GetTick();
     uint8_t read_buffer[test_data_length];
-    const uint8_t read_result = FLASH_read_data(hspi_ptr, chip_num, test_data_address, read_buffer, test_data_length);
+    const FLASH_error_enum_t read_result = FLASH_read_data(hspi_ptr, chip_num, test_data_address, read_buffer, test_data_length);
     if (read_result != 0) {
         snprintf(
             &response_str[strlen(response_str)],

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -93,17 +93,17 @@ uint8_t FLASH_read_status_register(SPI_HandleTypeDef *hspi, uint8_t chip_number,
     const HAL_StatusTypeDef tx_result = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_READ_STATUS_REG_1, 1, FLASH_HAL_TIMEOUT_MS);
     if (tx_result != HAL_OK) {
         FLASH_deactivate_chip_select();
-        return 1;
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
     const HAL_StatusTypeDef rx_result = HAL_SPI_Receive(hspi, (uint8_t *)buf, 1, FLASH_HAL_TIMEOUT_MS);
     if (rx_result != HAL_OK) {
         FLASH_deactivate_chip_select();
-        return 2;
+        return FLASH_ERR_SPI_RECEIVE_FAILED;
     }
 
     FLASH_deactivate_chip_select();
-    return 0;
+    return FLASH_ERR_OK;
 }
 
 /**
@@ -121,7 +121,7 @@ uint8_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
     const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_WRITE_ENABLE, 1, FLASH_HAL_TIMEOUT_MS);
     FLASH_deactivate_chip_select();
     if (tx_result_1 != HAL_OK) {
-        return 1;
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
     // Keep looping as long as device is busy (until the Write Enable Latch is active [1])
@@ -131,18 +131,18 @@ uint8_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
         const uint8_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
         if (read_status_result != 0) {
             FLASH_deactivate_chip_select();
-            return 3;
+            return read_status_result;
         }
 
         if ((status_reg_buffer[0] & FLASH_SR1_WRITE_ENABLE_LATCH_MASK) > 0) {
             // Success condition: write enabled.
-            return 0;
+            return FLASH_ERR_OK;
         }
 
         // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
         if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_REGISTER_CHANGE_TIMEOUT_MS) {
             DEBUG_uart_print_str("Flash write enable timeout\n");
-            return 2;
+            return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
         }
 
         DEBUG_uart_print_str("DEBUG: status_reg = 0x");
@@ -151,7 +151,7 @@ uint8_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
     }
 
     // Should never be reached:
-    return 5;
+    return FLASH_ERR_UNKOWN;
 }
 
 /**
@@ -169,7 +169,7 @@ uint8_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
     const HAL_StatusTypeDef tx_status = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_WRITE_DISABLE, 1, FLASH_HAL_TIMEOUT_MS);
     FLASH_deactivate_chip_select();
     if (tx_status != HAL_OK) {
-        return 1;
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
     // Keep looping as long as device is busy (until the Write Enable Latch is inactive [0])
@@ -179,18 +179,18 @@ uint8_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
         const uint8_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
         if (read_status_result != 0) {
             FLASH_deactivate_chip_select();
-            return 3;
+            return read_status_result;
         }
 
         if ((status_reg_buffer[0] & FLASH_SR1_WRITE_ENABLE_LATCH_MASK) == 0) {
             // Success condition: write disabled.
-            return 0;
+            return FLASH_ERR_OK;
         }
 
         // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
         if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_REGISTER_CHANGE_TIMEOUT_MS) {
             DEBUG_uart_print_str("Flash write disable timeout\n");
-            return 2;
+            return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
         }
 
         DEBUG_uart_print_str("DEBUG: status_reg = 0x");
@@ -199,7 +199,7 @@ uint8_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
     }
 
     // Should never be reached:
-    return 5;
+    return FLASH_ERR_UNKOWN;
 }
 
 /**
@@ -218,7 +218,7 @@ uint8_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
     const uint8_t wren_result = FLASH_write_enable(hspi, chip_number);
     if (wren_result != 0) {
         FLASH_deactivate_chip_select();
-        return 1;
+        return wren_result;
     }
 
     // Send Sector Erase Command
@@ -226,12 +226,12 @@ uint8_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
     const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_SECTOR_ERASE_4_BYTE_ADDR, 1, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
-        return 2;
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
     const HAL_StatusTypeDef tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_2 != HAL_OK) {
         FLASH_deactivate_chip_select();
-        return 3;
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
     FLASH_deactivate_chip_select();
 
@@ -245,24 +245,24 @@ uint8_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
         const uint8_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
         if (read_status_result != 0) {
             FLASH_deactivate_chip_select();
-            return 3;
+            return read_status_result;
         }
 
         if ((status_reg_buffer[0] & FLASH_SR1_ERASE_ERROR_MASK) > 0) {
             // Flash module returned "erase error" via the status register.
             DEBUG_uart_print_str("Flash erase error\n");
-            return 4;
+            return FLASH_ERR_STATUS_REG_ERROR;
         }
 
         if ((status_reg_buffer[0] & FLASH_SR1_WRITE_IN_PROGRESS_MASK) == 0) {
             // Success condition: write in progress has completed.
-            return 0;
+            return FLASH_ERR_OK;
         }
 
         // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
         if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_SECTOR_ERASE_TIMEOUT_MS) {
             DEBUG_uart_print_str("Flash erase timeout\n");
-            return 2;
+            return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
         }
 
         DEBUG_uart_print_str("DEBUG: status_reg = 0x");
@@ -271,7 +271,7 @@ uint8_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
     }
 
     // Should never be reached:
-    return 5;
+    return FLASH_ERR_UNKOWN;
 }
 
 /**
@@ -292,7 +292,7 @@ uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
     const uint8_t wren_result = FLASH_write_enable(hspi, chip_number);
     if (wren_result != 0) {
         FLASH_deactivate_chip_select();
-        return 1;
+        return wren_result;
     }
 
     // Send WREN Command and the Data required with the command
@@ -300,17 +300,17 @@ uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
     const uint8_t tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_WRITE_4_BYTE_ADDR, 1, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
-        return 2;
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
     const uint8_t tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_2 != HAL_OK) {
         FLASH_deactivate_chip_select();
-        return 3;
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
     const uint8_t tx_result_3 = HAL_SPI_Transmit(hspi, (uint8_t *)packet_buffer, size, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_3 != HAL_OK) {
         FLASH_deactivate_chip_select();
-        return 4;
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
     // Buffer to store status register value
@@ -323,24 +323,24 @@ uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
         const uint8_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
         if (read_status_result != 0) {
             FLASH_deactivate_chip_select();
-            return 3;
+            return read_status_result;
         }
 
         if ((status_reg_buffer[0] & FLASH_SR1_PROGRAMMING_ERROR_MASK) > 0) {
             // Flash module returned "programming error" via the status register.
             DEBUG_uart_print_str("Flash programming error\n");
-            return 4;
+            return FLASH_ERR_STATUS_REG_ERROR;
         }
 
         if ((status_reg_buffer[0] & FLASH_SR1_WRITE_IN_PROGRESS_MASK) == 0) {
             // Success condition: write in progress has completed.
-            return 0;
+            return FLASH_ERR_OK;
         }
 
         // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
         if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_WRITE_TIMEOUT_MS) {
             DEBUG_uart_print_str("Flash write timeout\n");
-            return 2;
+            return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
         }
 
         DEBUG_uart_print_str("DEBUG: status_reg = 0x");
@@ -349,7 +349,7 @@ uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
     }
 
     // Should never be reached:
-    return 5;
+    return FLASH_ERR_UNKOWN;
 }
 
 /**
@@ -371,21 +371,21 @@ uint8_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_
     const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_READ_4_BYTE_ADDR, 1, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
-        return 1;
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
     const HAL_StatusTypeDef tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_2 != HAL_OK) {
         FLASH_deactivate_chip_select();
-        return 2;
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
     const HAL_StatusTypeDef rx_result_1 = HAL_SPI_Receive(hspi, (uint8_t *)rx_buffer, rx_buffer_len, FLASH_HAL_TIMEOUT_MS);
     if (rx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
-        return 3;
+        return FLASH_ERR_SPI_RECEIVE_FAILED;
     }
     FLASH_deactivate_chip_select();
 
-    // Haven't yet implemented a way to check any errors while reading data from memory
+    // TODO: Haven't yet implemented a way to check any errors while reading data from memory
     return 0;
 }
 
@@ -403,13 +403,13 @@ uint8_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
     // Transmit the READ_ID_CMD
     if (HAL_SPI_Transmit(hspi, tx_buffer, 1, FLASH_HAL_TIMEOUT_MS) != HAL_OK) {
         FLASH_deactivate_chip_select();
-        return 1;
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
     // Receive the response
     if (HAL_SPI_Receive(hspi, rx_buffer, 5, FLASH_HAL_TIMEOUT_MS) != HAL_OK) {
         FLASH_deactivate_chip_select();
-        return 2;
+        return FLASH_ERR_SPI_RECEIVE_FAILED;
     }
 
     FLASH_deactivate_chip_select();

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -98,12 +98,22 @@ FLASH_error_enum_t FLASH_read_status_register(SPI_HandleTypeDef *hspi, uint8_t c
     const HAL_StatusTypeDef tx_result = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_READ_STATUS_REG_1, 1, FLASH_HAL_TIMEOUT_MS);
     if (tx_result != HAL_OK) {
         FLASH_deactivate_chip_select();
+
+        if (tx_result == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+        
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
     const HAL_StatusTypeDef rx_result = HAL_SPI_Receive(hspi, (uint8_t *)buf, 1, FLASH_HAL_TIMEOUT_MS);
     if (rx_result != HAL_OK) {
         FLASH_deactivate_chip_select();
+
+        if (rx_result == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_RECEIVE_TIMEOUT;
+        }
+
         return FLASH_ERR_SPI_RECEIVE_FAILED;
     }
 
@@ -126,6 +136,11 @@ FLASH_error_enum_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_WRITE_ENABLE, 1, FLASH_HAL_TIMEOUT_MS);
     FLASH_deactivate_chip_select();
     if (tx_result_1 != HAL_OK) {
+
+        if (tx_result_1 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
@@ -176,6 +191,11 @@ FLASH_error_enum_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_num
     const HAL_StatusTypeDef tx_status = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_WRITE_DISABLE, 1, FLASH_HAL_TIMEOUT_MS);
     FLASH_deactivate_chip_select();
     if (tx_status != HAL_OK) {
+
+        if (tx_status == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+        
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
@@ -233,11 +253,21 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
     const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_SECTOR_ERASE_4_BYTE_ADDR, 1, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
+
+        if (tx_result_1 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+        
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
     const HAL_StatusTypeDef tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_2 != HAL_OK) {
         FLASH_deactivate_chip_select();
+
+        if (tx_result_2 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
     FLASH_deactivate_chip_select();
@@ -307,16 +337,31 @@ FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
     const uint8_t tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_WRITE_4_BYTE_ADDR, 1, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
+
+        if (tx_result_1 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
     const uint8_t tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_2 != HAL_OK) {
         FLASH_deactivate_chip_select();
+
+        if (tx_result_2 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
     const uint8_t tx_result_3 = HAL_SPI_Transmit(hspi, (uint8_t *)packet_buffer, packet_buffer_len, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_3 != HAL_OK) {
         FLASH_deactivate_chip_select();
+
+        if (tx_result_3 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
@@ -378,16 +423,31 @@ FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number,
     const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_READ_4_BYTE_ADDR, 1, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
+
+        if (tx_result_1 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
     const HAL_StatusTypeDef tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_2 != HAL_OK) {
         FLASH_deactivate_chip_select();
+
+        if (tx_result_2 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
     const HAL_StatusTypeDef rx_result_1 = HAL_SPI_Receive(hspi, (uint8_t *)rx_buffer, rx_buffer_len, FLASH_HAL_TIMEOUT_MS);
     if (rx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
+
+        if (rx_result_1 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_RECEIVE_TIMEOUT;
+        }
+
         return FLASH_ERR_SPI_RECEIVE_FAILED;
     }
     FLASH_deactivate_chip_select();
@@ -405,17 +465,28 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     uint8_t rx_buffer[5];
     memset(rx_buffer, 0, 5);
 
-    FLASH_activate_chip_select(chip_number);
-
     // Transmit the READ_ID_CMD
-    if (HAL_SPI_Transmit(hspi, tx_buffer, 1, FLASH_HAL_TIMEOUT_MS) != HAL_OK) {
+    FLASH_activate_chip_select(chip_number);
+    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, tx_buffer, 1, FLASH_HAL_TIMEOUT_MS);
+    if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
+
+        if (tx_result_1 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
     // Receive the response
-    if (HAL_SPI_Receive(hspi, rx_buffer, 5, FLASH_HAL_TIMEOUT_MS) != HAL_OK) {
+    const HAL_StatusTypeDef rx_result = HAL_SPI_Receive(hspi, rx_buffer, 5, FLASH_HAL_TIMEOUT_MS);
+    if (rx_result != HAL_OK) {
         FLASH_deactivate_chip_select();
+
+        if (rx_result == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_RECEIVE_TIMEOUT;
+        }
+
         return FLASH_ERR_SPI_RECEIVE_FAILED;
     }
 

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -129,7 +129,7 @@ uint8_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
     while (1)
     {
         const uint8_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
-        if (read_status_result != 0) {
+        if (read_status_result != FLASH_ERR_OK) {
             FLASH_deactivate_chip_select();
             return read_status_result;
         }
@@ -151,7 +151,7 @@ uint8_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
     }
 
     // Should never be reached:
-    return FLASH_ERR_UNKOWN;
+    return FLASH_ERR_UNKNOWN;
 }
 
 /**
@@ -177,7 +177,7 @@ uint8_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
     while (1)
     {
         const uint8_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
-        if (read_status_result != 0) {
+        if (read_status_result != FLASH_ERR_OK) {
             FLASH_deactivate_chip_select();
             return read_status_result;
         }
@@ -199,7 +199,7 @@ uint8_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
     }
 
     // Should never be reached:
-    return FLASH_ERR_UNKOWN;
+    return FLASH_ERR_UNKNOWN;
 }
 
 /**
@@ -216,7 +216,7 @@ uint8_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
 
     // Send Write Enable Command
     const uint8_t wren_result = FLASH_write_enable(hspi, chip_number);
-    if (wren_result != 0) {
+    if (wren_result != FLASH_ERR_OK) {
         FLASH_deactivate_chip_select();
         return wren_result;
     }
@@ -243,7 +243,7 @@ uint8_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
     while (1)
     {
         const uint8_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
-        if (read_status_result != 0) {
+        if (read_status_result != FLASH_ERR_OK) {
             FLASH_deactivate_chip_select();
             return read_status_result;
         }
@@ -271,7 +271,7 @@ uint8_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
     }
 
     // Should never be reached:
-    return FLASH_ERR_UNKOWN;
+    return FLASH_ERR_UNKNOWN;
 }
 
 /**
@@ -290,7 +290,7 @@ uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
 
     // Enable WREN Command, so that we can write to the memory module
     const uint8_t wren_result = FLASH_write_enable(hspi, chip_number);
-    if (wren_result != 0) {
+    if (wren_result != FLASH_ERR_OK) {
         FLASH_deactivate_chip_select();
         return wren_result;
     }
@@ -321,7 +321,7 @@ uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
     while (1)
     {
         const uint8_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
-        if (read_status_result != 0) {
+        if (read_status_result != FLASH_ERR_OK) {
             FLASH_deactivate_chip_select();
             return read_status_result;
         }
@@ -349,7 +349,7 @@ uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
     }
 
     // Should never be reached:
-    return FLASH_ERR_UNKOWN;
+    return FLASH_ERR_UNKNOWN;
 }
 
 /**

--- a/firmware/Core/Src/littlefs/flash_testing_demos.c
+++ b/firmware/Core/Src/littlefs/flash_testing_demos.c
@@ -13,7 +13,7 @@ void demo_flash_write() {
     uint32_t num_bytes = strlen((char*)bytes_to_write);
 
     for (uint8_t i = 0; i < 2; i++) {
-        uint8_t result = FLASH_write(&hspi1, chip_num, flash_addr, bytes_to_write, num_bytes);
+        FLASH_error_enum_t result = FLASH_write(&hspi1, chip_num, flash_addr, bytes_to_write, num_bytes);
         if (result != 0) {
             DEBUG_uart_print_str("Error in FLASH_write\n");
             return;
@@ -33,7 +33,7 @@ void demo_flash_read() {
 
     uint8_t bytes_store[100];
 
-    uint8_t result = FLASH_read_data(&hspi1, chip_num, flash_addr, bytes_store, num_bytes);
+    FLASH_error_enum_t result = FLASH_read_data(&hspi1, chip_num, flash_addr, bytes_store, num_bytes);
 
     if (result != 0) {
         DEBUG_uart_print_str("Error in FLASH_read_data\n");

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -46,7 +46,7 @@ uint8_t TCMDEXEC_flash_each_is_reachable(const char *args_str, TCMD_TelecommandC
     FLASH_deactivate_chip_select();
 
     for (uint8_t chip_number = 0; chip_number < FLASH_NUMBER_OF_FLASH_DEVICES; chip_number++) {
-        const uint8_t result = FLASH_is_reachable(&hspi1, chip_number);
+        const FLASH_error_enum_t result = FLASH_is_reachable(&hspi1, chip_number);
         if (result != 0) {
             fail_count++;
 
@@ -125,7 +125,7 @@ uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_en
 
     uint8_t read_buf[max_num_bytes];
     uint32_t num_bytes = (uint32_t)arg_num_bytes;
-    uint8_t result = FLASH_read_data(&hspi1, chip_num, flash_addr, read_buf, num_bytes);
+    FLASH_error_enum_t result = FLASH_read_data(&hspi1, chip_num, flash_addr, read_buf, num_bytes);
 
     if (result != 0) {
         snprintf(
@@ -208,7 +208,7 @@ uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_e
     uint32_t flash_addr = (uint32_t)flash_addr_u64;
 
 
-    uint8_t result = FLASH_write(&hspi1, chip_num, flash_addr, bytes_to_write, num_bytes);
+    FLASH_error_enum_t result = FLASH_write(&hspi1, chip_num, flash_addr, bytes_to_write, num_bytes);
 
     if (result != 0) {
         snprintf(
@@ -255,7 +255,7 @@ uint8_t TCMDEXEC_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_
         return 2;
     }
 
-    uint8_t result = FLASH_erase(&hspi1, chip_num, flash_addr);
+    FLASH_error_enum_t result = FLASH_erase(&hspi1, chip_num, flash_addr);
 
     if (result != 0) {
         snprintf(


### PR DESCRIPTION
### Enum Created:

```enum FLASH_ERRORS {
    FLASH_ERR_OK                    = 0, // No error occurred
    FLASH_ERR_SPI_TRANSMIT_FAILED   = -3, // Error occurred while transmitting SPI signal
    FLASH_ERR_SPI_RECEIVE_FAILED    = -4, // Error occurred while receiving SPI signal
    FLASH_ERR_DEVICE_BUSY_TIMEOUT   = -6, // Took too long for the device to be in standby
    FLASH_ERR_UNKOWN                = -7, // Unknown error occurred (code reached where it shouldn't have been possible)
    FLASH_ERR_STATUS_REG_ERROR      = -8 // Error occurred which was indicated by one of the Status Register Bits.
};
```
The above are the values of the enum that are created to organize the type of errors we can expect in `.../littlefs/flash_driver.c`. The values have been cross-checked with LittleFS return enum values **only** in `lfs.h` file just in case they might conflict later on, so the integer values in the enum are unique to `.../littlefs/flash_driver.c`

### Changes Made:
Most return values have been replaced by the values of above enum, very few have been replaced by a variable, for e.g.:
```
const uint8_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
    if (read_status_result != FLASH_ERR_OK) {
        FLASH_deactivate_chip_select();
        return read_status_result;
    }
```
We are returning the variable since it contains the enum value of the error caused within `FLASH_read_status_register()`
