### PR TITLE
Telecommand that deletes agenda by telecommand name

### DIFF
--- a/firmware/Core/Inc/telecommands/agenda_telecommands_defs.h
+++ b/firmware/Core/Inc/telecommands/agenda_telecommands_defs.h
@@ -14,4 +14,7 @@ uint8_t TCMDEXEC_agenda_delete_by_tssent(const char *args_str, TCMD_TelecommandC
 uint8_t TCMDEXEC_agenda_fetch_jsonl(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
+uint8_t TCMDEXEC_agenda_delete_by_function_name(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
 #endif // __INCLUDE_GUARD__AGENDA_TELECOMMAND_DEFINITIONS_H

--- a/firmware/Core/Inc/telecommands/agenda_telecommands_defs.h
+++ b/firmware/Core/Inc/telecommands/agenda_telecommands_defs.h
@@ -14,7 +14,7 @@ uint8_t TCMDEXEC_agenda_delete_by_tssent(const char *args_str, TCMD_TelecommandC
 uint8_t TCMDEXEC_agenda_fetch_jsonl(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_agenda_delete_by_function_name(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_agenda_delete_by_name(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif // __INCLUDE_GUARD__AGENDA_TELECOMMAND_DEFINITIONS_H

--- a/firmware/Core/Inc/telecommands/telecommand_executor.h
+++ b/firmware/Core/Inc/telecommands/telecommand_executor.h
@@ -28,4 +28,6 @@ uint8_t TCMD_agenda_delete_by_tssent(uint64_t tssent);
 
 uint8_t TCMD_agenda_fetch();
 
+uint8_t TCMD_agenda_delete_by_function_name(const char *function_name);
+
 #endif // INCLUDE_GUARD__TELECOMMAND_EXECUTOR_H

--- a/firmware/Core/Inc/telecommands/telecommand_executor.h
+++ b/firmware/Core/Inc/telecommands/telecommand_executor.h
@@ -28,6 +28,6 @@ uint8_t TCMD_agenda_delete_by_tssent(uint64_t tssent);
 
 uint8_t TCMD_agenda_fetch();
 
-uint8_t TCMD_agenda_delete_by_function_name(const char *function_name);
+uint8_t TCMD_agenda_delete_by_name(const char *telecommand_name);
 
 #endif // INCLUDE_GUARD__TELECOMMAND_EXECUTOR_H

--- a/firmware/Core/Src/telecommands/agenda_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/agenda_telecommand_defs.c
@@ -79,3 +79,18 @@ uint8_t TCMDEXEC_agenda_fetch_jsonl(const char *args_str, TCMD_TelecommandChanne
     const uint8_t result = TCMD_agenda_fetch();
     return result;
 }
+
+
+/// @brief Telecommand: Delete agenda entry by function name
+/// @param args_str
+/// - Arg 0: function name (string) - The name of the telecommand function in the agenda to delete.
+/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
+/// @param response_output_buf The buffer to write the response to
+/// @param response_output_buf_len The maximum length of the response_output_buf (its size)
+/// @return 0 on success, > 0 on error
+uint8_t TCMDEXEC_agenda_delete_by_function_name(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+    
+    const uint8_t result = TCMD_agenda_delete_by_function_name(args_str);
+    return result;
+}

--- a/firmware/Core/Src/telecommands/agenda_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/agenda_telecommand_defs.c
@@ -83,14 +83,14 @@ uint8_t TCMDEXEC_agenda_fetch_jsonl(const char *args_str, TCMD_TelecommandChanne
 
 /// @brief Telecommand: Delete agenda entry by function name
 /// @param args_str
-/// - Arg 0: function name (string) - The name of the telecommand function in the agenda to delete.
+/// - Arg 0: telecommand name (string) - The name of the telecommand function in the agenda to delete. (e.g, hello_world)
 /// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0 on success, > 0 on error
-uint8_t TCMDEXEC_agenda_delete_by_function_name(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_agenda_delete_by_name(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     
-    const uint8_t result = TCMD_agenda_delete_by_function_name(args_str);
+    const uint8_t result = TCMD_agenda_delete_by_name(args_str);
     return result;
 }

--- a/firmware/Core/Src/telecommands/agenda_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/agenda_telecommand_defs.c
@@ -23,9 +23,9 @@ uint8_t TCMDEXEC_agenda_delete_all(const char *args_str, TCMD_TelecommandChannel
     return 0;
 }
 
-/// @brief Telecommand: Delete agenda entry by timestamp
+/// @brief Telecommand: Delete agenda entry by tssent timestamp
 /// @param args_str
-/// - Arg 0: Timestamp sent (uint64_t) - The timestamp of the agenda entry to delete.
+/// - Arg 0: Timestamp sent (uint64_t) - The tssent timestamp of the agenda entry to delete.
 /// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
@@ -81,7 +81,7 @@ uint8_t TCMDEXEC_agenda_fetch_jsonl(const char *args_str, TCMD_TelecommandChanne
 }
 
 
-/// @brief Telecommand: Delete agenda entry by function name
+/// @brief Telecommand: Delete all agenda entries with a telecommand name
 /// @param args_str
 /// - Arg 0: telecommand name (string) - The name of the telecommand function in the agenda to delete. (e.g, hello_world)
 /// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -340,8 +340,8 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
     },
 
     {
-        .tcmd_name = "agenda_delete_by_function_name",
-        .tcmd_func = TCMDEXEC_agenda_delete_by_function_name,
+        .tcmd_name = "agenda_delete_by_name",
+        .tcmd_func = TCMDEXEC_agenda_delete_by_name,
         .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -331,11 +331,18 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
-
-   {
+    
+    {
         .tcmd_name = "agenda_fetch",
         .tcmd_func = TCMDEXEC_agenda_fetch_jsonl,
         .number_of_args = 0,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+
+    {
+        .tcmd_name = "agenda_delete_by_function_name",
+        .tcmd_func = TCMDEXEC_agenda_delete_by_function_name,
+        .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
 

--- a/firmware/Core/Src/telecommands/telecommand_executor.c
+++ b/firmware/Core/Src/telecommands/telecommand_executor.c
@@ -317,36 +317,35 @@ uint8_t TCMD_agenda_fetch(){
 }
 
 
-/// @brief Deletes a telecommand from the agenda by the telecommand function name.
-/// @param function_name The `timestamp_sent` value of the telecommand to delete.
-/// @return 0 on success, > 0 if the telecommand was not found.
-/// @note Calls `LOG_message()` to log the deletion before all returns.
-uint8_t TCMD_agenda_delete_by_function_name(const char *function_name) {
-    bool is_valid_function_name_count = false;
+/// @brief Deletes telecommands from the agenda by the telecommand name.
+/// @param telecommand_name The name of the telecommand in the agenda to delete. (e.g, hello_world)
+/// @return 0 on success, > 0 on error.
+uint8_t TCMD_agenda_delete_by_name(const char *telecommand_name) {
 
     // Get count of active agendas
     const uint8_t active_agendas = TCMD_get_agenda_used_slots_count();
 
     if(active_agendas == 0){
         LOG_message(
-        LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
-        "TCMD_agenda_delete_by_function_name: No active telecommands in the agenda."
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "TCMD_agenda_delete_by_telecommand_name: No active telecommands in the agenda."
         );
-    return 1;
+        return 1;
     }
 
     // Loop through the telecommand definitions and check if the passed function name is valid
+    bool is_valid_telecommand_name = false;
     for (uint16_t idx = 0; idx < TCMD_NUM_TELECOMMANDS; idx++) {
-        if (strcmp(TCMD_telecommand_definitions[idx].tcmd_name,function_name) == 0) {
-            is_valid_function_name_count = true;
+        if (strcmp(TCMD_telecommand_definitions[idx].tcmd_name,telecommand_name) == 0) {
+            is_valid_telecommand_name = true;
             break;
         }
     }
 
-    if(!is_valid_function_name_count){
+    if(!is_valid_telecommand_name){
         LOG_message(
-        LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
-        "TCMD_agenda_delete_by_function_name: Invalid telecommand name passed in the function."
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "TCMD_agenda_delete_by_telecommand_name: Invalid telecommand name passed in the function."
         );
         return 2;
     }
@@ -356,23 +355,23 @@ uint8_t TCMD_agenda_delete_by_function_name(const char *function_name) {
         if (TCMD_agenda_is_valid[slot_num] ) {
 
             // Grab the index of the telecommand in the `TCMD_telecommand_definitions` array
-            uint8_t telecommand_index = TCMD_agenda[slot_num].tcmd_idx;
+            const uint8_t telecommand_index = TCMD_agenda[slot_num].tcmd_idx;
 
             // Perform a string comparision
-            if(strcmp(TCMD_telecommand_definitions[telecommand_index].tcmd_name,function_name) == 0){
+            if(strcmp(TCMD_telecommand_definitions[telecommand_index].tcmd_name,telecommand_name) == 0){
                 
                 // Set agenda as invalid
                 TCMD_agenda_is_valid[slot_num] = 0;
-                
-                LOG_message(
-                LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
-                "TCMD_agenda_delete_by_function_name: Telecommand with function name= %s (%s) deleted from agenda.",
-                function_name,
-                TCMD_telecommand_definitions[TCMD_agenda[slot_num].tcmd_idx].tcmd_name
-                );
             }
         }
     }
+    
+    LOG_message(
+        LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+        "TCMD_agenda_delete_by_telecommand_name: Removed %d telecommands with the name = (%s) from agenda.",
+        active_agendas,
+        telecommand_name
+    );
 
     return 0;
 }

--- a/firmware/Core/Src/telecommands/telecommand_executor.c
+++ b/firmware/Core/Src/telecommands/telecommand_executor.c
@@ -317,9 +317,10 @@ uint8_t TCMD_agenda_fetch(){
 }
 
 
-/// @brief Deletes telecommands from the agenda by the telecommand name.
+/// @brief Deletes all agenda entries with a telecommand name.
 /// @param telecommand_name The name of the telecommand in the agenda to delete. (e.g, hello_world)
 /// @return 0 on success, > 0 on error.
+/// @note Calls `LOG_message()` before all returns.
 uint8_t TCMD_agenda_delete_by_name(const char *telecommand_name) {
 
     // Get count of active agendas


### PR DESCRIPTION
This PR addresses deleting an agenda based on the telecommand name passed.

I achieved this by:
- Doing a string comparison with the passed string `function_name` with the `TCMD_telecommand_definitions[idx].tcmd_name` 

Testing:
I tested the code by:
- Scheduling one telecommand and invoking the `agenda_delete_by_function_name` command and passing: no string, wrong function name and the right function name
- Scheduling two telecommands and invoking the `agenda_delete_by_function_name` command and passing the right function name for either of the functions and using the `agenda_fetch` command to see if it was removed successfully.

Refactor Suggestions:
When using the `agenda_fetch` function, it was annoying not to know the name of the telecommand that is active in the agenda. We could possible add this into the function. Let me know what you think.