### PR TITLE
Telecommand to extract FreeRTOS stack information

### DIFF
--- a/firmware/Core/Inc/telecommands/freertos_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/freertos_telecommand_defs.h
@@ -3,9 +3,13 @@
 #define __INCLUDE_GUARD__FREERTOS_TELECOMMAND_DEFINITIONS_H
 
 #include <stdint.h>
+#include <FreeRTOS.h>
+#include <task.h>
 #include "telecommands/telecommand_types.h"
 
-uint8_t TCMDEXEC_retrieve_freertos_metadata(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+const char* freertos_current_state_enum_to_str(eTaskState state);
+
+uint8_t TCMDEXEC_freertos_get_metadata(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif // __INCLUDE_GUARD__FREERTOS_TELECOMMAND_DEFINITIONS_H

--- a/firmware/Core/Inc/telecommands/freertos_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/freertos_telecommand_defs.h
@@ -3,13 +3,8 @@
 #define __INCLUDE_GUARD__FREERTOS_TELECOMMAND_DEFINITIONS_H
 
 #include <stdint.h>
-#include <FreeRTOS.h>
-#include <task.h>
-#include "telecommands/telecommand_types.h"
 
-const char* freertos_current_state_enum_to_str(eTaskState state);
-
-uint8_t TCMDEXEC_freertos_get_metadata(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_freetos_list_tasks_jsonl(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif // __INCLUDE_GUARD__FREERTOS_TELECOMMAND_DEFINITIONS_H

--- a/firmware/Core/Inc/telecommands/freertos_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/freertos_telecommand_defs.h
@@ -1,0 +1,11 @@
+
+#ifndef __INCLUDE_GUARD__FREERTOS_TELECOMMAND_DEFINITIONS_H
+#define __INCLUDE_GUARD__FREERTOS_TELECOMMAND_DEFINITIONS_H
+
+#include <stdint.h>
+#include "telecommands/telecommand_types.h"
+
+uint8_t TCMDEXEC_retrieve_freertos_metadata(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+#endif // __INCLUDE_GUARD__FREERTOS_TELECOMMAND_DEFINITIONS_H

--- a/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
@@ -39,7 +39,7 @@ uint8_t TCMDEXEC_freertos_get_metadata(const char *args_str, TCMD_TelecommandCha
                         char *response_output_buf, uint16_t response_output_buf_len) {
                             
     TaskStatus_t *px_task_status_array;
-    UBaseType_t ux_array_size, x;
+    UBaseType_t ux_array_size;
     unsigned long ul_total_run_time;
 
     ux_array_size = uxTaskGetNumberOfTasks();
@@ -53,10 +53,10 @@ uint8_t TCMDEXEC_freertos_get_metadata(const char *args_str, TCMD_TelecommandCha
     ux_array_size = uxTaskGetSystemState(px_task_status_array, ux_array_size, &ul_total_run_time);
     DEBUG_uart_print_str("[");
 
-    for (x = 0; x < ux_array_size; x++) {
+    for (UBaseType_t x = 0; x < ux_array_size; x++) {
         char message_buffer[256];
         int len = snprintf(message_buffer, sizeof(message_buffer),
-                            "{\"TaskName\":\"%s\",\"State\":\"%s\",\"Priority\":%lu,\"Stack\":%u}%s",
+                            "{\"task_name\":\"%s\",\"state\":\"%s\",\"priority\":%lu,\"stack\":%u}%s",
                             px_task_status_array[x].pcTaskName,
                             freertos_current_state_enum_to_str(px_task_status_array[x].eCurrentState),
                             px_task_status_array[x].uxCurrentPriority,

--- a/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
@@ -1,0 +1,70 @@
+
+#include "telecommands/telecommand_definitions.h"
+#include "telecommands/telecommand_args_helpers.h"
+#include "transforms/arrays.h"
+#include "unit_tests/unit_test_executor.h"
+#include "timekeeping/timekeeping.h"
+
+#include "telecommands/freertos_telecommand_defs.h"
+#include "debug_tools/debug_uart.h"
+
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <inttypes.h>
+#include <FreeRTOS.h>
+#include <task.h>
+#include <portmacro.h>
+
+
+/// @brief Telecommand that return metadata regarding Tasks from FreeRTOS
+/// @param args_str No arguments expected
+/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
+/// @param response_output_buf The buffer to write the response to
+/// @param response_output_buf_len The maximum length of the response_output_buf (its size)
+/// @return 0 if successful, >0 if an error occurred (but hello_world can't return an error)
+
+uint8_t TCMDEXEC_retrieve_freertos_metadata(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+                            
+    TaskStatus_t *pxTaskStatusArray;
+    UBaseType_t uxArraySize, x;
+    unsigned long ulTotalRunTime;
+
+    uxArraySize = uxTaskGetNumberOfTasks();
+    pxTaskStatusArray = pvPortMalloc(uxArraySize * sizeof(TaskStatus_t));
+
+    if (pxTaskStatusArray != NULL) {
+
+        uxArraySize = uxTaskGetSystemState(pxTaskStatusArray, uxArraySize, &ulTotalRunTime);
+        DEBUG_uart_print_str("[");
+
+        for (x = 0; x < uxArraySize; x++) {
+            char message_buffer[256];
+            int len = snprintf(message_buffer, sizeof(message_buffer),
+                               "{\"TaskName\":\"%s\",\"State\":\"%s\",\"Priority\":%lu,\"Stack\":%u}%s",
+                               pxTaskStatusArray[x].pcTaskName,
+                               pxTaskStatusArray[x].eCurrentState == eRunning ? "RUN" :
+                               pxTaskStatusArray[x].eCurrentState == eReady ? "RDY" :
+                               pxTaskStatusArray[x].eCurrentState == eBlocked ? "BLK" :
+                               pxTaskStatusArray[x].eCurrentState == eSuspended ? "SUSP" :
+                               pxTaskStatusArray[x].eCurrentState == eDeleted ? "DEL" : "UNKN",
+                               pxTaskStatusArray[x].uxCurrentPriority,
+                               pxTaskStatusArray[x].usStackHighWaterMark,
+                               x < uxArraySize - 1 ? "," : "");
+            if (len > 0) {
+                DEBUG_uart_print_str(message_buffer);
+            }
+        }
+
+        DEBUG_uart_print_str("]");
+        vPortFree(pxTaskStatusArray);
+        
+        } else {
+            DEBUG_uart_print_str("Failed to allocate memory for task status array.");
+            return 1;
+            }
+
+    return 0;
+}

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -253,8 +253,8 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
    // ****************** SECTION: freertos_telecommand_defs ******************
 
    {
-        .tcmd_name = "retrieve_freertos_metadata",
-        .tcmd_func = TCMDEXEC_retrieve_freertos_metadata,
+        .tcmd_name = "freertos_get_metadata",
+        .tcmd_func = TCMDEXEC_freertos_get_metadata,
         .number_of_args = 0,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -7,6 +7,7 @@
 #include "debug_tools/debug_uart.h"
 
 // Additional telecommand definitions files:
+#include "telecommands/freertos_telecommand_defs.h"
 #include "telecommands/flash_telecommand_defs.h"
 #include "telecommands/lfs_telecommand_defs.h"
 #include "telecommands/log_telecommand_defs.h"
@@ -248,6 +249,17 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
     },
 
    // ****************** END SECTION: log_telecommand_defs ******************
+
+   // ****************** SECTION: freertos_telecommand_defs ******************
+
+   {
+        .tcmd_name = "retrieve_freertos_metadata",
+        .tcmd_func = TCMDEXEC_retrieve_freertos_metadata,
+        .number_of_args = 0,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+
+    // ****************** END SECTION: freertos_telecommand_defs ******************
 
 };
 

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -253,8 +253,8 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
    // ****************** SECTION: freertos_telecommand_defs ******************
 
    {
-        .tcmd_name = "freertos_get_metadata",
-        .tcmd_func = TCMDEXEC_freertos_get_metadata,
+        .tcmd_name = "freetos_list_tasks_jsonl",
+        .tcmd_func = TCMDEXEC_freetos_list_tasks_jsonl,
         .number_of_args = 0,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },


### PR DESCRIPTION
This PR addresses creating a telecommand for obtaining the task stack information using FreeRTOS APIs.

I have addressed issues and comments based on an earlier iteration of a previous PR  [#124 ](https://github.com/CalgaryToSpace/CTS-SAT-1-OBC-Firmware/pull/124)

I have added a new source and header file for the freeRTOS telecommand. I have changed how I was printing to use `DEBUG_uart_print_str`
