### PR TITLE
Create flash/LFS timing benchmark telecommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Then, rebase off of the `main` branch.
 * Connect to the STM32 debug serial port at baud=115200.
 * Use Breakpoints in VS Code to pause execution and explore the stack. Breakpoint are obeyed when you use the "Debug STM32" button to flash the chip.
 
-The "SerialTest" serial terminal works well for sending commands: https://github.com/wh201906/SerialTest/releases/, and is recommended.
+The "SerialTest" serial terminal works well for sending commands: https://github.com/wh201906/SerialTest/releases/, and is recommended. The ground support software (see above) is also solid.
 
 ### Python Serial Terminal
 
@@ -51,6 +51,13 @@ The Python serial terminal is useful for receiving only.
 python3 -m pip install pyserial
 python3 -m serial.tools.miniterm - 115200
 ```
+
+## Contributors
+
+Please add your name to the list below in your first Pull Request!
+
+* Parker L.
+
 
 ## Random Notes
 * Lower NVIC priority number means higher priority.

--- a/firmware/Core/Inc/config/static_config.h
+++ b/firmware/Core/Inc/config/static_config.h
@@ -4,11 +4,11 @@
 
 /// Whether to enable critical-path debug success logging in the FLASH drivers.
 /// Default: 0 (disabled)
-#define FLASH_ENABLE_UART_DEBUG_PRINT 1
+#define FLASH_ENABLE_UART_DEBUG_PRINT 0
 
 /// Whether to enable critical-path debug success logging in the LittleFS drivers.
 /// Default: 0 (disabled)
-#define LFS_ENABLE_UART_DEBUG_PRINT 1
+#define LFS_ENABLE_UART_DEBUG_PRINT 0
 
 
 // NOTE: All C files that use config variables from here should include a guard like the following:

--- a/firmware/Core/Inc/config/static_config.h
+++ b/firmware/Core/Inc/config/static_config.h
@@ -2,19 +2,14 @@
 #ifndef __INCLUDE_GUARD__STATIC_CONFIG_H__
 #define __INCLUDE_GUARD__STATIC_CONFIG_H__
 
-/// Whether to enable critical-path debug success logging in the FLASH drivers.
+#include <stdint.h>
+
+/// Whether to enable hot-path debug success logging in the FLASH drivers.
 /// Default: 0 (disabled)
-#define FLASH_ENABLE_UART_DEBUG_PRINT 0
+static const uint8_t FLASH_enable_hot_path_debug_logs = 0;
 
-/// Whether to enable critical-path debug success logging in the LittleFS drivers.
+/// Whether to enable hot-path debug success logging in the LittleFS drivers.
 /// Default: 0 (disabled)
-#define LFS_ENABLE_UART_DEBUG_PRINT 0
-
-
-// NOTE: All C files that use config variables from here should include a guard like the following:
-// #ifndef LFS_ENABLE_UART_DEBUG_PRINT
-//     #error "LFS_ENABLE_UART_DEBUG_PRINT not defined"
-// #endif
-
+static const uint8_t LFS_enable_hot_path_debug_logs = 0;
 
 #endif /* __INCLUDE_GUARD__STATIC_CONFIG_H__ */

--- a/firmware/Core/Inc/config/static_config.h
+++ b/firmware/Core/Inc/config/static_config.h
@@ -11,4 +11,10 @@
 #define LFS_ENABLE_UART_DEBUG_PRINT 1
 
 
+// NOTE: All C files that use config variables from here should include a guard like the following:
+// #ifndef LFS_ENABLE_UART_DEBUG_PRINT
+//     #error "LFS_ENABLE_UART_DEBUG_PRINT not defined"
+// #endif
+
+
 #endif /* __INCLUDE_GUARD__STATIC_CONFIG_H__ */

--- a/firmware/Core/Inc/config/static_config.h
+++ b/firmware/Core/Inc/config/static_config.h
@@ -1,0 +1,14 @@
+
+#ifndef __INCLUDE_GUARD__STATIC_CONFIG_H__
+#define __INCLUDE_GUARD__STATIC_CONFIG_H__
+
+/// Whether to enable critical-path debug success logging in the FLASH drivers.
+/// Default: 0 (disabled)
+#define FLASH_ENABLE_UART_DEBUG_PRINT 1
+
+/// Whether to enable critical-path debug success logging in the LittleFS drivers.
+/// Default: 0 (disabled)
+#define LFS_ENABLE_UART_DEBUG_PRINT 1
+
+
+#endif /* __INCLUDE_GUARD__STATIC_CONFIG_H__ */

--- a/firmware/Core/Inc/littlefs/flash_benchmark.h
+++ b/firmware/Core/Inc/littlefs/flash_benchmark.h
@@ -1,0 +1,8 @@
+#ifndef __INCLUDE_GUARD__FLASH_BENCHMARK_H__
+#define __INCLUDE_GUARD__FLASH_BENCHMARK_H__
+
+#include <stdint.h>
+
+uint8_t FLASH_benchmark_erase_write_read(uint8_t chip_num, uint32_t test_data_address, uint16_t test_data_length, char* response_str, uint16_t response_str_len);
+
+#endif /* __INCLUDE_GUARD__FLASH_BENCHMARK_H__ */

--- a/firmware/Core/Inc/littlefs/flash_driver.h
+++ b/firmware/Core/Inc/littlefs/flash_driver.h
@@ -59,7 +59,7 @@ uint8_t FLASH_read_status_register(SPI_HandleTypeDef *hspi, uint8_t chip_number,
 uint8_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_number);
 uint8_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_number);
 uint8_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr);
-uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *packet_buffer, lfs_size_t size);
+uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *packet_buffer, lfs_size_t packet_buffer_len);
 uint8_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *rx_buffer, lfs_size_t rx_buffer_len);
 
 uint8_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_number);

--- a/firmware/Core/Inc/littlefs/flash_driver.h
+++ b/firmware/Core/Inc/littlefs/flash_driver.h
@@ -13,7 +13,7 @@
 #include "littlefs/lfs.h"
 
 
-/*-----------------------------INCLUDES-----------------------------*/
+/*----------------------------- CONFIG VARIABLES ----------------------------- */
 
 // number of CS pins available
 #define FLASH_NUMBER_OF_FLASH_DEVICES 8 // TODO: update to 8, or 10 with FRAM maybe

--- a/firmware/Core/Inc/littlefs/lfs_util.h
+++ b/firmware/Core/Inc/littlefs/lfs_util.h
@@ -8,6 +8,19 @@
 #ifndef LFS_UTIL_H
 #define LFS_UTIL_H
 
+// ================ Configuration =================
+#define LFS_NO_MALLOC 1
+
+// TODO: try setting these macros to write to debug UART or logs, maybe
+#define LFS_NO_DEBUG 1
+#define LFS_NO_WARN 1
+#define LFS_NO_ERROR 1
+#define LFS_NO_ASSERT 1
+// #define LFS_NO_INTRINSICS // Use the default for this.
+
+// ============= END Configuration ================
+
+
 // Users can override lfs_util.h with their own configuration by defining
 // LFS_CONFIG as a header file to include (-DLFS_CONFIG=lfs_config.h).
 //

--- a/firmware/Core/Inc/littlefs/littlefs_benchmark.h
+++ b/firmware/Core/Inc/littlefs/littlefs_benchmark.h
@@ -1,0 +1,9 @@
+#ifndef __INCLUDE_GUARD__LITTLEFS_BENCHMARK_H__
+#define __INCLUDE_GUARD__LITTLEFS_BENCHMARK_H__
+
+#include <stdint.h>
+
+
+uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len);
+
+#endif // __INCLUDE_GUARD__LITTLEFS_BENCHMARK_H__

--- a/firmware/Core/Inc/littlefs/littlefs_helper.h
+++ b/firmware/Core/Inc/littlefs/littlefs_helper.h
@@ -14,6 +14,10 @@
 
 #include "littlefs/flash_driver.h"
 
+extern lfs_t lfs;
+extern struct lfs_config cfg;
+extern struct lfs_file_config file_cfg;
+
 /*---------------------------FUNCTIONS---------------------------*/
 int8_t LFS_format();
 int8_t LFS_mount();

--- a/firmware/Core/Inc/littlefs/littlefs_helper.h
+++ b/firmware/Core/Inc/littlefs/littlefs_helper.h
@@ -14,9 +14,9 @@
 
 #include "littlefs/flash_driver.h"
 
-extern lfs_t lfs;
-extern struct lfs_config cfg;
-extern struct lfs_file_config file_cfg;
+extern lfs_t LFS_filesystem; // LittleFS filesystem object; traditionally called `lfs`
+extern struct lfs_config LFS_cfg;
+extern struct lfs_file_config LFS_file_cfg;
 
 /*---------------------------FUNCTIONS---------------------------*/
 int8_t LFS_format();

--- a/firmware/Core/Inc/littlefs/littlefs_helper.h
+++ b/firmware/Core/Inc/littlefs/littlefs_helper.h
@@ -19,9 +19,9 @@ int8_t LFS_format();
 int8_t LFS_mount();
 int8_t LFS_unmount();
 int8_t LFS_list_directory(char *root_directory);
-int8_t LFS_delete_file(char *file_name);
+int8_t LFS_delete_file(const char file_name[]);
 int8_t LFS_make_directory(char *dir_name);
-int8_t LFS_write_file(char *file_name, uint8_t *write_buffer, uint32_t write_buffer_len);
-int8_t LFS_read_file(char *file_name, uint8_t *read_buffer, uint32_t read_buffer_len);
+int8_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t write_buffer_len);
+int8_t LFS_read_file(const char file_name[], uint8_t *read_buffer, uint32_t read_buffer_len);
 
 #endif /* __INCLUDE_GUARD__LITTLEFS_HELPER_H__ */

--- a/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
@@ -20,4 +20,7 @@ uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_e
 uint8_t TCMDEXEC_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
+uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+                        
 #endif /* __INCLUDE_GUARD__FLASH_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
@@ -20,7 +20,7 @@ uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_e
 uint8_t TCMDEXEC_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
                         
 #endif /* __INCLUDE_GUARD__FLASH_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Inc/telecommands/lfs_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/lfs_telecommand_defs.h
@@ -23,4 +23,7 @@ uint8_t TCMDEXEC_fs_read_file(const char *args_str, TCMD_TelecommandChannel_enum
 uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
+uint8_t TCMDEXEC_fs_benchmark_write_read(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
 #endif /* __INCLUDE_GUARD__LFS_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Inc/telecommands/lfs_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/lfs_telecommand_defs.h
@@ -23,7 +23,7 @@ uint8_t TCMDEXEC_fs_read_file(const char *args_str, TCMD_TelecommandChannel_enum
 uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_fs_benchmark_write_read(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_benchmark_write_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif /* __INCLUDE_GUARD__LFS_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Src/littlefs/flash_benchmark.c
+++ b/firmware/Core/Src/littlefs/flash_benchmark.c
@@ -4,6 +4,7 @@
 #include "littlefs/flash_driver.h"
 
 #include <string.h>
+#include <stdio.h>
 
 SPI_HandleTypeDef *hspi_ptr = &hspi1;
 

--- a/firmware/Core/Src/littlefs/flash_benchmark.c
+++ b/firmware/Core/Src/littlefs/flash_benchmark.c
@@ -1,0 +1,91 @@
+
+#include "main.h"
+#include "littlefs/flash_benchmark.h"
+#include "littlefs/flash_driver.h"
+
+#include <string.h>
+
+SPI_HandleTypeDef *hspi_ptr = &hspi1;
+
+/// @brief Benchmarks the erase/read/write operations on the flash memory module.
+/// @param chip_num Chip number to use.
+/// @param test_data_address Address to erase, write, and then read back from.
+/// @param test_data_length Must be <= 512. Otherwise, the verification will fail.
+/// @param response_str 
+/// @param response_str_len 
+/// @return 0 on success. 1 if erase failed. 2 if write failed. 3 if read failed. 4 if verify failed.
+/// @details This function will erase the flash memory, write test data to it, read it back, and verify the read data.
+///       The test data is a sequence of bytes from 0 to 255. The response_str is valid whether or not there are errors.
+uint8_t FLASH_benchmark_erase_write_read(uint8_t chip_num, uint32_t test_data_address, uint16_t test_data_length, char* response_str, uint16_t response_str_len) {
+    response_str[0] = '\0';
+
+    // Erase
+    const uint32_t erase_start_time = HAL_GetTick();
+    const uint8_t erase_result = FLASH_erase(hspi_ptr, chip_num, 0);
+    if (erase_result != 0) {
+        snprintf(
+            &response_str[strlen(response_str)],
+            response_str_len - strlen(response_str),
+            "Erase failed. FLASH_erase() return: %d\n", erase_result);
+        return 1;
+    }
+    const uint32_t erase_end_time = HAL_GetTick();
+    snprintf(
+        &response_str[strlen(response_str)],
+        response_str_len - strlen(response_str),
+        "Erase: %lu ms\n", erase_end_time - erase_start_time);
+
+    // Write
+    uint8_t write_buffer[test_data_length];
+    for (uint32_t i = 0; i < test_data_length; i++) {
+        // Add 42 below, because errors are likely to happen around powers of 2,
+        // so this avoids having a 0/255 right on a power of 2 boundary.
+        write_buffer[i] = (i + 42) % 256;
+    }
+    // TODO: for very large writes, split into multiple writes (instead of allocating the whole amount on the stack)
+    const uint32_t write_send_start_time = HAL_GetTick();
+    const uint8_t write_result = FLASH_write(hspi_ptr, chip_num, test_data_address, write_buffer, test_data_length);
+    if (write_result != 0) {
+        snprintf(
+            &response_str[strlen(response_str)],
+            response_str_len - strlen(response_str),
+            "Write failed. FLASH_write return: %d\n", write_result);
+        return 2;
+    }
+    const uint32_t write_send_end_time = HAL_GetTick();
+    snprintf(
+        &response_str[strlen(response_str)],
+        response_str_len - strlen(response_str),
+        "Write: %lu ms\n",
+        write_send_end_time - write_send_start_time);
+
+    // Read
+    const uint32_t read_start_time = HAL_GetTick();
+    uint8_t read_buffer[test_data_length];
+    const uint8_t read_result = FLASH_read_data(hspi_ptr, chip_num, test_data_address, read_buffer, test_data_length);
+    if (read_result != 0) {
+        snprintf(
+            &response_str[strlen(response_str)],
+            response_str_len - strlen(response_str),
+            "Read failed. FLASH_read_data return: %d\n", read_result);
+        return 3;
+    }
+    const uint32_t read_end_time = HAL_GetTick();
+    snprintf(
+        &response_str[strlen(response_str)],
+        response_str_len - strlen(response_str),
+        "Read: %lu ms\n", read_end_time - read_start_time);
+
+    // Verify Read
+    for (uint32_t i = 0; i < test_data_length; i++) {
+        if (read_buffer[i] != write_buffer[i]) {
+            snprintf(
+                &response_str[strlen(response_str)],
+                response_str_len - strlen(response_str),
+                "Verify failed at index %lu. Expected %u, got %u.\n", i, write_buffer[i], read_buffer[i]);
+            return 4;
+        }
+    }
+
+    return 0;
+}

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -5,9 +5,6 @@
 #include "debug_tools/debug_uart.h"
 
 #include "config/static_config.h"
-#ifndef FLASH_ENABLE_UART_DEBUG_PRINT
-    #error "FLASH_ENABLE_UART_DEBUG_PRINT not defined"
-#endif
 
 /// Timeout duration for HAL_SPI_READ/WRITE operations.
 // Note: FLASH_read_data has sporadic timeouts at 5ms; 10ms is a safe bet.
@@ -153,11 +150,11 @@ uint8_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
             return 2;
         }
 
-        #if FLASH_ENABLE_UART_DEBUG_PRINT
-        DEBUG_uart_print_str("DEBUG: status_reg = 0x");
-        DEBUG_uart_print_array_hex(status_reg_buffer, 1);
-        DEBUG_uart_print_str("\n");
-        #endif
+        if (FLASH_enable_hot_path_debug_logs) {
+            DEBUG_uart_print_str("DEBUG: status_reg = 0x");
+            DEBUG_uart_print_array_hex(status_reg_buffer, 1);
+            DEBUG_uart_print_str("\n");
+        }
     }
 
     // Should never be reached:

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -3,7 +3,11 @@
 
 #include "littlefs/flash_driver.h"
 #include "debug_tools/debug_uart.h"
+
 #include "config/static_config.h"
+#ifndef FLASH_ENABLE_UART_DEBUG_PRINT
+    #error "FLASH_ENABLE_UART_DEBUG_PRINT not defined"
+#endif
 
 /// Timeout duration for HAL_SPI_READ/WRITE operations.
 #define FLASH_HAL_TIMEOUT_MS 10 

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -287,10 +287,10 @@ uint8_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
  * @param chip_number - the chip select number to activate
  * @param addr - block number that is to be written
  * @param packet_buffer - Pointer to buffer containing data to write
- * @param size - integer that idicates the size of the data
+ * @param packet_buffer_len - integer that indicates the size of the data to write
  * @retval Returns 0 on success, >0 on failure
  */
-uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *packet_buffer, lfs_size_t size)
+uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *packet_buffer, lfs_size_t packet_buffer_len)
 {
     // Split address into its 4 bytes
     uint8_t addr_bytes[4] = {(addr >> 24) & 0xFF, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF};
@@ -314,7 +314,7 @@ uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
         FLASH_deactivate_chip_select();
         return 3;
     }
-    const uint8_t tx_result_3 = HAL_SPI_Transmit(hspi, (uint8_t *)packet_buffer, size, FLASH_HAL_TIMEOUT_MS);
+    const uint8_t tx_result_3 = HAL_SPI_Transmit(hspi, (uint8_t *)packet_buffer, packet_buffer_len, FLASH_HAL_TIMEOUT_MS);
     if (tx_result_3 != HAL_OK) {
         FLASH_deactivate_chip_select();
         return 4;
@@ -365,7 +365,7 @@ uint8_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t ad
  * @param chip_number - the chip select number to activate
  * @param addr - block number that is to be read
  * @param rx_buffer - a to buffer where the read data will be stored
- * @param rx_buffer_len - integer that idicates the size of the data
+ * @param rx_buffer_len - integer that indicates the capacity of `rx_buffer`
  * @retval Returns 0 on success, >0 on failure
  */
 uint8_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *rx_buffer, lfs_size_t rx_buffer_len)

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -10,6 +10,9 @@
 #endif
 
 /// Timeout duration for HAL_SPI_READ/WRITE operations.
+// Note: FLASH_read_data has sporadic timeouts at 5ms; 10ms is a safe bet.
+// 512 bytes should take 2ms at 2Mbps.
+// TODO: ^ investigate the HAL_SPI_Receive overhead (2ms expected, >5ms observed)
 #define FLASH_HAL_TIMEOUT_MS 10 
 
 // The following timeout values are sourced from Section 11.3.1, Table 56: "CFI system interface string"

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -3,6 +3,7 @@
 
 #include "littlefs/flash_driver.h"
 #include "debug_tools/debug_uart.h"
+#include "config/static_config.h"
 
 /// Timeout duration for HAL_SPI_READ/WRITE operations.
 #define FLASH_HAL_TIMEOUT_MS 10 
@@ -145,9 +146,11 @@ uint8_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
             return 2;
         }
 
+        #if FLASH_ENABLE_UART_DEBUG_PRINT
         DEBUG_uart_print_str("DEBUG: status_reg = 0x");
         DEBUG_uart_print_array_hex(status_reg_buffer, 1);
         DEBUG_uart_print_str("\n");
+        #endif
     }
 
     // Should never be reached:

--- a/firmware/Core/Src/littlefs/littlefs_benchmark.c
+++ b/firmware/Core/Src/littlefs/littlefs_benchmark.c
@@ -1,0 +1,77 @@
+
+#include "main.h"
+#include "littlefs/littlefs_benchmark.h"
+#include "littlefs/littlefs_helper.h"
+
+#include <string.h>
+
+uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len) {
+    const char file_name[] = "benchmark_test.txt";
+    response_str[0] = '\0';
+
+    uint8_t expected_checksum = 0;
+
+    // Write
+    uint8_t write_buffer[write_chunk_size];
+    for (uint32_t i = 0; i < write_chunk_size; i++) {
+        const uint8_t b = (i + 42) % 256;
+        write_buffer[i] = b;
+    }
+    const uint32_t write_send_start_time = HAL_GetTick();
+    for (uint32_t chunk_num = 0; chunk_num < write_chunk_count; chunk_num++) {
+        const int8_t write_result = LFS_write_file(file_name, write_buffer, write_chunk_size);
+        for (uint32_t i = 0; i < write_chunk_size; i++) {
+            // bad checksum, but good enough
+            expected_checksum ^= write_buffer[i];
+        }
+        if (write_result < 0) {
+            snprintf(
+                &response_str[strlen(response_str)],
+                response_str_len - strlen(response_str),
+                "Write failed. LFS_write_file return: %d\n", write_result);
+            return 1;
+        }
+    }
+    const uint32_t write_send_end_time = HAL_GetTick();
+    snprintf(
+        &response_str[strlen(response_str)],
+        response_str_len - strlen(response_str),
+        "Write: %lu ms\n",
+        write_send_end_time - write_send_start_time);
+
+    // Read
+    const uint32_t read_start_time = HAL_GetTick();
+    uint8_t read_buffer[write_chunk_size];
+    uint8_t read_checksum = 0;
+    for (uint32_t chunk_num = 0; chunk_num < write_chunk_count; chunk_num++) {
+        const int8_t read_result = LFS_read_file(file_name, read_buffer, write_chunk_size);
+        if (read_result < 0) {
+            snprintf(
+                &response_str[strlen(response_str)],
+                response_str_len - strlen(response_str),
+                "Read failed on chunk %lu. LFS_read_file return: %d\n",
+                chunk_num, read_result);
+            return 2;
+        }
+        for (uint32_t i = 0; i < write_chunk_size; i++) {
+            read_checksum ^= read_buffer[i];
+        }
+    }
+
+    const uint32_t read_end_time = HAL_GetTick();
+    snprintf(
+        &response_str[strlen(response_str)],
+        response_str_len - strlen(response_str),
+        "Read: %lu ms\n", read_end_time - read_start_time);
+    
+    if (read_checksum != expected_checksum) {
+        snprintf(
+            &response_str[strlen(response_str)],
+            response_str_len - strlen(response_str),
+            "Checksum mismatch: expected %u, got %u\n", expected_checksum, read_checksum);
+        return 3;
+    }
+
+    return 0;
+}
+

--- a/firmware/Core/Src/littlefs/littlefs_benchmark.c
+++ b/firmware/Core/Src/littlefs/littlefs_benchmark.c
@@ -29,7 +29,7 @@ uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk
     // Open file for writing
     const uint32_t write_open_start_time = HAL_GetTick();
     lfs_file_t file;
-    const int8_t open_result = lfs_file_opencfg(&lfs, &file, file_name, LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC, &file_cfg);
+    const int8_t open_result = lfs_file_opencfg(&LFS_filesystem, &file, file_name, LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC, &LFS_file_cfg);
 	if (open_result != 0)
 	{
 		snprintf(
@@ -47,7 +47,7 @@ uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk
     // Write
     const uint32_t write_send_start_time = HAL_GetTick();
     for (uint32_t chunk_num = 0; chunk_num < write_chunk_count; chunk_num++) {
-        const int8_t write_result = lfs_file_write(&lfs, &file, write_buffer, write_chunk_size);
+        const int8_t write_result = lfs_file_write(&LFS_filesystem, &file, write_buffer, write_chunk_size);
         for (uint32_t i = 0; i < write_chunk_size; i++) {
             // Weak checksum, but good enough
             expected_checksum ^= write_buffer[i];
@@ -69,7 +69,7 @@ uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk
 
     // Close the file
     const uint32_t close_start_time = HAL_GetTick();
-    const int8_t close_result = lfs_file_close(&lfs, &file);
+    const int8_t close_result = lfs_file_close(&LFS_filesystem, &file);
     if (close_result < 0) {
         snprintf(
             &response_str[strlen(response_str)],
@@ -85,7 +85,7 @@ uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk
 
     // Re-open the file for reading
     const uint32_t read_open_start_time = HAL_GetTick();
-    const int8_t read_open_result = lfs_file_opencfg(&lfs, &file, file_name, LFS_O_RDONLY, &file_cfg);
+    const int8_t read_open_result = lfs_file_opencfg(&LFS_filesystem, &file, file_name, LFS_O_RDONLY, &LFS_file_cfg);
     if (read_open_result < 0) {
         snprintf(
             &response_str[strlen(response_str)],
@@ -104,7 +104,7 @@ uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk
     uint8_t read_buffer[write_chunk_size];
     uint8_t read_checksum = 0;
     for (uint32_t chunk_num = 0; chunk_num < write_chunk_count; chunk_num++) {
-        const int8_t read_result = lfs_file_read(&lfs, &file, read_buffer, write_chunk_size);
+        const int8_t read_result = lfs_file_read(&LFS_filesystem, &file, read_buffer, write_chunk_size);
         if (read_result < 0) {
             snprintf(
                 &response_str[strlen(response_str)],
@@ -125,7 +125,7 @@ uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk
 
     // Close the file
     const uint32_t read_close_start_time = HAL_GetTick();
-    const int8_t read_close_result = lfs_file_close(&lfs, &file);
+    const int8_t read_close_result = lfs_file_close(&LFS_filesystem, &file);
     if (read_close_result < 0) {
         snprintf(
             &response_str[strlen(response_str)],

--- a/firmware/Core/Src/littlefs/littlefs_benchmark.c
+++ b/firmware/Core/Src/littlefs/littlefs_benchmark.c
@@ -4,6 +4,7 @@
 #include "littlefs/littlefs_helper.h"
 
 #include <string.h>
+#include <stdio.h>
 
 uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len) {
     const char file_name[] = "benchmark_test.txt";

--- a/firmware/Core/Src/littlefs/littlefs_benchmark.c
+++ b/firmware/Core/Src/littlefs/littlefs_benchmark.c
@@ -6,23 +6,50 @@
 #include <string.h>
 #include <stdio.h>
 
+/// @brief Benchmarks the write/read operations on the LittleFS file system.
+/// @details This function will write test data to a static filename, read it back, and verify the read data.
+/// @param write_chunk_size Number of bytes to write in each chunk.
+/// @param write_chunk_count Number of chunks to write.
+/// @param response_str 
+/// @param response_str_len 
+/// @return 0 on success. >0 if there was an error.
 uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len) {
     const char file_name[] = "benchmark_test.txt";
     response_str[0] = '\0';
 
     uint8_t expected_checksum = 0;
 
-    // Write
+    // Prep some data to write
     uint8_t write_buffer[write_chunk_size];
     for (uint32_t i = 0; i < write_chunk_size; i++) {
         const uint8_t b = (i + 42) % 256;
         write_buffer[i] = b;
     }
+
+    // Open file for writing
+    const uint32_t write_open_start_time = HAL_GetTick();
+    lfs_file_t file;
+    const int8_t open_result = lfs_file_opencfg(&lfs, &file, file_name, LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC, &file_cfg);
+	if (open_result != 0)
+	{
+		snprintf(
+            &response_str[strlen(response_str)],
+            response_str_len - strlen(response_str),
+            "Open failed. LFS_file_open return: %d\n", open_result);
+		return 1;
+	}
+    const uint32_t open_end_time = HAL_GetTick();
+    snprintf(
+        &response_str[strlen(response_str)],
+        response_str_len - strlen(response_str),
+        "Write open: %lu ms\n", open_end_time - write_open_start_time);
+
+    // Write
     const uint32_t write_send_start_time = HAL_GetTick();
     for (uint32_t chunk_num = 0; chunk_num < write_chunk_count; chunk_num++) {
-        const int8_t write_result = LFS_write_file(file_name, write_buffer, write_chunk_size);
+        const int8_t write_result = lfs_file_write(&lfs, &file, write_buffer, write_chunk_size);
         for (uint32_t i = 0; i < write_chunk_size; i++) {
-            // bad checksum, but good enough
+            // Weak checksum, but good enough
             expected_checksum ^= write_buffer[i];
         }
         if (write_result < 0) {
@@ -40,12 +67,44 @@ uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk
         "Write: %lu ms\n",
         write_send_end_time - write_send_start_time);
 
+    // Close the file
+    const uint32_t close_start_time = HAL_GetTick();
+    const int8_t close_result = lfs_file_close(&lfs, &file);
+    if (close_result < 0) {
+        snprintf(
+            &response_str[strlen(response_str)],
+            response_str_len - strlen(response_str),
+            "Close failed. LFS_file_close return: %d\n", close_result);
+        return 1;
+    }
+    const uint32_t close_end_time = HAL_GetTick();
+    snprintf(
+        &response_str[strlen(response_str)],
+        response_str_len - strlen(response_str),
+        "Write close: %lu ms\n", close_end_time - close_start_time);
+
+    // Re-open the file for reading
+    const uint32_t read_open_start_time = HAL_GetTick();
+    const int8_t read_open_result = lfs_file_opencfg(&lfs, &file, file_name, LFS_O_RDONLY, &file_cfg);
+    if (read_open_result < 0) {
+        snprintf(
+            &response_str[strlen(response_str)],
+            response_str_len - strlen(response_str),
+            "Read open failed. LFS_file_open return: %d\n", read_open_result);
+        return 1;
+    }
+    const uint32_t read_open_end_time = HAL_GetTick();
+    snprintf(
+        &response_str[strlen(response_str)],
+        response_str_len - strlen(response_str),
+        "Read open: %lu ms\n", read_open_end_time - read_open_start_time);
+
     // Read
     const uint32_t read_start_time = HAL_GetTick();
     uint8_t read_buffer[write_chunk_size];
     uint8_t read_checksum = 0;
     for (uint32_t chunk_num = 0; chunk_num < write_chunk_count; chunk_num++) {
-        const int8_t read_result = LFS_read_file(file_name, read_buffer, write_chunk_size);
+        const int8_t read_result = lfs_file_read(&lfs, &file, read_buffer, write_chunk_size);
         if (read_result < 0) {
             snprintf(
                 &response_str[strlen(response_str)],
@@ -58,13 +117,29 @@ uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk
             read_checksum ^= read_buffer[i];
         }
     }
-
     const uint32_t read_end_time = HAL_GetTick();
     snprintf(
         &response_str[strlen(response_str)],
         response_str_len - strlen(response_str),
         "Read: %lu ms\n", read_end_time - read_start_time);
+
+    // Close the file
+    const uint32_t read_close_start_time = HAL_GetTick();
+    const int8_t read_close_result = lfs_file_close(&lfs, &file);
+    if (read_close_result < 0) {
+        snprintf(
+            &response_str[strlen(response_str)],
+            response_str_len - strlen(response_str),
+            "Read close failed. LFS_file_close return: %d\n", read_close_result);
+        return 1;
+    }
+    const uint32_t read_close_end_time = HAL_GetTick();
+    snprintf(
+        &response_str[strlen(response_str)],
+        response_str_len - strlen(response_str),
+        "Read close: %lu ms\n", read_close_end_time - read_close_start_time);
     
+    // Verify checksum
     if (read_checksum != expected_checksum) {
         snprintf(
             &response_str[strlen(response_str)],

--- a/firmware/Core/Src/littlefs/littlefs_driver.c
+++ b/firmware/Core/Src/littlefs/littlefs_driver.c
@@ -59,11 +59,12 @@ int LFS_block_device_erase(const struct lfs_config *c, lfs_block_t block)
 
 /**
  * @brief LittleFS sync function
- * @param LittleFS Configurations
- * @retval int - 0 since this function isn't used
+ * @param c - LittleFS Configuration
+ * @retval int - 0 since we are not caching reads or writes
  */
 int LFS_block_device_sync(const struct lfs_config *c)
 {
+	// Per the README:
+	// If the write function does not perform caching, and therefore each read or write call hits the memory, the sync function can simply return 0.
 	return 0;
 }
-

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -241,9 +241,11 @@ int8_t LFS_write_file(char *file_name, uint8_t *write_buffer, uint32_t write_buf
 		return open_result;
 	}
 	
+    #if LFS_ENABLE_UART_DEBUG_PRINT
 	DEBUG_uart_print_str("Opened/created a file named: '");
 	DEBUG_uart_print_str(file_name);
 	DEBUG_uart_print_str("'\n");
+    #endif
 
 	// Write data to file
 	const int8_t write_result = lfs_file_write(&lfs, &file, write_buffer, write_buffer_len);
@@ -253,7 +255,9 @@ int8_t LFS_write_file(char *file_name, uint8_t *write_buffer, uint32_t write_buf
 		return write_result;
 	}
 	
+    #if LFS_ENABLE_UART_DEBUG_PRINT
 	DEBUG_uart_print_str("Successfully wrote data to file!\n");
+    #endif
 
 	// Close the File, the storage is not updated until the file is closed successfully
 	const int8_t close_result = lfs_file_close(&lfs, &file);
@@ -263,7 +267,10 @@ int8_t LFS_write_file(char *file_name, uint8_t *write_buffer, uint32_t write_buf
 		return close_result;
 	}
 	
+    #if LFS_ENABLE_UART_DEBUG_PRINT
 	DEBUG_uart_print_str("Successfully closed the file!\n");
+    #endif
+    
 	return 0;
 }
 
@@ -284,9 +291,11 @@ int8_t LFS_read_file(char *file_name, uint8_t *read_buffer, uint32_t read_buffer
 		return open_result;
 	}
 	
+    #if LFS_ENABLE_UART_DEBUG_PRINT
 	DEBUG_uart_print_str("Opened file to read: ");
 	DEBUG_uart_print_str(file_name);
 	DEBUG_uart_print_str("\n");
+    #endif
 
 	const int8_t read_result = lfs_file_read(&lfs, &file, read_buffer, read_buffer_len);
 	if (read_result < 0)
@@ -295,7 +304,9 @@ int8_t LFS_read_file(char *file_name, uint8_t *read_buffer, uint32_t read_buffer
 		return read_result;
 	}
 	
+    #if LFS_ENABLE_UART_DEBUG_PRINT
 	DEBUG_uart_print_str("Successfully read file!\n");
+    #endif
 
 	// Close the File, the storage is not updated until the file is closed successfully
 	const int8_t close_result = lfs_file_close(&lfs, &file);
@@ -305,6 +316,9 @@ int8_t LFS_read_file(char *file_name, uint8_t *read_buffer, uint32_t read_buffer
 		return close_result;
 	}
 	
+    #if LFS_ENABLE_UART_DEBUG_PRINT
 	DEBUG_uart_print_str("Successfully closed the file!\n");
+    #endif
+
 	return 0;	
 }

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -29,7 +29,7 @@ uint8_t LFS_file_buffer[FLASH_CHIP_PAGE_SIZE_BYTES];
 
 // TODO: look into the `LFS_F_INLINE` macro to increase the maximum number of files we can have
 
-// Variables LittleFS uses for various functions
+// Variables LittleFS uses for various functions (all externed in littlefs_helper.h)
 lfs_t lfs;
 struct lfs_config cfg = {
     .read = LFS_block_device_read,

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -30,8 +30,8 @@ uint8_t LFS_file_buffer[FLASH_CHIP_PAGE_SIZE_BYTES];
 // TODO: look into the `LFS_F_INLINE` macro to increase the maximum number of files we can have
 
 // Variables LittleFS uses for various functions (all externed in littlefs_helper.h)
-lfs_t lfs;
-struct lfs_config cfg = {
+lfs_t LFS_filesystem;
+struct lfs_config LFS_cfg = {
     .read = LFS_block_device_read,
     .prog = LFS_block_device_prog,
     .erase = LFS_block_device_erase,
@@ -51,7 +51,7 @@ struct lfs_config cfg = {
     .prog_buffer = LFS_prog_buffer,
     .lookahead_buffer = LFS_lookahead_buf};
 
-struct lfs_file_config file_cfg = {
+struct lfs_file_config LFS_file_cfg = {
     .buffer = LFS_file_buffer,
     .attr_count = 0,
     .attrs = NULL};
@@ -66,7 +66,7 @@ struct lfs_file_config file_cfg = {
  */
 int8_t LFS_format()
 {
-	int8_t result = lfs_format(&lfs, &cfg);
+	int8_t result = lfs_format(&LFS_filesystem, &LFS_cfg);
 	if (result < 0)
 	{
 		DEBUG_uart_print_str("Error formatting!\n");
@@ -90,7 +90,7 @@ int8_t LFS_mount()
 	}
 
     // Variable to store status of LittleFS mounting
-    int8_t mount_result = lfs_mount(&lfs, &cfg);
+    int8_t mount_result = lfs_mount(&LFS_filesystem, &LFS_cfg);
     if (mount_result < 0)
     {
         DEBUG_uart_print_str("Mounting unsuccessful\n");
@@ -116,7 +116,7 @@ int8_t LFS_unmount()
     }
 
     // Unmount LittleFS to release any resources used by LittleFS
-    const int8_t unmount_result = lfs_unmount(&lfs);
+    const int8_t unmount_result = lfs_unmount(&LFS_filesystem);
     if (unmount_result < 0)
     {
         DEBUG_uart_print_str("Error un-mounting.\n");
@@ -142,7 +142,7 @@ int8_t LFS_list_directory(char *root_directory)
     }
 
     lfs_dir_t dir;
-    int8_t open_dir_result = lfs_dir_open(&lfs, &dir, root_directory);
+    int8_t open_dir_result = lfs_dir_open(&LFS_filesystem, &dir, root_directory);
     if (open_dir_result < 0)
     {
         DEBUG_uart_print_str("Error opening a directory.\n");
@@ -154,7 +154,7 @@ int8_t LFS_list_directory(char *root_directory)
     while (read_dir_result >= 0)
     {
         struct lfs_info info;
-        read_dir_result = lfs_dir_read(&lfs, &dir, &info);
+        read_dir_result = lfs_dir_read(&LFS_filesystem, &dir, &info);
 
         DEBUG_uart_print_str(info.name);
         DEBUG_uart_print_str(", ");
@@ -170,7 +170,7 @@ int8_t LFS_list_directory(char *root_directory)
 
     DEBUG_uart_print_str("Successfully Listed Directory Contents.\n");
 
-    int8_t close_dir_result = lfs_dir_close(&lfs, &dir);
+    int8_t close_dir_result = lfs_dir_close(&LFS_filesystem, &dir);
     if (close_dir_result < 0)
     {
         DEBUG_uart_print_str("Error closing directory.\n");
@@ -193,7 +193,7 @@ int8_t LFS_delete_file(const char file_name[])
         return 1;
     }
 
-    int8_t remove_result = lfs_remove(&lfs, file_name);
+    int8_t remove_result = lfs_remove(&LFS_filesystem, file_name);
     if (remove_result < 0)
     {
         DEBUG_uart_print_str("Error removing file/directory.\n");
@@ -217,7 +217,7 @@ int8_t LFS_make_directory(char *dir_name)
         return 1;
     }
 
-    int8_t make_dir_result = lfs_mkdir(&lfs, dir_name);
+    int8_t make_dir_result = lfs_mkdir(&LFS_filesystem, dir_name);
     if (make_dir_result < 0)
     {
         DEBUG_uart_print_str("Error creating directory.\n");
@@ -245,7 +245,7 @@ int8_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t wr
 
     // Create or Open a file with Write only flag
     lfs_file_t file;
-    const int8_t open_result = lfs_file_opencfg(&lfs, &file, file_name, LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC, &file_cfg);
+    const int8_t open_result = lfs_file_opencfg(&LFS_filesystem, &file, file_name, LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC, &LFS_file_cfg);
 
 	if (open_result < 0)
 	{
@@ -260,7 +260,7 @@ int8_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t wr
     #endif
 
 	// Write data to file
-	const int8_t write_result = lfs_file_write(&lfs, &file, write_buffer, write_buffer_len);
+	const int8_t write_result = lfs_file_write(&LFS_filesystem, &file, write_buffer, write_buffer_len);
 	if (write_result < 0)
 	{
 		DEBUG_uart_print_str("Error writing to file!\n");
@@ -272,7 +272,7 @@ int8_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t wr
     #endif
 
 	// Close the File, the storage is not updated until the file is closed successfully
-	const int8_t close_result = lfs_file_close(&lfs, &file);
+	const int8_t close_result = lfs_file_close(&LFS_filesystem, &file);
 	if (close_result < 0)
 	{
 		DEBUG_uart_print_str("Error closing the file!\n");
@@ -296,7 +296,7 @@ int8_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t wr
 int8_t LFS_read_file(const char file_name[], uint8_t *read_buffer, uint32_t read_buffer_len)
 {
 	lfs_file_t file;
-	const int8_t open_result = lfs_file_opencfg(&lfs, &file, file_name, LFS_O_RDONLY, &file_cfg);
+	const int8_t open_result = lfs_file_opencfg(&LFS_filesystem, &file, file_name, LFS_O_RDONLY, &LFS_file_cfg);
 	if (open_result < 0)
 	{
 		DEBUG_uart_print_str("Error opening file to read\n");
@@ -309,7 +309,7 @@ int8_t LFS_read_file(const char file_name[], uint8_t *read_buffer, uint32_t read
 	DEBUG_uart_print_str("\n");
     #endif
 
-	const int8_t read_result = lfs_file_read(&lfs, &file, read_buffer, read_buffer_len);
+	const int8_t read_result = lfs_file_read(&LFS_filesystem, &file, read_buffer, read_buffer_len);
 	if (read_result < 0)
 	{
 		DEBUG_uart_print_str("Error Reading File!\n");
@@ -321,7 +321,7 @@ int8_t LFS_read_file(const char file_name[], uint8_t *read_buffer, uint32_t read
     #endif
 
 	// Close the File, the storage is not updated until the file is closed successfully
-	const int8_t close_result = lfs_file_close(&lfs, &file);
+	const int8_t close_result = lfs_file_close(&LFS_filesystem, &file);
 	if (close_result < 0)
 	{
 		DEBUG_uart_print_str("Error closing the file!\n");

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -179,7 +179,7 @@ int8_t LFS_list_directory(char *root_directory)
  * @param file_name Pointer to cstring holding the file name to remove
  * @retval 0 on success, 1 if LFS is unmounted, negative LFS error codes on failure
  */
-int8_t LFS_delete_file(char *file_name)
+int8_t LFS_delete_file(const char file_name[])
 {
     if (!LFS_is_lfs_mounted)
     {
@@ -229,7 +229,7 @@ int8_t LFS_make_directory(char *dir_name)
  * @param write_buffer_len - Size of the data to write
  * @retval 0 on success, 1 if LFS is unmounted, negative LFS error codes on failure
  */
-int8_t LFS_write_file(char *file_name, uint8_t *write_buffer, uint32_t write_buffer_len)
+int8_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t write_buffer_len)
 {
     if (!LFS_is_lfs_mounted)
     {
@@ -287,7 +287,7 @@ int8_t LFS_write_file(char *file_name, uint8_t *write_buffer, uint32_t write_buf
  * @param read_buffer_len - Size of the data to read
  * @retval Returns negative values if read or file open failed, else return 0
  */
-int8_t LFS_read_file(char *file_name, uint8_t *read_buffer, uint32_t read_buffer_len)
+int8_t LFS_read_file(const char file_name[], uint8_t *read_buffer, uint32_t read_buffer_len)
 {
 	lfs_file_t file;
 	const int8_t open_result = lfs_file_open(&lfs, &file, file_name, LFS_O_RDONLY);

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -7,6 +7,12 @@
 #include "littlefs/littlefs_driver.h"
 #include "debug_tools/debug_uart.h"
 
+
+#include "config/static_config.h"
+#ifndef LFS_ENABLE_UART_DEBUG_PRINT
+    #error "LFS_ENABLE_UART_DEBUG_PRINT not defined in static_config.h"
+#endif
+
 /*-----------------------------VARIABLES-----------------------------*/
 // Variables to track LittleFS on Flash Memory Module
 uint8_t LFS_is_lfs_mounted = 0;
@@ -270,7 +276,7 @@ int8_t LFS_write_file(char *file_name, uint8_t *write_buffer, uint32_t write_buf
     #if LFS_ENABLE_UART_DEBUG_PRINT
 	DEBUG_uart_print_str("Successfully closed the file!\n");
     #endif
-    
+
 	return 0;
 }
 

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -25,6 +25,7 @@ uint8_t LFS_is_lfs_mounted = 0;
 uint8_t LFS_read_buffer[FLASH_CHIP_PAGE_SIZE_BYTES];
 uint8_t LFS_prog_buffer[FLASH_CHIP_PAGE_SIZE_BYTES];
 uint8_t LFS_lookahead_buf[16];
+uint8_t LFS_file_buffer[FLASH_CHIP_PAGE_SIZE_BYTES];
 
 // TODO: look into the `LFS_F_INLINE` macro to increase the maximum number of files we can have
 
@@ -49,6 +50,11 @@ struct lfs_config cfg = {
     .read_buffer = LFS_read_buffer,
     .prog_buffer = LFS_prog_buffer,
     .lookahead_buffer = LFS_lookahead_buf};
+
+struct lfs_file_config file_cfg = {
+    .buffer = LFS_file_buffer,
+    .attr_count = 0,
+    .attrs = NULL};
 
 // -----------------------------LITTLEFS FUNCTIONS-----------------------------
 
@@ -239,7 +245,7 @@ int8_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t wr
 
     // Create or Open a file with Write only flag
     lfs_file_t file;
-    const int8_t open_result = lfs_file_open(&lfs, &file, file_name, LFS_O_WRONLY | LFS_O_CREAT);
+    const int8_t open_result = lfs_file_opencfg(&lfs, &file, file_name, LFS_O_WRONLY | LFS_O_CREAT, &file_cfg);
 
 	if (open_result < 0)
 	{
@@ -290,7 +296,7 @@ int8_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t wr
 int8_t LFS_read_file(const char file_name[], uint8_t *read_buffer, uint32_t read_buffer_len)
 {
 	lfs_file_t file;
-	const int8_t open_result = lfs_file_open(&lfs, &file, file_name, LFS_O_RDONLY);
+	const int8_t open_result = lfs_file_opencfg(&lfs, &file, file_name, LFS_O_RDONLY, &file_cfg);
 	if (open_result < 0)
 	{
 		DEBUG_uart_print_str("Error opening file to read\n");

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -245,7 +245,7 @@ int8_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t wr
 
     // Create or Open a file with Write only flag
     lfs_file_t file;
-    const int8_t open_result = lfs_file_opencfg(&lfs, &file, file_name, LFS_O_WRONLY | LFS_O_CREAT, &file_cfg);
+    const int8_t open_result = lfs_file_opencfg(&lfs, &file, file_name, LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC, &file_cfg);
 
 	if (open_result < 0)
 	{

--- a/firmware/Core/Src/main.c
+++ b/firmware/Core/Src/main.c
@@ -70,6 +70,7 @@ const osThreadAttr_t defaultTask_attributes = {
 };
 /* USER CODE BEGIN PV */
 
+// The STM32 has 640 KB of RAM.
 // For CTS-SAT-1, please create threads here (and not in the IOC file):
 
 osThreadId_t TASK_DEBUG_print_heartbeat_Handle;
@@ -82,7 +83,7 @@ const osThreadAttr_t TASK_DEBUG_print_heartbeat_Attributes = {
 osThreadId_t TASK_handle_uart_telecommands_Handle;
 const osThreadAttr_t TASK_handle_uart_telecommands_Attributes = {
   .name = "TASK_handle_uart_telecommands",
-  // Size 2048 doesn't work with LFS settings, but 8192 does
+  // Size 2048 doesn't work with LFS settings, but 8192 does.
   // TODO: confirm stack size
   .stack_size = 8192,
   .priority = (osPriority_t) osPriorityNormal,

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -104,7 +104,6 @@ void TASK_handle_uart_telecommands(void *argument) {
 				continue;
 			}
 
-			// execute/queue the command
 			// process the telecommand name
 			int32_t tcmd_idx = TCMD_parse_telecommand_get_index((char *)latest_tcmd, latest_tcmd_len);
 			if (tcmd_idx < 0) {
@@ -157,14 +156,19 @@ void TASK_handle_uart_telecommands(void *argument) {
 			latest_tcmd[latest_tcmd_len] = '\0';
 			char response_buf[512];
 			memset(response_buf, 0, sizeof(response_buf));
+			const uint32_t uptime_before_tcmd_exec_ms = HAL_GetTick();
 			const uint8_t tcmd_result = tcmd_def.tcmd_func(
 				args_str_no_parens,
 				TCMD_TelecommandChannel_DEBUG_UART,
 				response_buf,
 				sizeof(response_buf));
+			const uint32_t uptime_after_tcmd_exec_ms = HAL_GetTick();
+			const uint32_t tcmd_exec_duration_ms = uptime_after_tcmd_exec_ms - uptime_before_tcmd_exec_ms;
 
 			// print back the response
-			DEBUG_uart_print_str("======== Response (err=");
+			DEBUG_uart_print_str("======== Response (duration=");
+			DEBUG_uart_print_int32(tcmd_exec_duration_ms);
+			DEBUG_uart_print_str("ms, err=");
 			DEBUG_uart_print_uint32(tcmd_result);
 			if (tcmd_result != 0) {
 				DEBUG_uart_print_str(" !!!!!! ERROR !!!!!!");

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -3,6 +3,7 @@
 
 #include "telecommands/flash_telecommand_defs.h"
 #include "littlefs/flash_driver.h"
+#include "littlefs/flash_benchmark.h"
 #include "debug_tools/debug_uart.h"
 
 #include <string.h>
@@ -263,4 +264,37 @@ uint8_t TCMDEXEC_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_
     }
     
     return 0;
+}
+
+/// @brief Telecommand: Benchmarks the erase/write/read operations on the flash memory module.
+/// @param args_str Arg 0: Chip Number (CS number) as uint, Arg 1: Test Data Address as uint,
+///     Arg 2: Test Data Length as uint
+/// @return 0 on success, >0 on error
+uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+    uint64_t chip_num, test_data_address, test_data_length;
+
+    uint8_t arg0_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 0, &chip_num);
+    uint8_t arg1_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 1, &test_data_address);
+    uint8_t arg2_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 2, &test_data_length);
+    
+    if (arg0_result != 0 || arg1_result != 0 || arg2_result != 0) {
+        snprintf(
+            response_output_buf, response_output_buf_len,
+            "Error parsing arguments. Return codes: arg0=%d, arg1=%d, arg2=%d",
+            arg0_result, arg1_result, arg2_result);
+        return 1;
+    }
+
+    uint8_t result = FLASH_benchmark_erase_write_read((uint8_t)chip_num, (uint32_t)test_data_address, (uint32_t)test_data_length, response_output_buf, response_output_buf_len);
+    response_output_buf[response_output_buf_len - 1] = '\0'; // ensure null-terminated
+    if (result != 0) {
+        snprintf(
+            &response_output_buf[strlen(response_output_buf)],
+            response_output_buf_len - strlen(response_output_buf) - 1,
+            "Error benchmarking flash: Returned %d", result);
+        return 2;
+    }
+    
+    return result;
 }

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -6,6 +6,7 @@
 #include "littlefs/flash_benchmark.h"
 #include "debug_tools/debug_uart.h"
 
+#include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
 

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -271,7 +271,7 @@ uint8_t TCMDEXEC_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_
 /// @param args_str Arg 0: Chip Number (CS number) as uint, Arg 1: Test Data Address as uint,
 ///     Arg 2: Test Data Length as uint
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t chip_num, test_data_address, test_data_length;
 

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -268,8 +268,10 @@ uint8_t TCMDEXEC_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_
 }
 
 /// @brief Telecommand: Benchmarks the erase/write/read operations on the flash memory module.
-/// @param args_str Arg 0: Chip Number (CS number) as uint, Arg 1: Test Data Address as uint,
-///     Arg 2: Test Data Length as uint
+/// @param args_str
+/// - Arg 0: Chip Number (CS number) as uint
+/// - Arg 1: Test Data Address as uint
+/// - Arg 2: Test Data Length as uint
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -152,7 +152,9 @@ uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str, TCMD_TelecommandC
 }
 
 /// @brief Telecommand: Benchmark LittleFS write and read operations
-/// @param args_str Arg 0: Write chunk size, Arg 1: Write chunk count
+/// @param args_str
+/// - Arg 0: Write chunk size (bytes)
+/// - Arg 1: Write chunk count
 /// @return 0 on success, 1 if error parsing args, 2 if benchmark failed
 /// @note The maximum write chunk size is 127 bytes, apparently; need to investigate why so small.
 uint8_t TCMDEXEC_fs_benchmark_write_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -140,7 +140,7 @@ uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str, TCMD_TelecommandC
         return 3;
     }
 
-    // Rnsure safety for upcoming print.
+    // Ensure safety for upcoming print.
     read_buffer[sizeof(read_buffer) - 1] = '\0';
 
     snprintf(

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -127,7 +127,6 @@ uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str, TCMD_TelecommandC
         return 1;
     }
 
-    // TODO: Delete file first, if it exists, otherwise it just overwrites from the start, keeping anything extra longer in the file.
     const int8_t write_result = LFS_write_file(file_name, (uint8_t*) file_content, strlen(file_content));
     if (write_result < 0) {
         snprintf(response_output_buf, response_output_buf_len, "LittleFS writing error: %d\n", write_result);
@@ -141,7 +140,7 @@ uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str, TCMD_TelecommandC
         return 3;
     }
 
-    // ensure safety for upcoming print
+    // Rnsure safety for upcoming print.
     read_buffer[sizeof(read_buffer) - 1] = '\0';
 
     snprintf(

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 #include "littlefs/littlefs_helper.h"
+#include "littlefs/littlefs_benchmark.h"
 #include "telecommands/telecommand_definitions.h"
 #include "telecommands/telecommand_args_helpers.h"
 
@@ -147,5 +148,38 @@ uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str, TCMD_TelecommandC
         response_output_buf, response_output_buf_len,
         "LittleFS Successfully Read File '%s'. System uptime: %lu, File Content: '%s'!",
         file_name, HAL_GetTick(), (char*)read_buffer);
+    return 0;
+}
+
+/// @brief Telecommand: Benchmark LittleFS write and read operations
+/// @param args_str Arg 0: Write chunk size, Arg 1: Write chunk count
+/// @return 0 on success, 1 if error parsing args, 2 if benchmark failed
+/// @note The maximum write chunk size is 127 bytes, apparently; need to investigate why so small.
+uint8_t TCMDEXEC_fs_benchmark_write_read(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+    
+    uint64_t arg_write_chunk_size, arg_write_chunk_count;
+
+    const uint8_t parse_write_chunk_size_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 0, &arg_write_chunk_size);
+    const uint8_t parse_write_chunk_count_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 1, &arg_write_chunk_count);
+    if (parse_write_chunk_size_result != 0 || parse_write_chunk_count_result != 0) {
+        // error parsing
+        snprintf(
+            response_output_buf,
+            response_output_buf_len,
+            "Error parsing write chunk size arg: Arg 0 Err=%d, Arg 1 Err=%d", parse_write_chunk_size_result, parse_write_chunk_count_result);
+        return 1;
+    }
+
+    const int8_t benchmark_result = LFS_benchmark_write_read(arg_write_chunk_size, arg_write_chunk_count, response_output_buf, response_output_buf_len);
+    response_output_buf[response_output_buf_len - 1] = '\0'; // ensure null-terminated
+
+    if (benchmark_result != 0) {
+        snprintf(
+            &response_output_buf[strlen(response_output_buf)],
+            response_output_buf_len - strlen(response_output_buf) - 1,
+            "Benchmark failed. Error: %d", benchmark_result);
+        return 2;
+    }
     return 0;
 }

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -155,7 +155,7 @@ uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str, TCMD_TelecommandC
 /// @param args_str Arg 0: Write chunk size, Arg 1: Write chunk count
 /// @return 0 on success, 1 if error parsing args, 2 if benchmark failed
 /// @note The maximum write chunk size is 127 bytes, apparently; need to investigate why so small.
-uint8_t TCMDEXEC_fs_benchmark_write_read(const uint8_t *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_benchmark_write_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     
     uint64_t arg_write_chunk_size, arg_write_chunk_count;

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -97,6 +97,11 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .tcmd_func = TCMDEXEC_flash_erase,
         .number_of_args = 2,
     },
+    {
+        .tcmd_name = "flash_benchmark_erase_write_read",
+        .tcmd_func = TCMDEXEC_flash_benchmark_erase_write_read,
+        .number_of_args = 3,
+    },
     // ****************** END SECTION: flash_telecommand_defs ******************
 
     // ****************** SECTION: lfs_telecommand_defs ******************

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -135,6 +135,11 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .tcmd_func = TCMDEXEC_fs_demo_write_then_read,
         .number_of_args = 0,
     },
+    {
+        .tcmd_name = "fs_benchmark_write_read",
+        .tcmd_func = TCMDEXEC_fs_benchmark_write_read,
+        .number_of_args = 2,
+    },
     // ****************** END SECTION: lfs_telecommand_defs ******************
 
 };


### PR DESCRIPTION
* Create flash module and LFS timing benchmark telecommands
* Switch LFS to not use `malloc` via its macro
* Rename global `lfs`, `cfg`, and `file_cfg` variables

Closes #57 (benchmark LFS)