### PR TITLE
Create testing tcmds: `demo_blocking_delay`, `freertos_demo_stack_usage`

### DIFF
--- a/firmware/Core/Inc/telecommands/freertos_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/freertos_telecommand_defs.h
@@ -2,6 +2,8 @@
 #ifndef __INCLUDE_GUARD__FREERTOS_TELECOMMAND_DEFINITIONS_H
 #define __INCLUDE_GUARD__FREERTOS_TELECOMMAND_DEFINITIONS_H
 
+#include "telecommands/telecommand_types.h"
+
 #include <stdint.h>
 
 uint8_t TCMDEXEC_freetos_list_tasks_jsonl(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,

--- a/firmware/Core/Inc/telecommands/freertos_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/freertos_telecommand_defs.h
@@ -9,4 +9,9 @@
 uint8_t TCMDEXEC_freetos_list_tasks_jsonl(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
+uint8_t TCMDEXEC_freertos_demo_stack_usage(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len
+);
+
 #endif // __INCLUDE_GUARD__FREERTOS_TELECOMMAND_DEFINITIONS_H

--- a/firmware/Core/Inc/telecommands/telecommand_definitions.h
+++ b/firmware/Core/Inc/telecommands/telecommand_definitions.h
@@ -21,15 +21,6 @@ uint8_t TCMDEXEC_heartbeat_on(const char *args_str, TCMD_TelecommandChannel_enum
 uint8_t TCMDEXEC_core_system_stats(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_echo_back_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len);
-
-uint8_t TCMDEXEC_echo_back_uint32_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len);
-
-uint8_t TCMDEXEC_run_all_unit_tests(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len);
-
 uint8_t TCMDEXEC_available_telecommands(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 

--- a/firmware/Core/Inc/telecommands/testing_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/testing_telecommand_defs.h
@@ -1,0 +1,17 @@
+
+#ifndef INCLUDE_GUARD__TESTING_TELECOMMAND_DEFINITIONS_H
+#define INCLUDE_GUARD__TESTING_TELECOMMAND_DEFINITIONS_H
+
+#include "telecommands/telecommand_types.h"
+#include <stdint.h>
+
+uint8_t TCMDEXEC_echo_back_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_echo_back_uint32_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_run_all_unit_tests(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+#endif // INCLUDE_GUARD__TESTING_TELECOMMAND_DEFINITIONS_H

--- a/firmware/Core/Inc/telecommands/testing_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/testing_telecommand_defs.h
@@ -14,4 +14,9 @@ uint8_t TCMDEXEC_echo_back_uint32_args(const char *args_str, TCMD_TelecommandCha
 uint8_t TCMDEXEC_run_all_unit_tests(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
+uint8_t TCMDEXEC_demo_blocking_delay(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len
+);
+
 #endif // INCLUDE_GUARD__TESTING_TELECOMMAND_DEFINITIONS_H

--- a/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
@@ -7,7 +7,7 @@
 
 #include "telecommands/freertos_telecommand_defs.h"
 #include "debug_tools/debug_uart.h"
-
+#include "timekeeping/timekeeping.h"
 
 #include <stdio.h>
 #include <stdint.h>
@@ -72,5 +72,40 @@ uint8_t TCMDEXEC_freetos_list_tasks_jsonl(const char *args_str, TCMD_Telecommand
         response_output_buf, response_output_buf_len,
         "{\"number_of_tasks\":%lu,\"total_run_time\":%lu}", number_of_tasks, total_run_time
     );
+    return 0;
+}
+
+/// @brief Demo using stack memory by allocating a Variable-Length Array (VLA) on the stack.
+/// @param args_str 
+/// - Arg 0: num_bytes (uint64_t) - The number of elements to allocate in the VLA. <=1_000_000.
+/// @return 0 on success, >0 on error
+uint8_t TCMDEXEC_freertos_demo_stack_usage(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len
+) {
+    uint64_t num_bytes;
+    uint8_t parse_result = TCMD_extract_uint64_arg(
+        args_str, strlen(args_str), 0, &num_bytes
+    );
+    if (parse_result > 0) {
+        snprintf(response_output_buf, response_output_buf_len, "Error parsing num_bytes: Err=%d", parse_result);
+        return 1;
+    }
+
+    if (num_bytes > 1000000) {
+        snprintf(response_output_buf, response_output_buf_len, "num_bytes too large. Must be <=1_000_000.");
+        return 2;
+    }
+
+    // Allocate a VLA on the stack
+    uint8_t vla[num_bytes];
+    memset(vla, 42, num_bytes);
+
+    // Force the compiler to not optimize out the memset calls.
+    uint32_t sum = 0;
+    for (uint32_t i = 0; i < num_bytes; i++) {
+        sum += vla[i] * TIM_get_current_system_uptime_ms();
+    }
+    
     return 0;
 }

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -103,7 +103,7 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .tcmd_name = "demo_blocking_delay",
         .tcmd_func = TCMDEXEC_demo_blocking_delay,
         .number_of_args = 1,
-        .readiness_level = TCMD_READINESS_LEVEL_FLIGHT_TESTING,
+        .readiness_level = TCMD_READINESS_LEVEL_FLIGHT_TESTING, // Can cause crash via Watchdog reset.
     },
 
     // ****************** END SECTION: testing_telecommand_defs ******************
@@ -302,6 +302,13 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .tcmd_func = TCMDEXEC_freetos_list_tasks_jsonl,
         .number_of_args = 0,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+
+    {
+        .tcmd_name = "freertos_demo_stack_usage",
+        .tcmd_func = TCMDEXEC_freertos_demo_stack_usage,
+        .number_of_args = 1,
+        .readiness_level = TCMD_READINESS_LEVEL_FLIGHT_TESTING, // Can cause crash via stack overflow.
     },
 
     // ****************** END SECTION: freertos_telecommand_defs ******************

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -2,7 +2,6 @@
 #include "telecommands/telecommand_definitions.h"
 #include "telecommands/telecommand_args_helpers.h"
 #include "transforms/arrays.h"
-#include "unit_tests/unit_test_executor.h"
 #include "timekeeping/timekeeping.h"
 #include "debug_tools/debug_uart.h"
 
@@ -14,6 +13,7 @@
 #include "telecommands/timekeeping_telecommand_defs.h"
 #include "telecommands/i2c_telecommand_defs.h"
 #include "telecommands/config_telecommand_defs.h"
+#include "telecommands/testing_telecommand_defs.h"
 
 #include <stdio.h>
 #include <stdint.h>
@@ -49,24 +49,6 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {
-        .tcmd_name = "echo_back_args",
-        .tcmd_func = TCMDEXEC_echo_back_args,
-        .number_of_args = 1, // TODO: support more than 1 arg
-        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
-    },
-    {
-        .tcmd_name = "echo_back_uint32_args",
-        .tcmd_func = TCMDEXEC_echo_back_uint32_args,
-        .number_of_args = 10,
-        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
-    },
-    {
-        .tcmd_name = "run_all_unit_tests",
-        .tcmd_func = TCMDEXEC_run_all_unit_tests,
-        .number_of_args = 0,
-        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
-    },
-    {
         .tcmd_name = "get_system_time",
         .tcmd_func = TCMDEXEC_get_system_time,
         .number_of_args = 0,
@@ -96,6 +78,29 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
+
+    // ****************** SECTION: testing_telecommand_defs ******************
+
+    {
+        .tcmd_name = "echo_back_args",
+        .tcmd_func = TCMDEXEC_echo_back_args,
+        .number_of_args = 1, // TODO: support more than 1 arg
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+    {
+        .tcmd_name = "echo_back_uint32_args",
+        .tcmd_func = TCMDEXEC_echo_back_uint32_args,
+        .number_of_args = 10,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+    {
+        .tcmd_name = "run_all_unit_tests",
+        .tcmd_func = TCMDEXEC_run_all_unit_tests,
+        .number_of_args = 0,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+
+    // ****************** END SECTION: testing_telecommand_defs ******************
 
     // ****************** SECTION: config_telecommand_defs ******************
     {
@@ -335,48 +340,6 @@ uint8_t TCMDEXEC_core_system_stats(const char *args_str, TCMD_TelecommandChannel
     // TODO: implement this (Issue #103)
     // Use `TCMD_get_agenda_used_slots_count`
     snprintf(response_output_buf, response_output_buf_len, "System stats: TODO\n");
-    return 0;
-}
-
-uint8_t TCMDEXEC_echo_back_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len) {
-
-    snprintf(response_output_buf, response_output_buf_len, "SUCCESS: Echo Args: '%s'\n", args_str);
-    // TODO: handle args_str being too long
-    return 0;
-}
-
-uint8_t TCMDEXEC_echo_back_uint32_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len) {
-    response_output_buf[0] = '\0'; // clear the response buffer
-
-    for (uint8_t arg_num = 0; arg_num < 10; arg_num++) {
-        uint64_t arg_uint64;
-        uint8_t parse_result = TCMD_extract_uint64_arg(
-            args_str, strlen(args_str), arg_num, &arg_uint64);
-        if (parse_result > 0) {
-            // error parsing
-            snprintf(
-                &response_output_buf[strlen(response_output_buf)],
-                response_output_buf_len - strlen(response_output_buf) - 1,
-                "Arg%d=error%d, ", arg_num, parse_result);
-        }
-        else {
-            // success parsing
-            snprintf(
-                &response_output_buf[strlen(response_output_buf)],
-                response_output_buf_len - strlen(response_output_buf) - 1,
-                "Arg%d=%" PRIu32 ", ",
-                arg_num, (uint32_t)arg_uint64);
-        }
-    }
-    return 0;
-}
-
-
-uint8_t TCMDEXEC_run_all_unit_tests(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len) {
-    TEST_run_all_unit_tests_and_log(response_output_buf, response_output_buf_len);
     return 0;
 }
 

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -99,6 +99,12 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .number_of_args = 0,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
+    {
+        .tcmd_name = "demo_blocking_delay",
+        .tcmd_func = TCMDEXEC_demo_blocking_delay,
+        .number_of_args = 1,
+        .readiness_level = TCMD_READINESS_LEVEL_FLIGHT_TESTING,
+    },
 
     // ****************** END SECTION: testing_telecommand_defs ******************
 

--- a/firmware/Core/Src/telecommands/testing_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/testing_telecommand_defs.c
@@ -54,3 +54,32 @@ uint8_t TCMDEXEC_run_all_unit_tests(const char *args_str, TCMD_TelecommandChanne
     TEST_run_all_unit_tests_and_log(response_output_buf, response_output_buf_len);
     return 0;
 }
+
+/// @brief Delay for a specified number of milliseconds, for testing purposes.
+/// @param args_str 1 argument: delay_ms (uint64_t)
+/// - Arg 0: delay_ms (uint64_t) - The number of milliseconds to delay for. <=30_000ms.
+/// @return 0 on success, 1 on error
+uint8_t TCMDEXEC_demo_blocking_delay(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len
+) {
+    uint64_t delay_ms;
+    uint8_t parse_result = TCMD_extract_uint64_arg(
+        args_str, strlen(args_str), 0, &delay_ms
+    );
+    if (parse_result > 0) {
+        snprintf(response_output_buf, response_output_buf_len, "Error parsing delay_ms: Err=%d", parse_result);
+        return 1;
+    }
+    
+    if (delay_ms > 30000) {
+        snprintf(response_output_buf, response_output_buf_len, "Delay too long. Must be <=30_000ms.");
+        return 1;
+    }
+
+    const uint32_t delay_ms_u32 = (uint32_t)delay_ms;
+    
+    snprintf(response_output_buf, response_output_buf_len, "Delay for %" PRIu32 " ms\n", delay_ms_u32);
+    HAL_Delay(delay_ms_u32);
+    return 0;
+}

--- a/firmware/Core/Src/telecommands/testing_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/testing_telecommand_defs.c
@@ -1,0 +1,56 @@
+
+#include "telecommands/telecommand_definitions.h"
+#include "telecommands/telecommand_args_helpers.h"
+
+#include "telecommands/testing_telecommand_defs.h"
+#include "debug_tools/debug_uart.h"
+
+#include "unit_tests/unit_test_executor.h"
+
+#include <stdio.h>
+#include <inttypes.h>
+#include <string.h>
+
+
+
+uint8_t TCMDEXEC_echo_back_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+
+    snprintf(response_output_buf, response_output_buf_len, "SUCCESS: Echo Args: '%s'\n", args_str);
+    // TODO: handle args_str being too long
+    return 0;
+}
+
+uint8_t TCMDEXEC_echo_back_uint32_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+    response_output_buf[0] = '\0'; // clear the response buffer
+
+    for (uint8_t arg_num = 0; arg_num < 10; arg_num++) {
+        uint64_t arg_uint64;
+        uint8_t parse_result = TCMD_extract_uint64_arg(
+            args_str, strlen(args_str), arg_num, &arg_uint64);
+        if (parse_result > 0) {
+            // error parsing
+            snprintf(
+                &response_output_buf[strlen(response_output_buf)],
+                response_output_buf_len - strlen(response_output_buf) - 1,
+                "Arg%d=error%d, ", arg_num, parse_result);
+        }
+        else {
+            // success parsing
+            snprintf(
+                &response_output_buf[strlen(response_output_buf)],
+                response_output_buf_len - strlen(response_output_buf) - 1,
+                "Arg%d=%" PRIu32 ", ",
+                arg_num, (uint32_t)arg_uint64);
+        }
+    }
+    return 0;
+}
+
+
+uint8_t TCMDEXEC_run_all_unit_tests(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+    TEST_run_all_unit_tests_and_log(response_output_buf, response_output_buf_len);
+    return 0;
+}


### PR DESCRIPTION
Closes #130. Prework for #74 (blocking delay telecommand is required to test the watchdog). 