### PR TITLE
Updated Flash driver and LittleFS helper to use NAND memory module (MT29F1G Series)

### DIFF
--- a/firmware/Core/Src/littlefs/flash_benchmark.c
+++ b/firmware/Core/Src/littlefs/flash_benchmark.c
@@ -45,7 +45,7 @@ uint8_t FLASH_benchmark_erase_write_read(uint8_t chip_num, uint32_t test_data_ad
     }
     // TODO: for very large writes, split into multiple writes (instead of allocating the whole amount on the stack)
     const uint32_t write_send_start_time = HAL_GetTick();
-    const FLASH_error_enum_t write_result = FLASH_write(hspi_ptr, chip_num, test_data_address, write_buffer, test_data_length);
+    const FLASH_error_enum_t write_result = FLASH_write_data(hspi_ptr, chip_num, test_data_address, write_buffer, test_data_length);
     if (write_result != 0) {
         snprintf(
             &response_str[strlen(response_str)],

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -94,19 +94,39 @@ void FLASH_deactivate_chip_select()
  */
 FLASH_error_enum_t FLASH_read_status_register(SPI_HandleTypeDef *hspi, uint8_t chip_number, uint8_t *buf)
 {
+    // Send GET FEATURES command
     FLASH_activate_chip_select(chip_number);
-    const HAL_StatusTypeDef tx_result = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_READ_STATUS_REG_1, 1, FLASH_HAL_TIMEOUT_MS);
-    if (tx_result != HAL_OK) {
+    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_GET_FEATURES, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the command, check why
+    if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
-        if (tx_result == HAL_TIMEOUT) {
+        if (tx_result_1 == HAL_TIMEOUT) {
             return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
         }
         
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
+    // Send the byte address of status register
+    const HAL_StatusTypeDef tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_FEAT_STATUS, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the byte, check why
+    if (tx_result_2 != HAL_OK) {
+        FLASH_deactivate_chip_select();
+
+        if (tx_result_2 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+        
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
+    }
+
+    // Receive the Status Register bits
     const HAL_StatusTypeDef rx_result = HAL_SPI_Receive(hspi, (uint8_t *)buf, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't receive the byte, check why
     if (rx_result != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -132,9 +152,12 @@ FLASH_error_enum_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     // Buffer to store status register value
     uint8_t status_reg_buffer[1] = {0};
 
+    // Send the WRITE ENABLE Command
     FLASH_activate_chip_select(chip_number);
     const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_WRITE_ENABLE, 1, FLASH_HAL_TIMEOUT_MS);
     FLASH_deactivate_chip_select();
+
+    // If couldn't send the command, check why
     if (tx_result_1 != HAL_OK) {
 
         if (tx_result_1 == HAL_TIMEOUT) {
@@ -148,6 +171,7 @@ FLASH_error_enum_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     const uint32_t start_loop_time_ms = HAL_GetTick();
     while (1)
     {
+        // Get status register bits
         const FLASH_error_enum_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
         if (read_status_result != FLASH_ERR_OK) {
             FLASH_deactivate_chip_select();
@@ -187,9 +211,12 @@ FLASH_error_enum_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_num
     // Buffer to store status register value
     uint8_t status_reg_buffer[1] = {0};
 
+    // Send WRITE DISABLE Command
     FLASH_activate_chip_select(chip_number);
     const HAL_StatusTypeDef tx_status = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_WRITE_DISABLE, 1, FLASH_HAL_TIMEOUT_MS);
     FLASH_deactivate_chip_select();
+
+    // If couldn't send the command, check why
     if (tx_status != HAL_OK) {
 
         if (tx_status == HAL_TIMEOUT) {
@@ -203,6 +230,7 @@ FLASH_error_enum_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_num
     const uint32_t start_loop_time_ms = HAL_GetTick();
     while (1)
     {
+        // Get status register bits
         const FLASH_error_enum_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
         if (read_status_result != FLASH_ERR_OK) {
             FLASH_deactivate_chip_select();
@@ -220,9 +248,11 @@ FLASH_error_enum_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_num
             return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
         }
 
-        DEBUG_uart_print_str("DEBUG: status_reg = 0x");
-        DEBUG_uart_print_array_hex(status_reg_buffer, 1);
-        DEBUG_uart_print_str("\n");
+        if (FLASH_enable_hot_path_debug_logs) {
+            DEBUG_uart_print_str("DEBUG: status_reg = 0x");
+            DEBUG_uart_print_array_hex(status_reg_buffer, 1);
+            DEBUG_uart_print_str("\n");
+        }
     }
 
     // Should never be reached:
@@ -230,10 +260,10 @@ FLASH_error_enum_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_num
 }
 
 /**
- * @brief Sends Sector Erase Command
+ * @brief Sends Block Erase Command
  * @param hspi - Pointer to the SPI HAL handle
  * @param chip_number - the chip select number to activate
- * @param addr - block number that is to be erased
+ * @param addr - block address that is to be erased
  * @retval FLASH_ERR_OK on success, < 0 on failure
  */
 FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr)
@@ -241,16 +271,18 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
     // Split address into its 4 bytes
     uint8_t addr_bytes[4] = {(addr >> 24) & 0xFF, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF};
 
-    // Send Write Enable Command
+    // Send WRITE ENABLE Command
     const FLASH_error_enum_t wren_result = FLASH_write_enable(hspi, chip_number);
     if (wren_result != FLASH_ERR_OK) {
         FLASH_deactivate_chip_select();
         return wren_result;
     }
 
-    // Send Sector Erase Command
+    // Send BLOCK ERASE Command
     FLASH_activate_chip_select(chip_number);
-    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_SECTOR_ERASE_4_BYTE_ADDR, 1, FLASH_HAL_TIMEOUT_MS);
+    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_BLOCK_ERASE, 1, FLASH_HAL_TIMEOUT_MS);
+    
+    // If couldn't send the command, check why
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -260,7 +292,11 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
         
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
+
+    // Send the address bytes
     const HAL_StatusTypeDef tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the bytes, check why
     if (tx_result_2 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -275,10 +311,11 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
     // Buffer to store status register value
     uint8_t status_reg_buffer[1] = {0};
 
-    // Keep looping as long as device is busy (until the Write Enable Latch is active [1])
+    // Keep looping as long as device is busy (until the Operation In Progress bit is active [1])
     const uint32_t start_loop_time_ms = HAL_GetTick();
     while (1)
     {
+        // Get status register bits
         const FLASH_error_enum_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
         if (read_status_result != FLASH_ERR_OK) {
             FLASH_deactivate_chip_select();
@@ -302,9 +339,11 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
             return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
         }
 
-        DEBUG_uart_print_str("DEBUG: status_reg = 0x");
-        DEBUG_uart_print_array_hex(status_reg_buffer, 1);
-        DEBUG_uart_print_str("\n");
+        if (FLASH_enable_hot_path_debug_logs) {
+            DEBUG_uart_print_str("DEBUG: status_reg = 0x");
+            DEBUG_uart_print_array_hex(status_reg_buffer, 1);
+            DEBUG_uart_print_str("\n");
+        }
     }
 
     // Should never be reached:
@@ -315,26 +354,33 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
  * @brief Sends Page Program Command
  * @param hspi - Pointer to the SPI HAL handle
  * @param chip_number - the chip select number to activate
- * @param addr - block number that is to be written
+ * @param addr - block address that is to be written
  * @param packet_buffer - Pointer to buffer containing data to write
  * @param packet_buffer_len - integer that indicates the size of the data to write
  * @retval FLASH_ERR_OK on success, < 0 on failure
  */
-FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *packet_buffer, lfs_size_t packet_buffer_len)
+FLASH_error_enum_t FLASH_write_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *packet_buffer, lfs_size_t packet_buffer_len)
 {
-    // Split address into its 4 bytes
+    // Split main address into its 4 bytes
     uint8_t addr_bytes[4] = {(addr >> 24) & 0xFF, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF};
+    
+    // Define the address where data will be stored in cache register (First 4 bits are dummy bits)
+    // TODO: Is it fine to always have this at 0?
+    uint16_t cache_addr = 0x0000;
+    uint8_t cache_addr_bytes[2] = {(cache_addr >> 8) & 0xFF, cache_addr & 0xFF};
 
-    // Enable WREN Command, so that we can write to the memory module
+    // Send WRITE ENABLE Command
     const FLASH_error_enum_t wren_result = FLASH_write_enable(hspi, chip_number);
     if (wren_result != FLASH_ERR_OK) {
         FLASH_deactivate_chip_select();
         return wren_result;
     }
 
-    // Send WREN Command and the Data required with the command
+    // Send PROGAM LOAD Command
     FLASH_activate_chip_select(chip_number);
-    const uint8_t tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_WRITE_4_BYTE_ADDR, 1, FLASH_HAL_TIMEOUT_MS);
+    const uint8_t tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_PROGRAM_LOAD, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the command, check why
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -344,7 +390,11 @@ FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
 
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
-    const uint8_t tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
+
+    // Send Cache Register address
+    const uint8_t tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)cache_addr_bytes, 2, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the bytes, check why
     if (tx_result_2 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -354,7 +404,11 @@ FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
 
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
+
+    // Send the data bytes
     const uint8_t tx_result_3 = HAL_SPI_Transmit(hspi, (uint8_t *)packet_buffer, packet_buffer_len, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the bytes, check why
     if (tx_result_3 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -365,10 +419,44 @@ FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
+    // TODO: If Write doesn't work as intended or not all data bits are stored
+    // do the status register check loop here before deactivating chip select
+    FLASH_deactivate_chip_select();
+
+    // Send PROGAM EXECUTE Command
+    FLASH_activate_chip_select(chip_number);
+    const uint8_t tx_result_4 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_PROGRAM_EXEC, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the command, check why
+    if (tx_result_4 != HAL_OK) {
+        FLASH_deactivate_chip_select();
+
+        if (tx_result_4 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
+    }
+
+    // Send address bytes
+    const uint8_t tx_result_5 = HAL_SPI_Transmit(hspi, (uint8_t *)addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the bytes, check why
+    if (tx_result_5 != HAL_OK) {
+        FLASH_deactivate_chip_select();
+
+        if (tx_result_5 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
+    }
+    FLASH_deactivate_chip_select();
+
     // Buffer to store status register value
     uint8_t status_reg_buffer[1] = {0};
 
-    // Keep looping as long as device is busy (until the Write Enable Latch is active [1])
+    // Keep looping as long as device is busy (until the Operation In Progress bit is active [1])
     const uint32_t start_loop_time_ms = HAL_GetTick();
     while (1)
     {
@@ -395,9 +483,11 @@ FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
             return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
         }
 
-        DEBUG_uart_print_str("DEBUG: status_reg = 0x");
-        DEBUG_uart_print_array_hex(status_reg_buffer, 1);
-        DEBUG_uart_print_str("\n");
+        if (FLASH_enable_hot_path_debug_logs) {
+            DEBUG_uart_print_str("DEBUG: status_reg = 0x");
+            DEBUG_uart_print_array_hex(status_reg_buffer, 1);
+            DEBUG_uart_print_str("\n");
+        }
     }
 
     // Should never be reached:
@@ -405,22 +495,28 @@ FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
 }
 
 /**
- * @brief Sends Page Program Command
+ * @brief Sends Page Read Command
  * @param hspi - Pointer to the SPI HAL handle
- * @param chip_number - the chip select number to activate
- * @param addr - block number that is to be read
- * @param rx_buffer - a to buffer where the read data will be stored
- * @param rx_buffer_len - integer that indicates the capacity of `rx_buffer`
+ * @param chip_number - The chip select number to activate
+ * @param addr - Address to be read
+ * @param rx_buffer - A buffer where the read data will be stored
+ * @param rx_buffer_len - Integer that indicates the capacity of `rx_buffer`
  * @retval FLASH_ERR_OK on success, < 0 on failure
  */
 FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *rx_buffer, lfs_size_t rx_buffer_len)
 {
-    // Split address into its 4 bytes
-    uint8_t addr_bytes[4] = {(addr >> 24) & 0xFF, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF};
+    uint8_t read_addr_bytes[4] = {(addr >> 24) & 0xFF, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF};
 
-    // Send Read Command and the data required with it
+    // Define the address where data will be read from in cache register (First 4 bits are dummy bits)
+    // TODO: Is it fine to always have this at 0?
+    uint16_t cache_addr = 0x0000;
+    uint8_t cache_addr_bytes[2] = {(cache_addr >> 8) & 0xFF, cache_addr & 0xFF};
+
+    // Send PAGE READ command
     FLASH_activate_chip_select(chip_number);
-    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_READ_4_BYTE_ADDR, 1, FLASH_HAL_TIMEOUT_MS);
+    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *) &FLASH_CMD_PAGE_READ, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the command, check why
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -430,7 +526,12 @@ FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number,
 
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
-    const HAL_StatusTypeDef tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
+
+    // FIXME: Datasheet Page 16 talks about only giving 8-bit dummy values and 16-bit address, not sure how that works
+    // Send Address bytes 
+    const HAL_StatusTypeDef tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *) read_addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the bytes, check why
     if (tx_result_2 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -440,7 +541,89 @@ FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number,
 
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
+
+    // Set Chip Select HIGH
+    FLASH_deactivate_chip_select();
+
+    // Buffer to store status register value
+    uint8_t status_reg_buffer[1] = {0};
+
+    // Keep looping as long as device is busy (until the Operation In Progress bit is active [1])
+    const uint32_t start_loop_time_ms = HAL_GetTick();
+    while (1)
+    {
+        const FLASH_error_enum_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
+        if (read_status_result != FLASH_ERR_OK) {
+            FLASH_deactivate_chip_select();
+            return read_status_result;
+        }
+
+        if ((status_reg_buffer[0] & FLASH_SR1_WRITE_IN_PROGRESS_MASK) == 0) {
+            // Success condition: write in progress has completed.
+            return FLASH_ERR_OK;
+        }
+
+        // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
+        if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_WRITE_TIMEOUT_MS) {
+            DEBUG_uart_print_str("Flash read timeout\n");
+            return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
+        }
+
+        if (FLASH_enable_hot_path_debug_logs) {
+            DEBUG_uart_print_str("DEBUG: status_reg = 0x");
+            DEBUG_uart_print_array_hex(status_reg_buffer, 1);
+            DEBUG_uart_print_str("\n");
+        }
+    }
+    FLASH_deactivate_chip_select();
+
+    // Send READ FROM CACHE command
+    FLASH_activate_chip_select(chip_number);
+    const HAL_StatusTypeDef tx_result_3 = HAL_SPI_Transmit(hspi, (uint8_t *) &FLASH_CMD_READ_FROM_CACHE, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the command, check why
+    if (tx_result_3 != HAL_OK) {
+        FLASH_deactivate_chip_select();
+
+        if (tx_result_3 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
+    }
+
+    // Send cache address bytes 
+    const HAL_StatusTypeDef tx_result_4 = HAL_SPI_Transmit(hspi, (uint8_t *) cache_addr_bytes, 2, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the bytes, check why
+    if (tx_result_4 != HAL_OK) {
+        FLASH_deactivate_chip_select();
+
+        if (tx_result_4 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
+    }
+
+    // Send cache address bytes again just as 2 dummy bytes to use 2 8-bit clock cycles
+    const HAL_StatusTypeDef tx_result_5 = HAL_SPI_Transmit(hspi, (uint8_t *) cache_addr_bytes, 2, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the bytes, check why
+    if (tx_result_5 != HAL_OK) {
+        FLASH_deactivate_chip_select();
+
+        if (tx_result_5 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
+    }
+
+    // Receive the data into the buffer
     const HAL_StatusTypeDef rx_result_1 = HAL_SPI_Receive(hspi, (uint8_t *)rx_buffer, rx_buffer_len, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't receive data, check why
     if (rx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -450,12 +633,44 @@ FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number,
 
         return FLASH_ERR_SPI_RECEIVE_FAILED;
     }
+
+    // Set Chip Select HIGH
     FLASH_deactivate_chip_select();
 
-    // TODO: Haven't yet implemented a way to check any errors while reading data from memory
-    return 0;
+    // TODO: Are there any other errors that can occur while reading?
+    return FLASH_ERR_OK;
 }
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+/**
+ * @brief Checks if the FLASH chip is reachable by checking it's ID
+ * @param hspi - Pointer to the SPI HAL handle
+ * @param chip_number - The chip select number to activate
+ * @retval FLASH_ERR_OK on success, < 0 on failure
+ */
 FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
 {
     // TODO: confirm if this works with the CS2 logical chip on each physical FLASH chip;
@@ -465,9 +680,11 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     uint8_t rx_buffer[5];
     memset(rx_buffer, 0, 5);
 
-    // Transmit the READ_ID_CMD
+    // Send READ ID Command
     FLASH_activate_chip_select(chip_number);
     const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, tx_buffer, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the command, check why
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -478,8 +695,24 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
+    // Send the command again just as a dummy byte
+    const HAL_StatusTypeDef tx_result_2 = HAL_SPI_Transmit(hspi, tx_buffer, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the command, check why
+    if (tx_result_2 != HAL_OK) {
+        FLASH_deactivate_chip_select();
+
+        if (tx_result_2 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
+    }
+
     // Receive the response
     const HAL_StatusTypeDef rx_result = HAL_SPI_Receive(hspi, rx_buffer, 5, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't receive, checky why
     if (rx_result != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -498,7 +731,7 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     // rx_buffer[2] is 0x20=512 for 512 Mib (mebibits)
     // TODO: maybe check the capacity as well here, esp. in deployment
     uint8_t are_bytes_correct = 0;
-    if (rx_buffer[0] == 0x01 && rx_buffer[1] == 0x02) {
+    if (rx_buffer[0] == 0x2C && rx_buffer[1] == 0x14) {
         DEBUG_uart_print_str("SUCCESS: FLASH_is_reachable received IDs: ");
         are_bytes_correct = 1;
     } else {
@@ -511,7 +744,7 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
 
     if (!are_bytes_correct) {
         // error: IDs don't match
-        return 3;
+        return FLASH_ERR_UNKNOWN;
     }
-    return 0; // success
+    return FLASH_ERR_OK; // success
 }

--- a/firmware/Core/Src/littlefs/flash_testing_demos.c
+++ b/firmware/Core/Src/littlefs/flash_testing_demos.c
@@ -13,7 +13,7 @@ void demo_flash_write() {
     uint32_t num_bytes = strlen((char*)bytes_to_write);
 
     for (uint8_t i = 0; i < 2; i++) {
-        FLASH_error_enum_t result = FLASH_write(&hspi1, chip_num, flash_addr, bytes_to_write, num_bytes);
+        FLASH_error_enum_t result = FLASH_write_data(&hspi1, chip_num, flash_addr, bytes_to_write, num_bytes);
         if (result != 0) {
             DEBUG_uart_print_str("Error in FLASH_write\n");
             return;

--- a/firmware/Core/Src/littlefs/littlefs_driver.c
+++ b/firmware/Core/Src/littlefs/littlefs_driver.c
@@ -34,7 +34,7 @@ int LFS_block_device_read(const struct lfs_config *c, lfs_block_t block, lfs_off
  */
 int LFS_block_device_prog(const struct lfs_config *c, lfs_block_t block, lfs_off_t off, const void *buffer, lfs_size_t size)
 {
-	return FLASH_write(
+	return FLASH_write_data(
 		hspi_lfs_ptr,
 		LFS_get_chip_number(block),
 		(block * c->block_size + off),

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -14,8 +14,8 @@
 // Variables to track LittleFS on Flash Memory Module
 uint8_t LFS_is_lfs_mounted = 0;
 
-#define FLASH_CHIP_PAGE_SIZE_BYTES 512
-#define FLASH_CHIP_BLOCK_SIZE_BYTES 262144
+#define FLASH_CHIP_PAGE_SIZE_BYTES 2176
+#define FLASH_CHIP_BLOCK_SIZE_BYTES 139264
 #define FLASH_LOOKAHEAD_SIZE 16
 
 // LittleFS Buffers for reading and writing

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -202,7 +202,7 @@ uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_e
     uint32_t flash_addr = (uint32_t)flash_addr_u64;
 
 
-    FLASH_error_enum_t result = FLASH_write(&hspi1, chip_num, flash_addr, bytes_to_write, num_bytes);
+    FLASH_error_enum_t result = FLASH_write_data(&hspi1, chip_num, flash_addr, bytes_to_write, num_bytes);
 
     if (result != 0) {
         snprintf(


### PR DESCRIPTION
## Update
Replaced all driver code to encompass the NAND memory module commands from the [datasheet](https://www.farnell.com/datasheets/3151163.pdf). The code has not yet been tested, and should be tested first using the function `FLASH_is_reachable()`

For writing to the module, we first write to the cache register, and then run another command which reads the cache register and writes to the main memory array. 
For reading to the module, we first send a command which reads the data to a cache register and send another command which outputs the data from the cache register. 

## Comments
I am not sure if Reading and Writing will work right away since in the documentation for reading from cache (Page 18) and documentation for writing to the cache (Page 29, 30) doesn't specify if we should be checking Status Register to see and wait for data to load to and from cache registers, it only states that read/write operations from cache register will end when CS# is driven to HIGH. 