### PR TITLE
Fix `TCMDEXEC_flash_write_hex` with new `TCMD_extract_hex_array_arg()`

### DIFF
--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -87,9 +87,11 @@ uint8_t TCMDEXEC_flash_each_is_reachable(const char *args_str, TCMD_TelecommandC
 
 
 /// @brief Telecommand: Read bytes as hex from a flash address
-/// @param args_str Arg 0: Chip Number (CS number) as uint, Arg 1: Flash Address as uint,
-///     Arg 2: Number of bytes to read as uint
-/// @return 0 on success, >0 on error // TODO: explain better
+/// @param args_str
+/// - Arg 0: Chip Number (CS number) as uint
+/// - Arg 1: Flash Address as uint
+/// - Arg 2: Number of bytes to read as uint
+/// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     const uint16_t max_num_bytes = 256;
@@ -155,32 +157,24 @@ uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_en
 
 
 /// @brief Telecommand: Read bytes as hex from a flash address
-/// @param args_str Arg 0: Chip Number (CS number) as uint, Arg 1: Flash Address as uint,
-///     Arg 2: Hex string of bytes to write, with no delimiters, in all lowercase
-/// @return 0 on success, >0 on error // TODO: explain better
+/// @param args_str
+/// - Arg 0: Chip Number (CS number) as uint
+/// - Arg 1: Flash Address as uint
+/// - Arg 2: Hex string of bytes to write (any case, allows space/underscore separators)
+/// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     const uint16_t max_num_bytes = 256;
     uint16_t num_bytes;
     uint64_t chip_num, flash_addr_u64;
 
-    char hex_str[max_num_bytes * 2 + 1];
-    hex_str[0] = '\0';
-
     uint8_t bytes_to_write[max_num_bytes];
 
-    uint8_t arg0_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &chip_num);
-    uint8_t arg1_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 1, &flash_addr_u64);
-    
-    // FIXME: actually extract the hex from the string
-    // uint8_t arg2_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 2, &num_bytes);
-    uint8_t arg2_result = 0; // temporary - fake success
-
-    // FIXME: remove this next temp code, and write a string
-    bytes_to_write[0] = '\0';
-    strcpy((char*)bytes_to_write, "1234567890abcdef_XYZ");
-    num_bytes = strlen((char*)bytes_to_write);
-    // end temp code
+    const uint8_t arg0_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &chip_num);
+    const uint8_t arg1_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 1, &flash_addr_u64);
+    const uint8_t arg2_result = TCMD_extract_hex_array_arg(
+        args_str, 2, bytes_to_write, max_num_bytes, &num_bytes
+    );
     
     if (arg0_result != 0 || arg1_result != 0 || arg2_result != 0) {
         snprintf(
@@ -231,7 +225,7 @@ uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_e
 /// - Arg 0: Chip Number (CS number) as uint
 /// - Arg 1: Flash Address as uint
 /// - Arg 2: Number of bytes to erase as uint
-/// @return 0 on success, >0 on error // TODO: explain better
+/// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t chip_num, flash_addr;


### PR DESCRIPTION
* Fixes the annoying build warning that accidentally got into `main` long ago. 
* Implements `TCMDEXEC_flash_write_hex` as expected.
* Fixes documentation formatting
