### PR TITLE
Ground Support: Add telecommand docs and per-argument labels

### DIFF
--- a/cts1_ground_support/src/cts1_ground_support/telecommand_array_parser.py
+++ b/cts1_ground_support/src/cts1_ground_support/telecommand_array_parser.py
@@ -182,7 +182,7 @@ def extract_telecommand_arg_list(docstring: str) -> list[str]:
 
     """
     arg_pattern = re.compile(
-        r"@param args_str.*\n(?P<args>([\s/]*- Arg (?P<arg_num>\d+): (?P<arg_description>.+)\n)*)"
+        r"@param args_str.*\n(?P<args>([\s/]*- Arg (?P<arg_num>\d+): (?P<arg_description>.+)\s*)*)"
     )
 
     matches = []
@@ -191,7 +191,7 @@ def extract_telecommand_arg_list(docstring: str) -> list[str]:
         return None
 
     args_text = match.group("args")
-    arg_desc_pattern = re.compile(r"- Arg (?P<arg_num>\d+): (?P<arg_description>.+)\n")
+    arg_desc_pattern = re.compile(r"- Arg (?P<arg_num>\d+): (?P<arg_description>.+)\s*")
 
     matches.extend(
         [arg_match.group("arg_description") for arg_match in arg_desc_pattern.finditer(args_text)]

--- a/cts1_ground_support/src/cts1_ground_support/telecommand_array_parser.py
+++ b/cts1_ground_support/src/cts1_ground_support/telecommand_array_parser.py
@@ -17,7 +17,7 @@ def remove_c_comments(text: str) -> str:
     return re.sub(r"\s*//.*", "", text)
 
 
-def parse_telecommand_list(c_code: str | Path) -> list[TelecommandDefinition]:
+def parse_telecommand_array_table(c_code: str | Path) -> list[TelecommandDefinition]:
     """Read the list of telecommands from a file like the `telecommand_definitions.c` file.
 
     Args:
@@ -99,19 +99,155 @@ def parse_telecommand_list(c_code: str | Path) -> list[TelecommandDefinition]:
     return telecommands
 
 
-def parse_telecommand_list_from_repo() -> list[TelecommandDefinition]:
-    """Read the list of telecommands from the `telecommand_definitions.c` file in the repo.
+def extract_c_function_docstring(function_name: str, c_code: str) -> str | None:
+    """Read the docstring for the specified function, and extract the description of each argument.
 
-    This type of function definitely has a code smell, but it's the main function here, so it's
-    fine.
+    Does not support `/* */` style comments, only `///` style comments.
+
+    Args:
+    ----
+        function_name: The name of the function to extract the docstring for.
+        c_code: The C code containing the function definitions. Can be multiple files worth.
+
+    Returns:
+    -------
+        The docstring for the function, with the `///` characters removed. If the function is not
+        found, returns None.
+
+    Example:
+    -------
+    In the following example, the output is the comment section before the `hello_world` function,
+    without the leading `///` characters.
+
+    ```c
+    /// @brief This is a docstring for the `hello_world` function.
+    /// @param arg1 This is the first argument.
+    /// @return This function returns 0.
+    int hello_world(int arg1) {
+        return 0;
+    }
+    ```
+
     """
-    telecommands_defs_path = (
-        get_repo_path() / "firmware/Core/Src/telecommands/telecommand_definitions.c"
+    pattern = re.compile(
+        rf"(?P<docstring>(///(.*)\s*)+)\s*(?P<return_type>\w+)\s+{function_name}\s*\("
     )
-    return parse_telecommand_list(telecommands_defs_path)
+    match = pattern.search(c_code)
+    if match:
+        docstring = match.group("docstring")
+        docstring_lines = [
+            line.strip().lstrip("/").strip() for line in docstring.strip().split("\n")
+        ]
+        return "\n".join(docstring_lines)
+
+    # If the function is not found, return None
+    return None
+
+
+def extract_telecommand_arg_list(docstring: str) -> list[str]:
+    """Extract the list of argument descriptions from a telecommand docstring.
+
+    Args:
+    ----
+        docstring: The docstring for a telecommand function, as extracted by
+        `extract_c_function_docstring`. Can be prefixed with comment characters or not.
+
+    Returns:
+    -------
+        A list of argument descriptions, starting with Arg 0 and increasing.
+        Returns an empty list if there are no broken-out arguments
+        Returns None if the input docstring does not contain a `@param args_str` section.
+
+    Example:
+    -------
+    Input:
+
+    ```text
+    @brief Telecommand: Erase a sector of flash memory.
+    @param args_str
+    - Arg 0: Chip Number (CS number) as uint
+    - Arg 1: Flash Address as uint
+    - Arg 2: Number of bytes to erase as uint
+    @return 0 on success, >0 on error
+    ```
+
+    Output:
+    ```json
+    [
+        "Chip Number (CS number) as uint",
+        "Flash Address as uint",
+        "Number of bytes to erase as uint"
+    ]
+    ```
+
+    """
+    arg_pattern = re.compile(
+        r"@param args_str.*\n(?P<args>([\s/]*- Arg (?P<arg_num>\d+): (?P<arg_description>.+)\n)*)"
+    )
+
+    matches = []
+    match = arg_pattern.search(docstring)
+    if not match:
+        return None
+
+    args_text = match.group("args")
+    arg_desc_pattern = re.compile(r"- Arg (?P<arg_num>\d+): (?P<arg_description>.+)\n")
+
+    matches.extend(
+        [arg_match.group("arg_description") for arg_match in arg_desc_pattern.finditer(args_text)]
+    )
+
+    return matches
+
+
+def parse_telecommand_list_from_repo(repo_path: Path | None = None) -> list[TelecommandDefinition]:
+    """Read the list of telecommands array table and extract docstrings for each telecommand.
+
+    Args:
+    ----
+        repo_path: The path to the root of the repository. If None, the path is set automatically.
+
+    """
+    if repo_path is None:
+        repo_path = get_repo_path()
+
+    # Assert that the input is a Path object.
+    if not isinstance(repo_path, Path):
+        msg = f"Expected a Path object, but got {type(repo_path)}"
+        raise TypeError(msg)
+    # Assert that the input is a directory.
+    if not repo_path.is_dir():
+        msg = f"Expected a directory, but got {repo_path}"
+        raise ValueError(msg)
+
+    telecommands_defs_path = repo_path / "firmware/Core/Src/telecommands/telecommand_definitions.c"
+
+    # Assert that the file exists.
+    if not telecommands_defs_path.is_file():
+        msg = "The telecommand definitions file does not exist in the expected location."
+        raise ValueError(msg)
+
+    tcmd_list = parse_telecommand_array_table(telecommands_defs_path)
+
+    # Read the files which may contain the TCMDEXEC functions.
+    c_files_concat: str = "\n".join(
+        f.read_text() for f in repo_path.glob("firmware/Core/Src/**/*.c")
+    )
+
+    # Extract the docstrings for each telecommand.
+    for tcmd_idx in range(len(tcmd_list)):
+        docstring = extract_c_function_docstring(
+            tcmd_list[tcmd_idx].tcmd_func,
+            c_files_concat,
+        )
+        if docstring is not None:
+            tcmd_list[tcmd_idx].full_docstring = docstring
+            tcmd_list[tcmd_idx].argument_descriptions = extract_telecommand_arg_list(docstring)
+
+    return tcmd_list
 
 
 if __name__ == "__main__":
-    # Do a demo of the `parse_telecommand_list` function
+    # Do a demo of the `parse_telecommand_array_table` function
     telecommands = parse_telecommand_list_from_repo()
     print(json.dumps([tcmd.to_dict() for tcmd in telecommands], indent=2))  # noqa: T201

--- a/cts1_ground_support/src/cts1_ground_support/telecommand_types.py
+++ b/cts1_ground_support/src/cts1_ground_support/telecommand_types.py
@@ -11,12 +11,16 @@ class TelecommandDefinition:
     tcmd_func: str
     description: str | None = None
     number_of_args: int
+    full_docstring: str | None = None
+    argument_descriptions: list[str] | None = None
 
-    def to_dict(self: "TelecommandDefinition") -> dict[str, str | int]:
+    def to_dict(self: "TelecommandDefinition") -> dict[str, str | int | list[str] | None]:
         """Convert the telecommand definition to a dictionary."""
         return {
             "name": self.name,
             "tcmd_func": self.tcmd_func,
             "description": self.description,
             "number_of_args": self.number_of_args,
+            "full_docstring": self.full_docstring,
+            "argument_descriptions": self.argument_descriptions,
         }

--- a/cts1_ground_support/src/cts1_ground_support/terminal_app/app_store.py
+++ b/cts1_ground_support/src/cts1_ground_support/terminal_app/app_store.py
@@ -20,6 +20,7 @@ class AppStore:
 
     selected_command_name: str | None = None
     uart_log_refresh_rate_ms: int = 500
+    command_preview: str = ""
 
 
 app_store = AppStore()

--- a/cts1_ground_support/src/cts1_ground_support/terminal_app/dash_gui.py
+++ b/cts1_ground_support/src/cts1_ground_support/terminal_app/dash_gui.py
@@ -200,6 +200,28 @@ def update_uart_port_dropdown_options(uart_port_name: str, _n_intervals: int) ->
     ] + [{"label": port, "value": port} for port in port_name_list]
 
 
+@callback(
+    Output("selected-tcmd-info-container", "children"),
+    Input("telecommand-dropdown", "value"),
+)
+def update_selected_tcmd_info(selected_command_name: str) -> list:
+    """Make an area with the docstring for the selected telecommand."""
+    selected_command = get_telecommand_by_name(selected_command_name)
+
+    if selected_command.full_docstring is None:
+        docstring = f"No docstring found for {selected_command.tcmd_func}"
+    else:
+        docstring = selected_command.full_docstring
+
+    return [
+        html.H4(
+            ["Docs: ", html.Span(selected_command_name, style={"fontFamily": "monospace"})],
+        ),
+        # TODO: add the "brief" docstring here, and then hide the rest in a "Click to expand"
+        html.Pre(docstring, id="selected-tcmd-info", className="mb-3"),
+    ]
+
+
 def generate_rx_tx_log() -> html.Div:
     """Generate the RX/TX log, which shows the most recent received and transmitted messages."""
     return html.Div(
@@ -285,6 +307,7 @@ def generate_left_pane() -> list:
                 ),
             ],
         ),
+        html.Div(id="argument-inputs", className="mb-3"),
         dbc.Row(
             [
                 dbc.Button(
@@ -306,7 +329,7 @@ def generate_left_pane() -> list:
             justify="center",
             className="mb-3",
         ),
-        html.Div(id="argument-inputs", className="mb-3"),
+        html.Div(id="selected-tcmd-info-container", className="mb-3"),
     ]
 
 

--- a/cts1_ground_support/src/cts1_ground_support/terminal_app/dash_gui.py
+++ b/cts1_ground_support/src/cts1_ground_support/terminal_app/dash_gui.py
@@ -74,24 +74,37 @@ def update_argument_inputs(selected_command_name: str) -> list[html.Div]:
 
     app_store.selected_command_name = selected_command_name
 
-    return [
-        dbc.FormFloating(
-            [
-                dbc.Input(
-                    type="text",
-                    id=(this_id := f"arg-input-{arg_num}"),
-                    placeholder=f"Argument {arg_num}",
-                    disabled=(arg_num >= selected_tcmd.number_of_args),
-                    style={"fontFamily": "monospace"},
-                ),
-                dbc.Label(f"Argument {arg_num}", html_for=this_id),
-            ],
-            className="mb-3",
-            # Hide the argument input if it is not needed for the selected telecommand.
-            style=({"display": "none"} if arg_num >= selected_tcmd.number_of_args else {}),
+    arg_inputs = []
+    for arg_num in range(get_max_arguments_per_telecommand()):
+        if (selected_tcmd.argument_descriptions is not None) and (
+            arg_num < len(selected_tcmd.argument_descriptions)
+        ):
+            arg_description = selected_tcmd.argument_descriptions[arg_num]
+            label = f"Arg {arg_num}: {arg_description}"
+        else:
+            label = f"Arg {arg_num}"
+
+        this_id = f"arg-input-{arg_num}"
+
+        arg_inputs.append(
+            dbc.FormFloating(
+                [
+                    dbc.Input(
+                        type="text",
+                        id=this_id,
+                        placeholder=label,
+                        disabled=(arg_num >= selected_tcmd.number_of_args),
+                        style={"fontFamily": "monospace"},
+                    ),
+                    dbc.Label(label, html_for=this_id),
+                ],
+                className="mb-3",
+                # Hide the argument input if it is not needed for the selected telecommand.
+                style=({"display": "none"} if arg_num >= selected_tcmd.number_of_args else {}),
+            )
         )
-        for arg_num in range(get_max_arguments_per_telecommand())
-    ]
+
+    return arg_inputs
 
 
 def handle_uart_port_change(uart_port_name: str) -> None:

--- a/cts1_ground_support/src/cts1_ground_support/terminal_app/dash_gui.py
+++ b/cts1_ground_support/src/cts1_ground_support/terminal_app/dash_gui.py
@@ -61,16 +61,12 @@ def get_max_arguments_per_telecommand() -> int:
 
 
 @callback(
-    Output("argument-inputs", "children"),
+    Output("argument-inputs-container", "children"),
     Input("telecommand-dropdown", "value"),
 )
 def update_argument_inputs(selected_command_name: str) -> list[html.Div]:
     """Generate the argument input fields based on the selected telecommand."""
     selected_tcmd = get_telecommand_by_name(selected_command_name)
-
-    if selected_tcmd is None:
-        app_store.selected_command_name = None
-        return []
 
     app_store.selected_command_name = selected_command_name
 
@@ -130,9 +126,34 @@ def handle_uart_port_change(uart_port_name: str) -> None:
 
 
 @callback(
+    Output("command-preview-container", "children"),
+    Input("telecommand-dropdown", "value"),
+    # TODO: maybe this could be cleaner with `Input/State("argument-inputs-container", "children")`
+    *[
+        Input(f"arg-input-{arg_num}", "value")
+        for arg_num in range(get_max_arguments_per_telecommand())
+    ],
+    prevent_initial_call=True,  # Objects aren't created yet, so errors are thrown.
+)
+def update_command_preview(selected_command_name: str, *every_arg_value: tuple[str]) -> list:
+    """Make an area with the command preview for the selected telecommand."""
+    selected_command = get_telecommand_by_name(selected_command_name)
+    arg_vals = [every_arg_value[arg_num] for arg_num in range(selected_command.number_of_args)]
+
+    # Replace None with empty string, to avoid "None" in the preview.
+    arg_vals = [arg if arg is not None else "" for arg in arg_vals]
+
+    app_store.command_preview = f"CTS1+{selected_command_name}({','.join(arg_vals)})!"
+    return [
+        html.H4(["Preview"], className="text-center"),
+        html.Pre(app_store.command_preview, id="command-preview", className="mb-3"),
+    ]
+
+
+@callback(
     Input("send-button", "n_clicks"),
     State("telecommand-dropdown", "value"),
-    # TODO: maybe this could be cleanear with `Input/State("argument-inputs", "children")`, somehow
+    # TODO: maybe this could be cleaner with `Input/State("argument-inputs-container", "children")`
     *[
         State(f"arg-input-{arg_num}", "value")
         for arg_num in range(get_max_arguments_per_telecommand())
@@ -167,11 +188,10 @@ def send_button_callback(
         app_store.rxtx_log.append(RxTxLogEntry(msg.encode(), "error"))
         return
 
-    logger.info(f"Adding command to queue: {selected_command_name}{args}")
+    logger.info(f"Adding command to queue: {app_store.command_preview}")
 
-    command_str = f"CTS1+{selected_command_name}({','.join(args)})!"
     app_store.last_tx_timestamp_sec = time.time()
-    app_store.tx_queue.append(command_str.encode("ascii"))
+    app_store.tx_queue.append(app_store.command_preview.encode("ascii"))
 
 
 @callback(
@@ -229,6 +249,7 @@ def update_selected_tcmd_info(selected_command_name: str) -> list:
     return [
         html.H4(
             ["Docs: ", html.Span(selected_command_name, style={"fontFamily": "monospace"})],
+            className="text-center",
         ),
         # TODO: add the "brief" docstring here, and then hide the rest in a "Click to expand"
         html.Pre(docstring, id="selected-tcmd-info", className="mb-3"),
@@ -308,19 +329,26 @@ def generate_left_pane() -> list:
                 ),
             ],
         ),
+        html.Hr(),
         dbc.Row(
             [
                 dbc.Label("Select a Telecommand:", html_for="telecommand-dropdown"),
                 dcc.Dropdown(
                     id="telecommand-dropdown",
                     options=[{"label": cmd, "value": cmd} for cmd in get_telecommand_name_list()],
-                    value=get_telecommand_name_list()[0],
+                    value=app_store.selected_command_name,
                     className="mb-3",  # Add margin bottom to the dropdown
                     style={"fontFamily": "monospace"},
                 ),
             ],
         ),
-        html.Div(id="argument-inputs", className="mb-3"),
+        html.Div(
+            update_argument_inputs(app_store.selected_command_name),
+            id="argument-inputs-container",
+            className="mb-3",
+        ),
+        html.Hr(),
+        html.Div(id="command-preview-container", className="mb-3"),
         dbc.Row(
             [
                 dbc.Button(
@@ -342,12 +370,16 @@ def generate_left_pane() -> list:
             justify="center",
             className="mb-3",
         ),
+        html.Hr(),
         html.Div(id="selected-tcmd-info-container", className="mb-3"),
     ]
 
 
 def run_dash_app(*, enable_debug: bool = False) -> None:
     """Run the main Dash application."""
+    # Set the inital state of the app store.
+    app_store.selected_command_name = get_telecommand_name_list()[0]
+
     app_name = "CTS-SAT-1 Ground Support"
     app = dash.Dash(
         __name__,  # required to load /assets folder

--- a/cts1_ground_support/tests/test_telecommand_array_parser.py
+++ b/cts1_ground_support/tests/test_telecommand_array_parser.py
@@ -140,7 +140,7 @@ def test_extract_telecommand_arg_list() -> None:
     - Arg 1: Flash Address as uint
     - Arg 2: Number of bytes to erase as uint
     @return 0 on success, >0 on error
-    """
+    """.strip()
     exp_output1 = [
         "Chip Number (CS number) as uint",
         "Flash Address as uint",
@@ -165,6 +165,22 @@ def test_extract_telecommand_arg_list() -> None:
     """
     assert extract_telecommand_arg_list(input3) is None
 
+    # Similar case to 1, but without anything after the last argument description.
+    input4 = """
+    @brief Telecommand: Erase a sector of flash memory.
+    @param args_str
+    - Arg 0: Chip Number (CS number) as uint
+    - Arg 1: Flash Address as uint
+    - Arg 2: Number of bytes to erase as uint
+    """.strip()
+    exp_output4 = [
+        "Chip Number (CS number) as uint",
+        "Flash Address as uint",
+        "Number of bytes to erase as uint",
+    ]
+    result4 = extract_telecommand_arg_list(input4)
+    assert result4 == exp_output4
+
 
 def test_parse_telecommand_list_from_repo() -> None:
     """Test the `parse_telecommand_list_from_repo` function with the real file in this repo."""
@@ -185,7 +201,7 @@ def test_parse_telecommand_list_from_repo() -> None:
     assert hello_world_telecommand.full_docstring.startswith("@brief ")
     assert hello_world_telecommand.argument_descriptions == []
 
-    # Check a telecommand with arguments.
+    # Check a telecommand with 1 argument.
     found_read_file_tcmds = [tcmd for tcmd in telecommands if tcmd.name == "fs_read_file"]
     assert (
         len(found_read_file_tcmds) == 1
@@ -197,4 +213,19 @@ def test_parse_telecommand_list_from_repo() -> None:
     assert read_file_telecommand.full_docstring.startswith("@brief ")
     assert read_file_telecommand.argument_descriptions == [
         "File path as string",
+    ]
+
+    # Check a telecommand with 2 arguments.
+    found_read_file_tcmds = [tcmd for tcmd in telecommands if tcmd.name == "fs_write_file"]
+    assert (
+        len(found_read_file_tcmds) == 1
+    ), f"Expected to find 1 fs_read_file telecommand, but found {len(found_read_file_tcmds)}"
+    read_file_telecommand = found_read_file_tcmds[0]
+    assert read_file_telecommand.name == "fs_write_file"
+    assert read_file_telecommand.tcmd_func == "TCMDEXEC_fs_write_file"
+    assert read_file_telecommand.number_of_args == 2
+    assert read_file_telecommand.full_docstring.startswith("@brief ")
+    assert read_file_telecommand.argument_descriptions == [
+        "File path as string",
+        "String to write to file",
     ]

--- a/docs/C_General_Guidelines.md
+++ b/docs/C_General_Guidelines.md
@@ -36,3 +36,20 @@ uint8_t function_name(int input1, int input2, int *output_arr, int output_arr_le
     // Function body here.
 }
 ```
+
+For telecommands executors (`TCMDEXEC_` functions), the docstring should be formatted to describle each argument, in this exact format. For example:
+```c
+
+/// @brief Telecommand: Write data to a file in LittleFS
+/// @param args_str
+/// - Arg 0: File name
+/// - Arg 1: String to write to file
+/// @return 0 on success, >0 on error
+uint8_t TCMDEXEC_fs_write_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                               char *response_output_buf, uint16_t response_output_buf_len) {
+    char arg_file_name[64] = {0};
+    char arg_file_content[100] = {0};
+    const uint8_t parse_file_name_result = TCMD_extract_string_arg(args_str, 0, arg_file_name, sizeof(arg_file_name));
+    const uint8_t parse_file_content_result = TCMD_extract_string_arg(args_str, 1, arg_file_content, sizeof(arg_file_content));
+}
+```

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -225,8 +225,10 @@ uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_e
 
 
 /// @brief Telecommand: Erase a sector of flash memory.
-/// @param args_str Arg 0: Chip Number (CS number) as uint, Arg 1: Flash Address as uint,
-///     Arg 2: Number of bytes to erase as uint
+/// @param args_str
+/// - Arg 0: Chip Number (CS number) as uint
+/// - Arg 1: Flash Address as uint
+/// - Arg 2: Number of bytes to erase as uint
 /// @return 0 on success, >0 on error // TODO: explain better
 uint8_t TCMDEXEC_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -44,7 +44,9 @@ uint8_t TCMDEXEC_fs_unmount(const char *args_str, TCMD_TelecommandChannel_enum_t
 }
 
 /// @brief Telecommand: Write data to a file in LittleFS
-/// @param args_str Arg 0: File name, Arg 1: String to write to file
+/// @param args_str
+/// - Arg 0: File path as string
+/// - Arg 1: String to write to file
 uint8_t TCMDEXEC_fs_write_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
 
@@ -80,6 +82,10 @@ uint8_t TCMDEXEC_fs_write_file(const char *args_str, TCMD_TelecommandChannel_enu
     return 0;
 }
 
+/// @brief Reads a file from LittleFS, and responds with its contents in raw form (including non-printable and null bytes).
+/// @param args_str
+/// - Arg 0: File path as string
+/// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_fs_read_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint8_t rx_buffer[512] = {0};

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -141,6 +141,12 @@ const int16_t TCMD_NUM_TELECOMMANDS = sizeof(TCMD_telecommand_definitions) / siz
 // uint8_t <function_name>(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
 //                          char *response_output_buf, uint16_t response_output_buf_len)
 
+/// @brief A simple telecommand that responds with "Hello, world!"
+/// @param args_str No arguments expected
+/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
+/// @param response_output_buf The buffer to write the response to
+/// @param response_output_buf_len The maximum length of the response_output_buf (its size)
+/// @return 0 if successful, >0 if an error occurred (but hello_world can't return an error)
 uint8_t TCMDEXEC_hello_world(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     snprintf(response_output_buf, response_output_buf_len, "Hello, world!\n");

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -63,7 +63,7 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
     {
         .tcmd_name = "set_system_time",
         .tcmd_func = TCMDEXEC_set_system_time,
-        .number_of_args = 0,
+        .number_of_args = 1,
     },
     {
         .tcmd_name = "available_telecommands",

--- a/firmware/Core/Src/telecommands/timekeeping_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/timekeeping_telecommand_defs.c
@@ -12,6 +12,10 @@ uint8_t TCMDEXEC_get_system_time(const char *args_str, TCMD_TelecommandChannel_e
     return 0;
 }
 
+/// @brief Set the system time to the provided Unix epoch time in milliseconds
+/// @param args_str
+/// - Arg 0: Unix epoch time in milliseconds (uint64_t)
+/// @return 0 if successful, 1 if error
 uint8_t TCMDEXEC_set_system_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
   


### PR DESCRIPTION
* Added methods to parse the telecommand docstrings out of the C codebase
* Formalized the notation to explain each telecommand argument
* Display each telecommand argument description in the ground support software
* Display each command docstring in the ground support software
* Add preview of telecommand before sending it

### Screenshot
![image](https://github.com/CalgaryToSpace/CTS-SAT-1-OBC-Firmware/assets/166864283/d27d1339-35d6-40ef-a7e2-8599e32cda00)

### Related Issues
* Closes #87 (arg descriptions)
* Closes #58 (preview the command)