### PR TITLE
In-memory LOG storage for most recent messages

### DIFF
--- a/firmware/Core/Inc/log/log.h
+++ b/firmware/Core/Inc/log/log.h
@@ -63,5 +63,9 @@ void LOG_report_system_file_logging_state(LOG_system_enum_t systems);
 uint16_t LOG_number_of_logging_sinks(void);
 uint16_t LOG_number_of_logging_systems(void);
 const char* LOG_get_severity_name(LOG_severity_enum_t severity);
+uint8_t LOG_memory_table_max_entries(void);
+uint8_t LOG_get_memory_table_index_of_most_recent_log_entry(void);
+const char *LOG_get_memory_table_full_message_at_index(uint8_t index);
+const char *LOG_get_most_recent_log_message_text(void);
 
 #endif // __INCLUDE__GUARD__LOG_H_

--- a/firmware/Core/Inc/telecommands/log_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/log_telecommand_defs.h
@@ -29,4 +29,10 @@ uint8_t TCMDEXEC_log_set_sink_debugging_messages_state(const char *args_str, TCM
 uint8_t TCMDEXEC_log_set_system_debugging_messages_state(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
+uint8_t TCMDEXEC_log_report_latest_message_from_memory(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_log_report_n_latest_messages_from_memory(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
 #endif /* __INCLUDE_GUARD__LOG_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Src/log/log.c
+++ b/firmware/Core/Src/log/log.c
@@ -19,7 +19,7 @@
 #define LOG_SYSTEM_NAME_MAX_LENGTH 20
 // Messages up to 256 characters
 #define LOG_FORMATTED_MESSAGE_MAX_LENGTH 256
-// Includes prefix, with cushion for delimiters and newline
+// Includes prefix, with cushion for delimiters, newline, and null terminator
 #define LOG_FULL_MESSAGE_MAX_LENGTH ( LOG_FORMATTED_MESSAGE_MAX_LENGTH + LOG_TIMESTAMP_MAX_LENGTH + LOG_SINK_NAME_MAX_LENGTH + LOG_SYSTEM_NAME_MAX_LENGTH + 1 )
 
 typedef struct {
@@ -189,7 +189,7 @@ void LOG_message(LOG_system_enum_t source, LOG_severity_enum_t severity, uint32_
                 case LOG_SINK_UNKNOWN:
                 default:
                     // Should not reach this except by memory corruption 
-                    LOG_to_umbilical_uart("Error: unkown log sink\n");
+                    LOG_to_umbilical_uart("Error: unknown log sink\n");
                     break;
             }
         }
@@ -446,7 +446,7 @@ const char *LOG_get_memory_table_full_message_at_index(uint8_t index)
 }
 
 /// @brief Get the most recent log message text 
-/// @return pointer to the full text of the most recent lost message
+/// @return pointer to the full text of the most recent message
 /// (statically allocated)
 const char *LOG_get_most_recent_log_message_text(void)
 {

--- a/firmware/Core/Src/telecommands/log_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/log_telecommand_defs.c
@@ -242,10 +242,12 @@ uint8_t TCMDEXEC_log_report_n_latest_messages_from_memory(const char *args_str, 
 
     // Report the entries in the log table, which is a circular buffer
     uint8_t current_index = LOG_get_memory_table_index_of_most_recent_log_entry();
-    int16_t start_index = ((int16_t)current_index + 1 - (int16_t)requested_number_of_entries); 
-    if (start_index < 0) {
-        start_index += max_entries;
+    int16_t signed_start_index = ((int16_t)current_index + 1 - (int16_t)requested_number_of_entries); 
+    if (signed_start_index < 0) {
+        signed_start_index += max_entries;
     }
+    uint16_t start_index = (uint16_t)signed_start_index;
+
     void (*transmit_function)(const char *);
     switch (tcmd_channel) {
         case TCMD_TelecommandChannel_DEBUG_UART:
@@ -262,7 +264,7 @@ uint8_t TCMDEXEC_log_report_n_latest_messages_from_memory(const char *args_str, 
     }
 
     // Report the messages
-    for (uint8_t response_number = 0; response_number < requested_number_of_entries; response_number++) {
+    for (uint16_t response_number = 0; response_number < requested_number_of_entries; response_number++) {
         const uint16_t log_index = (start_index + response_number) % max_entries;
         const char *log_text = LOG_get_memory_table_full_message_at_index(log_index);
         transmit_function(log_text);

--- a/firmware/Core/Src/telecommands/log_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/log_telecommand_defs.c
@@ -4,8 +4,10 @@
 #include <stdint.h>
 
 #include "log/log.h"
+#include "log/log_sinks.h"
 #include "telecommands/log_telecommand_defs.h"
 #include "telecommands/telecommand_args_helpers.h"
+#include "telecommands/telecommand_types.h"
 
 
 /// @brief Telecommand: Set a LOG sink's enabled state
@@ -195,3 +197,80 @@ uint8_t TCMDEXEC_log_set_system_debugging_messages_state(const char *args_str, T
     return 0;
 }
 
+/// @brief Telecommand: Report the latest log message to the incoming
+/// telecommand channel
+uint8_t TCMDEXEC_log_report_latest_message_from_memory(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+    // This does not get logged. Send result directly back on telecommand
+    // channel the request arrived on
+    const char *log_text = LOG_get_most_recent_log_message_text();
+    switch (tcmd_channel) {
+        case TCMD_TelecommandChannel_DEBUG_UART:
+            LOG_to_umbilical_uart(log_text);
+            break;
+        case TCMD_TelecommandChannel_RADIO1:
+            LOG_to_uhf_radio(log_text);
+            break;
+        default:
+            // Channel is unknown, log just to the filesystem
+            LOG_message(LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_ERROR, LOG_SINK_FILE, "TCMDEXEC_log_report_latest_message(): Unknown telecommand channel");
+            break;
+    }
+
+    return 0;
+}
+
+/// @brief Telecommand: Report the N latest log messages to the incoming
+/// telecommand channel
+/// @param args_str
+/// - Arg 0: Number of latest log messages to report
+uint8_t TCMDEXEC_log_report_n_latest_messages_from_memory(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+    // This does not get logged. Send result directly back on telecommand
+    // channel the request arrived on
+    uint64_t requested_number_of_entries = 0;
+    uint8_t result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &requested_number_of_entries);
+    if (result) {
+        LOG_message(LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_ERROR, LOG_SINK_ALL, "TCMDEXEC_log_report_n_latest_messages(): Unable to parse number of entries from first telecommand argument");
+        return 1;
+    }
+    const uint8_t max_entries = LOG_memory_table_max_entries();
+    if (requested_number_of_entries > max_entries) {
+        LOG_message(LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_ERROR, LOG_SINK_ALL, "TCMDEXEC_log_report_n_latest_messages(): Requested number of log messages must be at most %d", max_entries);
+        return 1;
+    }
+
+    // Report the entries in the log table, which is a circular buffer
+    uint8_t current_index = LOG_get_memory_table_index_of_most_recent_log_entry();
+    int16_t start_index = ((int16_t)current_index + 1 - (int16_t)requested_number_of_entries); 
+    if (start_index < 0) {
+        start_index += max_entries;
+    }
+    uint8_t index = (uint8_t)start_index;
+    void (*transmit_function)(const char *);
+    switch (tcmd_channel) {
+        case TCMD_TelecommandChannel_DEBUG_UART:
+            transmit_function = LOG_to_umbilical_uart;
+            break;
+        case TCMD_TelecommandChannel_RADIO1:
+            transmit_function = LOG_to_umbilical_uart;
+            break;
+        default:
+            // Channel is unknown, log error to the filesystem and return
+            LOG_message(LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_ERROR, LOG_SINK_FILE, "TCMDEXEC_log_report_latest_message(): Unknown telecommand channel");
+            return 1;
+            break;
+    }
+
+    // Report the messages
+    for (uint8_t i = 0; i < requested_number_of_entries; i++) {
+        if (index > max_entries - 1) {
+            index = 0;
+        }
+        const char *log_text = LOG_get_memory_table_full_message_at_index(index);
+        transmit_function(log_text);
+        index++;
+    }
+    
+    return 0;
+}

--- a/firmware/Core/Src/telecommands/log_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/log_telecommand_defs.c
@@ -246,14 +246,13 @@ uint8_t TCMDEXEC_log_report_n_latest_messages_from_memory(const char *args_str, 
     if (start_index < 0) {
         start_index += max_entries;
     }
-    uint8_t index = (uint8_t)start_index;
     void (*transmit_function)(const char *);
     switch (tcmd_channel) {
         case TCMD_TelecommandChannel_DEBUG_UART:
             transmit_function = LOG_to_umbilical_uart;
             break;
         case TCMD_TelecommandChannel_RADIO1:
-            transmit_function = LOG_to_umbilical_uart;
+            transmit_function = LOG_to_uhf_radio;
             break;
         default:
             // Channel is unknown, log error to the filesystem and return
@@ -263,13 +262,10 @@ uint8_t TCMDEXEC_log_report_n_latest_messages_from_memory(const char *args_str, 
     }
 
     // Report the messages
-    for (uint8_t i = 0; i < requested_number_of_entries; i++) {
-        if (index > max_entries - 1) {
-            index = 0;
-        }
-        const char *log_text = LOG_get_memory_table_full_message_at_index(index);
+    for (uint8_t response_number = 0; response_number < requested_number_of_entries; response_number++) {
+        const uint16_t log_index = (start_index + response_number) % max_entries;
+        const char *log_text = LOG_get_memory_table_full_message_at_index(log_index);
         transmit_function(log_text);
-        index++;
     }
     
     return 0;

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -234,6 +234,19 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .number_of_args = 2,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
+    {
+        .tcmd_name = "log_report_latest_message_from_memory",
+        .tcmd_func = TCMDEXEC_log_report_latest_message_from_memory,
+        .number_of_args = 0,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+    {
+        .tcmd_name = "log_report_n_latest_messages_from_memory",
+        .tcmd_func = TCMDEXEC_log_report_n_latest_messages_from_memory,
+        .number_of_args = 1,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+
    // ****************** END SECTION: log_telecommand_defs ******************
 
 };


### PR DESCRIPTION
Addresses issue #116.

The in-memory log table serves as statically-allocated log message storage that allows concurrent and nested calls to LOG_message() and serves as a limited backup for the filesystem logs. As such, this is not considered a traditional log sink.

Logs are stored in a circular buffer.

Adds telecommands for reporting the latest and the N-latest log messages from in-memory log table.

