### PR TITLE
Updated flash driver and littlefs helper to use NAND memory module (MT29F1G Series)

### DIFF
--- a/firmware/Core/Inc/littlefs/flash_driver.h
+++ b/firmware/Core/Inc/littlefs/flash_driver.h
@@ -15,8 +15,12 @@
 // Total size of a singular Memory Module in bytes
 #define FLASH_CHIP_SIZE_BYTES 134217728  // 128MiB // TODO: update
 
-//Number of pages contained within a single block of memory module
+// Number of pages contained within a single block of memory module
 #define FLASH_CHIP_PAGES_PER_BLOCK 64
+
+// NAND Flash Memory Datasheet https://www.farnell.com/datasheets/3151163.pdf
+// Each page is divided into a 2048-byte data storage region, and a 128 bytes spare area (2176 bytes total).
+static const uint16_t FLASH_MAX_BYTES_PER_PAGE = 2048;
 
 /*-------------------------------FLASH FEATURES-------------------------------*/
 // Features that can be accessed using Get Feature command

--- a/firmware/Core/Inc/littlefs/flash_driver.h
+++ b/firmware/Core/Inc/littlefs/flash_driver.h
@@ -20,7 +20,7 @@
 
 // NAND Flash Memory Datasheet https://www.farnell.com/datasheets/3151163.pdf
 // Each page is divided into a 2048-byte data storage region, and a 128 bytes spare area (2176 bytes total).
-static const uint16_t FLASH_MAX_BYTES_PER_PAGE = 2048;
+#define FLASH_MAX_BYTES_PER_PAGE 2048
 
 /*-------------------------------FLASH FEATURES-------------------------------*/
 // Features that can be accessed using Get Feature command

--- a/firmware/Core/Inc/littlefs/flash_driver.h
+++ b/firmware/Core/Inc/littlefs/flash_driver.h
@@ -41,10 +41,11 @@ static const uint8_t FLASH_CMD_WRITE_ENABLE = 0x06;  // Write Enable
 static const uint8_t FLASH_CMD_WRITE_DISABLE = 0x04; // Write Disable
 
 static const uint8_t FLASH_CMD_GET_FEATURES = 0x0F; // Get Features
+static const uint8_t FLASH_CMD_SET_FEATURES = 0x1F; // Set Features
 
 static const uint8_t FLASH_CMD_READ_ID = 0x9F; // Read ID (0x2C 0x14)
 
-static const uint8_t FLASH_CMD_RESET = 0xFF;
+static const uint8_t FLASH_CMD_RESET = 0xFF; // Reset operation
 
 // ------------------- Status Register 1 - Byte Masks -------------------
 // Source: Table 5
@@ -68,7 +69,9 @@ typedef enum {
 /*-----------------------------DRIVER FUNCTIONS-----------------------------*/
 void FLASH_activate_chip_select(uint8_t chip_number);
 void FLASH_deactivate_chip_select();
+FLASH_error_enum_t FLASH_unblock_block_lock(SPI_HandleTypeDef *hspi, uint8_t chip_number, uint8_t *buf);
 FLASH_error_enum_t FLASH_read_status_register(SPI_HandleTypeDef *hspi, uint8_t chip_number, uint8_t *buf);
+FLASH_error_enum_t FLASH_read_block_lock_register(SPI_HandleTypeDef *hspi, uint8_t chip_number, uint8_t *buf);
 FLASH_error_enum_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_number);
 FLASH_error_enum_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_number);
 FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr);
@@ -76,5 +79,6 @@ FLASH_error_enum_t FLASH_write_data(SPI_HandleTypeDef *hspi, uint8_t chip_number
 FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *rx_buffer, lfs_size_t rx_buffer_len);
 
 FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_number);
+FLASH_error_enum_t FLASH_reset(SPI_HandleTypeDef *hspi, uint8_t chip_number);
 
 #endif /* __INCLUDE_GUARD__FLASH_DRIVER_H__ */

--- a/firmware/Core/Inc/littlefs/flash_driver.h
+++ b/firmware/Core/Inc/littlefs/flash_driver.h
@@ -15,6 +15,9 @@
 // Total size of a singular Memory Module in bytes
 #define FLASH_CHIP_SIZE_BYTES 134217728  // 128MiB // TODO: update
 
+//Number of pages contained within a single block of memory module
+#define FLASH_CHIP_PAGES_PER_BLOCK 64
+
 /*-------------------------------FLASH FEATURES-------------------------------*/
 // Features that can be accessed using Get Feature command
 
@@ -74,9 +77,9 @@ FLASH_error_enum_t FLASH_read_status_register(SPI_HandleTypeDef *hspi, uint8_t c
 FLASH_error_enum_t FLASH_read_block_lock_register(SPI_HandleTypeDef *hspi, uint8_t chip_number, uint8_t *buf);
 FLASH_error_enum_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_number);
 FLASH_error_enum_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_number);
-FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr);
-FLASH_error_enum_t FLASH_write_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *packet_buffer, lfs_size_t packet_buffer_len);
-FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *rx_buffer, lfs_size_t rx_buffer_len);
+FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t page);
+FLASH_error_enum_t FLASH_write_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t page, uint8_t *packet_buffer, lfs_size_t packet_buffer_len);
+FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t page, uint8_t *rx_buffer, lfs_size_t rx_buffer_len);
 
 FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_number);
 FLASH_error_enum_t FLASH_reset(SPI_HandleTypeDef *hspi, uint8_t chip_number);

--- a/firmware/Core/Inc/littlefs/littlefs_benchmark.h
+++ b/firmware/Core/Inc/littlefs/littlefs_benchmark.h
@@ -8,10 +8,10 @@
 typedef enum {
     LFS_SINGLE_FILE,
     LFS_NEW_FILE
-} LFS_benchmark_mode;
+} LFS_benchmark_mode_enum_t;
 
 /*-----------------------------BENCHMARK FUNCTIONS-----------------------------*/
-uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len, LFS_benchmark_mode mode);
+uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len, LFS_benchmark_mode_enum_t mode);
 uint8_t LFS_benchmark_write_read_single_and_new(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len);
 
 #endif // __INCLUDE_GUARD__LITTLEFS_BENCHMARK_H__

--- a/firmware/Core/Inc/littlefs/littlefs_benchmark.h
+++ b/firmware/Core/Inc/littlefs/littlefs_benchmark.h
@@ -1,13 +1,16 @@
 #ifndef __INCLUDE_GUARD__LITTLEFS_BENCHMARK_H__
 #define __INCLUDE_GUARD__LITTLEFS_BENCHMARK_H__
 
+/*-----------------------------INCLUDES----------------------------------------*/
 #include <stdint.h>
 
+/*-------------------------------BENCHMARK FEATURES----------------------------*/
 typedef enum {
     LFS_SINGLE_FILE,
     LFS_NEW_FILE
 } LFS_benchmark_mode;
 
+/*-----------------------------BENCHMARK FUNCTIONS-----------------------------*/
 uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len, LFS_benchmark_mode mode);
 uint8_t LFS_benchmark_write_read_single_and_new(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len);
 

--- a/firmware/Core/Inc/littlefs/littlefs_benchmark.h
+++ b/firmware/Core/Inc/littlefs/littlefs_benchmark.h
@@ -3,7 +3,12 @@
 
 #include <stdint.h>
 
+typedef enum {
+    LFS_SINGLE_FILE,
+    LFS_NEW_FILE
+} LFS_benchmark_mode;
 
-uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len);
+uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len, LFS_benchmark_mode mode);
+uint8_t LFS_benchmark_write_read_single_and_new(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len);
 
 #endif // __INCLUDE_GUARD__LITTLEFS_BENCHMARK_H__

--- a/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include "telecommands/telecommand_definitions.h"
 
+#define MAX_NUM_BYTES_TO_READ 2048
+
 uint8_t TCMDEXEC_flash_activate_each_cs(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
@@ -21,6 +23,12 @@ uint8_t TCMDEXEC_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_flash_reset(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_flash_unblock_block_locks(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
                         
 #endif /* __INCLUDE_GUARD__FLASH_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
@@ -7,7 +7,7 @@
 
 /*----------------------------- CONFIG VARIABLES ----------------------------- */
 // Maximum number of bytes to read from the flash
-#define MAX_NUM_BYTES_TO_READ 2048
+#define MAX_NUM_BYTES 2048
 
 uint8_t TCMDEXEC_flash_activate_each_cs(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
@@ -28,9 +28,6 @@ uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const char *args_str, TCMD_Tel
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 uint8_t TCMDEXEC_flash_reset(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len);
-
-uint8_t TCMDEXEC_flash_unblock_block_locks(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
                         
 #endif /* __INCLUDE_GUARD__FLASH_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
@@ -6,7 +6,8 @@
 #include "telecommands/telecommand_definitions.h"
 
 /*----------------------------- CONFIG VARIABLES ----------------------------- */
-// Maximum number of bytes to read from the flash
+// NAND Flash Memory Datasheet https://www.farnell.com/datasheets/3151163.pdf (pg.7)
+// Each page is divided into a 2048-byte data storage region, and a 128 bytes spare area (2176 bytes total).
 #define MAX_NUM_BYTES 2048
 
 uint8_t TCMDEXEC_flash_activate_each_cs(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,

--- a/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
@@ -5,11 +5,7 @@
 #include <stdint.h>
 #include "telecommands/telecommand_definitions.h"
 
-/*----------------------------- CONFIG VARIABLES ----------------------------- */
-// NAND Flash Memory Datasheet https://www.farnell.com/datasheets/3151163.pdf (pg.7)
-// Each page is divided into a 2048-byte data storage region, and a 128 bytes spare area (2176 bytes total).
-#define MAX_NUM_BYTES 2048
-
+/*----------------------------- TELECOMMAND DEFINITIONS ----------------------------- */
 uint8_t TCMDEXEC_flash_activate_each_cs(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 

--- a/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include "telecommands/telecommand_definitions.h"
 
+/*----------------------------- CONFIG VARIABLES ----------------------------- */
+// Maximum number of bytes to read from the flash
 #define MAX_NUM_BYTES_TO_READ 2048
 
 uint8_t TCMDEXEC_flash_activate_each_cs(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,

--- a/firmware/Core/Src/littlefs/flash_benchmark.c
+++ b/firmware/Core/Src/littlefs/flash_benchmark.c
@@ -45,7 +45,7 @@ uint8_t FLASH_benchmark_erase_write_read(uint8_t chip_num, uint32_t test_data_ad
     }
     // TODO: for very large writes, split into multiple writes (instead of allocating the whole amount on the stack)
     const uint32_t write_send_start_time = HAL_GetTick();
-    const FLASH_error_enum_t write_result = FLASH_write(hspi_ptr, chip_num, test_data_address, write_buffer, test_data_length);
+    const FLASH_error_enum_t write_result = FLASH_write_data(hspi_ptr, chip_num, test_data_address, write_buffer, test_data_length);
     if (write_result != 0) {
         snprintf(
             &response_str[strlen(response_str)],

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -394,13 +394,13 @@ FLASH_error_enum_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_num
  * @brief Sends Block Erase Command
  * @param hspi - Pointer to the SPI HAL handle
  * @param chip_number - the chip select number to activate
- * @param addr - block address that is to be erased
+ * @param page - page number to erase the block the page is contained in
  * @retval FLASH_ERR_OK on success, < 0 on failure
  */
-FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr)
+FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t page)
 {
     // Split address into its 3 bytes
-    uint8_t addr_bytes[3] = {(addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF};
+    uint8_t addr_bytes[3] = {(page >> 16) & 0xFF, (page >> 8) & 0xFF, page & 0xFF};
 
     // Set Block Lock Register to 0x00
     uint8_t block_lock_reg_buffer[1] = {0};
@@ -493,15 +493,15 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
  * @brief Sends Page Program Command
  * @param hspi - Pointer to the SPI HAL handle
  * @param chip_number - the chip select number to activate
- * @param addr - block address that is to be written
+ * @param page - page number the data is to be written to
  * @param packet_buffer - Pointer to buffer containing data to write
  * @param packet_buffer_len - integer that indicates the size of the data to write
  * @retval FLASH_ERR_OK on success, < 0 on failure
  */
-FLASH_error_enum_t FLASH_write_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *packet_buffer, lfs_size_t packet_buffer_len)
+FLASH_error_enum_t FLASH_write_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t page, uint8_t *packet_buffer, lfs_size_t packet_buffer_len)
 {
     // Split main address into its 3 bytes
-    uint8_t addr_bytes[3] = {(addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF};
+    uint8_t addr_bytes[3] = {(page >> 16) & 0xFF, (page >> 8) & 0xFF, page & 0xFF};
     
     // Define the address where data will be stored in cache register (First 4 bits are dummy bits)
     // TODO: Is it fine to always have this at 0?
@@ -646,14 +646,14 @@ FLASH_error_enum_t FLASH_write_data(SPI_HandleTypeDef *hspi, uint8_t chip_number
  * @brief Sends Page Read Command
  * @param hspi - Pointer to the SPI HAL handle
  * @param chip_number - The chip select number to activate
- * @param addr - Address to be read
+ * @param page - page number to be read
  * @param rx_buffer - A buffer where the read data will be stored
  * @param rx_buffer_len - Integer that indicates the capacity of `rx_buffer`
  * @retval FLASH_ERR_OK on success, < 0 on failure
  */
-FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *rx_buffer, lfs_size_t rx_buffer_len)
+FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t page, uint8_t *rx_buffer, lfs_size_t rx_buffer_len)
 {
-    uint8_t read_addr_bytes[3] = {0, (addr >> 8) & 0xFF, addr & 0xFF};
+    uint8_t read_addr_bytes[3] = {(page >> 16) & 0xFF, (page >> 8) & 0xFF, page & 0xFF};
 
     // Define the address where data will be read from in cache register (First 4 bits are dummy bits)
     // TODO: Is it fine to always have this at 0?

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -94,19 +94,39 @@ void FLASH_deactivate_chip_select()
  */
 FLASH_error_enum_t FLASH_read_status_register(SPI_HandleTypeDef *hspi, uint8_t chip_number, uint8_t *buf)
 {
+    // Send GET FEATURES command
     FLASH_activate_chip_select(chip_number);
-    const HAL_StatusTypeDef tx_result = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_READ_STATUS_REG_1, 1, FLASH_HAL_TIMEOUT_MS);
-    if (tx_result != HAL_OK) {
+    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_GET_FEATURES, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the command, check why
+    if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
-        if (tx_result == HAL_TIMEOUT) {
+        if (tx_result_1 == HAL_TIMEOUT) {
             return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
         }
         
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
+    // Send the byte address of status register
+    const HAL_StatusTypeDef tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_FEAT_STATUS, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the byte, check why
+    if (tx_result_2 != HAL_OK) {
+        FLASH_deactivate_chip_select();
+
+        if (tx_result_2 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+        
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
+    }
+
+    // Receive the Status Register bits
     const HAL_StatusTypeDef rx_result = HAL_SPI_Receive(hspi, (uint8_t *)buf, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't receive the byte, check why
     if (rx_result != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -132,9 +152,12 @@ FLASH_error_enum_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     // Buffer to store status register value
     uint8_t status_reg_buffer[1] = {0};
 
+    // Send the WRITE ENABLE Command
     FLASH_activate_chip_select(chip_number);
     const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_WRITE_ENABLE, 1, FLASH_HAL_TIMEOUT_MS);
     FLASH_deactivate_chip_select();
+
+    // If couldn't send the command, check why
     if (tx_result_1 != HAL_OK) {
 
         if (tx_result_1 == HAL_TIMEOUT) {
@@ -148,6 +171,7 @@ FLASH_error_enum_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     const uint32_t start_loop_time_ms = HAL_GetTick();
     while (1)
     {
+        // Get status register bits
         const FLASH_error_enum_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
         if (read_status_result != FLASH_ERR_OK) {
             FLASH_deactivate_chip_select();
@@ -187,9 +211,12 @@ FLASH_error_enum_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_num
     // Buffer to store status register value
     uint8_t status_reg_buffer[1] = {0};
 
+    // Send WRITE DISABLE Command
     FLASH_activate_chip_select(chip_number);
     const HAL_StatusTypeDef tx_status = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_WRITE_DISABLE, 1, FLASH_HAL_TIMEOUT_MS);
     FLASH_deactivate_chip_select();
+
+    // If couldn't send the command, check why
     if (tx_status != HAL_OK) {
 
         if (tx_status == HAL_TIMEOUT) {
@@ -203,6 +230,7 @@ FLASH_error_enum_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_num
     const uint32_t start_loop_time_ms = HAL_GetTick();
     while (1)
     {
+        // Get status register bits
         const FLASH_error_enum_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
         if (read_status_result != FLASH_ERR_OK) {
             FLASH_deactivate_chip_select();
@@ -220,9 +248,11 @@ FLASH_error_enum_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_num
             return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
         }
 
-        DEBUG_uart_print_str("DEBUG: status_reg = 0x");
-        DEBUG_uart_print_array_hex(status_reg_buffer, 1);
-        DEBUG_uart_print_str("\n");
+        if (FLASH_enable_hot_path_debug_logs) {
+            DEBUG_uart_print_str("DEBUG: status_reg = 0x");
+            DEBUG_uart_print_array_hex(status_reg_buffer, 1);
+            DEBUG_uart_print_str("\n");
+        }
     }
 
     // Should never be reached:
@@ -230,10 +260,10 @@ FLASH_error_enum_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_num
 }
 
 /**
- * @brief Sends Sector Erase Command
+ * @brief Sends Block Erase Command
  * @param hspi - Pointer to the SPI HAL handle
  * @param chip_number - the chip select number to activate
- * @param addr - block number that is to be erased
+ * @param addr - block address that is to be erased
  * @retval FLASH_ERR_OK on success, < 0 on failure
  */
 FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr)
@@ -241,16 +271,18 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
     // Split address into its 4 bytes
     uint8_t addr_bytes[4] = {(addr >> 24) & 0xFF, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF};
 
-    // Send Write Enable Command
+    // Send WRITE ENABLE Command
     const FLASH_error_enum_t wren_result = FLASH_write_enable(hspi, chip_number);
     if (wren_result != FLASH_ERR_OK) {
         FLASH_deactivate_chip_select();
         return wren_result;
     }
 
-    // Send Sector Erase Command
+    // Send BLOCK ERASE Command
     FLASH_activate_chip_select(chip_number);
-    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_SECTOR_ERASE_4_BYTE_ADDR, 1, FLASH_HAL_TIMEOUT_MS);
+    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_BLOCK_ERASE, 1, FLASH_HAL_TIMEOUT_MS);
+    
+    // If couldn't send the command, check why
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -260,7 +292,11 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
         
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
+
+    // Send the address bytes
     const HAL_StatusTypeDef tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the bytes, check why
     if (tx_result_2 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -275,10 +311,11 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
     // Buffer to store status register value
     uint8_t status_reg_buffer[1] = {0};
 
-    // Keep looping as long as device is busy (until the Write Enable Latch is active [1])
+    // Keep looping as long as device is busy (until the Operation In Progress bit is active [1])
     const uint32_t start_loop_time_ms = HAL_GetTick();
     while (1)
     {
+        // Get status register bits
         const FLASH_error_enum_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
         if (read_status_result != FLASH_ERR_OK) {
             FLASH_deactivate_chip_select();
@@ -302,9 +339,11 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
             return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
         }
 
-        DEBUG_uart_print_str("DEBUG: status_reg = 0x");
-        DEBUG_uart_print_array_hex(status_reg_buffer, 1);
-        DEBUG_uart_print_str("\n");
+        if (FLASH_enable_hot_path_debug_logs) {
+            DEBUG_uart_print_str("DEBUG: status_reg = 0x");
+            DEBUG_uart_print_array_hex(status_reg_buffer, 1);
+            DEBUG_uart_print_str("\n");
+        }
     }
 
     // Should never be reached:
@@ -315,26 +354,33 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
  * @brief Sends Page Program Command
  * @param hspi - Pointer to the SPI HAL handle
  * @param chip_number - the chip select number to activate
- * @param addr - block number that is to be written
+ * @param addr - block address that is to be written
  * @param packet_buffer - Pointer to buffer containing data to write
  * @param packet_buffer_len - integer that indicates the size of the data to write
  * @retval FLASH_ERR_OK on success, < 0 on failure
  */
-FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *packet_buffer, lfs_size_t packet_buffer_len)
+FLASH_error_enum_t FLASH_write_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *packet_buffer, lfs_size_t packet_buffer_len)
 {
-    // Split address into its 4 bytes
+    // Split main address into its 4 bytes
     uint8_t addr_bytes[4] = {(addr >> 24) & 0xFF, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF};
+    
+    // Define the address where data will be stored in cache register (First 4 bits are dummy bits)
+    // TODO: Is it fine to always have this at 0?
+    uint16_t cache_addr = 0x0000;
+    uint8_t cache_addr_bytes[2] = {(cache_addr >> 8) & 0xFF, cache_addr & 0xFF};
 
-    // Enable WREN Command, so that we can write to the memory module
+    // Send WRITE ENABLE Command
     const FLASH_error_enum_t wren_result = FLASH_write_enable(hspi, chip_number);
     if (wren_result != FLASH_ERR_OK) {
         FLASH_deactivate_chip_select();
         return wren_result;
     }
 
-    // Send WREN Command and the Data required with the command
+    // Send PROGAM LOAD Command
     FLASH_activate_chip_select(chip_number);
-    const uint8_t tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_WRITE_4_BYTE_ADDR, 1, FLASH_HAL_TIMEOUT_MS);
+    const uint8_t tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_PROGRAM_LOAD, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the command, check why
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -344,7 +390,11 @@ FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
 
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
-    const uint8_t tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
+
+    // Send Cache Register address
+    const uint8_t tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)cache_addr_bytes, 2, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the bytes, check why
     if (tx_result_2 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -354,7 +404,11 @@ FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
 
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
+
+    // Send the data bytes
     const uint8_t tx_result_3 = HAL_SPI_Transmit(hspi, (uint8_t *)packet_buffer, packet_buffer_len, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the bytes, check why
     if (tx_result_3 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -365,10 +419,44 @@ FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
+    // TODO: If Write doesn't work as intended or not all data bits are stored
+    // do the status register check loop here before deactivating chip select
+    FLASH_deactivate_chip_select();
+
+    // Send PROGAM EXECUTE Command
+    FLASH_activate_chip_select(chip_number);
+    const uint8_t tx_result_4 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_PROGRAM_EXEC, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the command, check why
+    if (tx_result_4 != HAL_OK) {
+        FLASH_deactivate_chip_select();
+
+        if (tx_result_4 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
+    }
+
+    // Send address bytes
+    const uint8_t tx_result_5 = HAL_SPI_Transmit(hspi, (uint8_t *)addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the bytes, check why
+    if (tx_result_5 != HAL_OK) {
+        FLASH_deactivate_chip_select();
+
+        if (tx_result_5 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
+    }
+    FLASH_deactivate_chip_select();
+
     // Buffer to store status register value
     uint8_t status_reg_buffer[1] = {0};
 
-    // Keep looping as long as device is busy (until the Write Enable Latch is active [1])
+    // Keep looping as long as device is busy (until the Operation In Progress bit is active [1])
     const uint32_t start_loop_time_ms = HAL_GetTick();
     while (1)
     {
@@ -395,9 +483,11 @@ FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
             return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
         }
 
-        DEBUG_uart_print_str("DEBUG: status_reg = 0x");
-        DEBUG_uart_print_array_hex(status_reg_buffer, 1);
-        DEBUG_uart_print_str("\n");
+        if (FLASH_enable_hot_path_debug_logs) {
+            DEBUG_uart_print_str("DEBUG: status_reg = 0x");
+            DEBUG_uart_print_array_hex(status_reg_buffer, 1);
+            DEBUG_uart_print_str("\n");
+        }
     }
 
     // Should never be reached:
@@ -405,22 +495,28 @@ FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
 }
 
 /**
- * @brief Sends Page Program Command
+ * @brief Sends Page Read Command
  * @param hspi - Pointer to the SPI HAL handle
- * @param chip_number - the chip select number to activate
- * @param addr - block number that is to be read
- * @param rx_buffer - a to buffer where the read data will be stored
- * @param rx_buffer_len - integer that indicates the capacity of `rx_buffer`
+ * @param chip_number - The chip select number to activate
+ * @param addr - Address to be read
+ * @param rx_buffer - A buffer where the read data will be stored
+ * @param rx_buffer_len - Integer that indicates the capacity of `rx_buffer`
  * @retval FLASH_ERR_OK on success, < 0 on failure
  */
 FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs_block_t addr, uint8_t *rx_buffer, lfs_size_t rx_buffer_len)
 {
-    // Split address into its 4 bytes
-    uint8_t addr_bytes[4] = {(addr >> 24) & 0xFF, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF};
+    uint8_t read_addr_bytes[4] = {(addr >> 24) & 0xFF, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF};
 
-    // Send Read Command and the data required with it
+    // Define the address where data will be read from in cache register (First 4 bits are dummy bits)
+    // TODO: Is it fine to always have this at 0?
+    uint16_t cache_addr = 0x0000;
+    uint8_t cache_addr_bytes[2] = {(cache_addr >> 8) & 0xFF, cache_addr & 0xFF};
+
+    // Send PAGE READ command
     FLASH_activate_chip_select(chip_number);
-    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *)&FLASH_CMD_READ_4_BYTE_ADDR, 1, FLASH_HAL_TIMEOUT_MS);
+    const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, (uint8_t *) &FLASH_CMD_PAGE_READ, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the command, check why
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -430,7 +526,12 @@ FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number,
 
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
-    const HAL_StatusTypeDef tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *)addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
+
+    // FIXME: Datasheet Page 16 talks about only giving 8-bit dummy values and 16-bit address, not sure how that works
+    // Send Address bytes 
+    const HAL_StatusTypeDef tx_result_2 = HAL_SPI_Transmit(hspi, (uint8_t *) read_addr_bytes, 4, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the bytes, check why
     if (tx_result_2 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -440,7 +541,89 @@ FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number,
 
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
+
+    // Set Chip Select HIGH
+    FLASH_deactivate_chip_select();
+
+    // Buffer to store status register value
+    uint8_t status_reg_buffer[1] = {0};
+
+    // Keep looping as long as device is busy (until the Operation In Progress bit is active [1])
+    const uint32_t start_loop_time_ms = HAL_GetTick();
+    while (1)
+    {
+        const FLASH_error_enum_t read_status_result = FLASH_read_status_register(hspi, chip_number, status_reg_buffer);
+        if (read_status_result != FLASH_ERR_OK) {
+            FLASH_deactivate_chip_select();
+            return read_status_result;
+        }
+
+        if ((status_reg_buffer[0] & FLASH_SR1_WRITE_IN_PROGRESS_MASK) == 0) {
+            // Success condition: write in progress has completed.
+            return FLASH_ERR_OK;
+        }
+
+        // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
+        if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_WRITE_TIMEOUT_MS) {
+            DEBUG_uart_print_str("Flash read timeout\n");
+            return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
+        }
+
+        if (FLASH_enable_hot_path_debug_logs) {
+            DEBUG_uart_print_str("DEBUG: status_reg = 0x");
+            DEBUG_uart_print_array_hex(status_reg_buffer, 1);
+            DEBUG_uart_print_str("\n");
+        }
+    }
+    FLASH_deactivate_chip_select();
+
+    // Send READ FROM CACHE command
+    FLASH_activate_chip_select(chip_number);
+    const HAL_StatusTypeDef tx_result_3 = HAL_SPI_Transmit(hspi, (uint8_t *) &FLASH_CMD_READ_FROM_CACHE, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the command, check why
+    if (tx_result_3 != HAL_OK) {
+        FLASH_deactivate_chip_select();
+
+        if (tx_result_3 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
+    }
+
+    // Send cache address bytes 
+    const HAL_StatusTypeDef tx_result_4 = HAL_SPI_Transmit(hspi, (uint8_t *) cache_addr_bytes, 2, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the bytes, check why
+    if (tx_result_4 != HAL_OK) {
+        FLASH_deactivate_chip_select();
+
+        if (tx_result_4 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
+    }
+
+    // Send cache address bytes again just as 2 dummy bytes to use 2 8-bit clock cycles
+    const HAL_StatusTypeDef tx_result_5 = HAL_SPI_Transmit(hspi, (uint8_t *) cache_addr_bytes, 2, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the bytes, check why
+    if (tx_result_5 != HAL_OK) {
+        FLASH_deactivate_chip_select();
+
+        if (tx_result_5 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
+    }
+
+    // Receive the data into the buffer
     const HAL_StatusTypeDef rx_result_1 = HAL_SPI_Receive(hspi, (uint8_t *)rx_buffer, rx_buffer_len, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't receive data, check why
     if (rx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -450,12 +633,44 @@ FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number,
 
         return FLASH_ERR_SPI_RECEIVE_FAILED;
     }
+
+    // Set Chip Select HIGH
     FLASH_deactivate_chip_select();
 
-    // TODO: Haven't yet implemented a way to check any errors while reading data from memory
-    return 0;
+    // TODO: Are there any other errors that can occur while reading?
+    return FLASH_ERR_OK;
 }
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+/**
+ * @brief Checks if the FLASH chip is reachable by checking it's ID
+ * @param hspi - Pointer to the SPI HAL handle
+ * @param chip_number - The chip select number to activate
+ * @retval FLASH_ERR_OK on success, < 0 on failure
+ */
 FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_number)
 {
     // TODO: confirm if this works with the CS2 logical chip on each physical FLASH chip;
@@ -465,9 +680,11 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     uint8_t rx_buffer[5];
     memset(rx_buffer, 0, 5);
 
-    // Transmit the READ_ID_CMD
+    // Send READ ID Command
     FLASH_activate_chip_select(chip_number);
     const HAL_StatusTypeDef tx_result_1 = HAL_SPI_Transmit(hspi, tx_buffer, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the command, check why
     if (tx_result_1 != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -478,8 +695,24 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
         return FLASH_ERR_SPI_TRANSMIT_FAILED;
     }
 
+    // Send the command again just as a dummy byte
+    const HAL_StatusTypeDef tx_result_2 = HAL_SPI_Transmit(hspi, tx_buffer, 1, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't send the command, check why
+    if (tx_result_2 != HAL_OK) {
+        FLASH_deactivate_chip_select();
+
+        if (tx_result_2 == HAL_TIMEOUT) {
+            return FLASH_ERR_SPI_TRANSMIT_TIMEOUT;
+        }
+
+        return FLASH_ERR_SPI_TRANSMIT_FAILED;
+    }
+
     // Receive the response
     const HAL_StatusTypeDef rx_result = HAL_SPI_Receive(hspi, rx_buffer, 5, FLASH_HAL_TIMEOUT_MS);
+
+    // If couldn't receive, checky why
     if (rx_result != HAL_OK) {
         FLASH_deactivate_chip_select();
 
@@ -498,7 +731,7 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     // rx_buffer[2] is 0x20=512 for 512 Mib (mebibits)
     // TODO: maybe check the capacity as well here, esp. in deployment
     uint8_t are_bytes_correct = 0;
-    if (rx_buffer[0] == 0x01 && rx_buffer[1] == 0x02) {
+    if (rx_buffer[0] == 0x2C && rx_buffer[1] == 0x14) {
         DEBUG_uart_print_str("SUCCESS: FLASH_is_reachable received IDs: ");
         are_bytes_correct = 1;
     } else {
@@ -511,7 +744,7 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
 
     if (!are_bytes_correct) {
         // error: IDs don't match
-        return 3;
+        return FLASH_ERR_UNKNOWN;
     }
-    return 0; // success
+    return FLASH_ERR_OK; // success
 }

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -795,14 +795,14 @@ FLASH_error_enum_t FLASH_read_data(SPI_HandleTypeDef *hspi, uint8_t chip_number,
 
     // Set Chip Select HIGH
     FLASH_deactivate_chip_select();
-
+/*
     DEBUG_uart_print_str("Read data: \n");
     DEBUG_uart_print_array_hex(rx_buffer, rx_buffer_len);
     DEBUG_uart_print_str("\n");
     DEBUG_uart_print_str("Length of data read: ");
     DEBUG_uart_print_uint32((uint32_t)rx_buffer_len);
     DEBUG_uart_print_str("\n");
-
+*/
     // TODO: Are there any other errors that can occur while reading?
     return FLASH_ERR_OK;
 }
@@ -915,6 +915,12 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     return FLASH_ERR_OK; // success
 }
 
+/**
+ * @brief Resets the NAND flash memory module
+ * @param hspi - Pointer to the SPI HAL handle
+ * @param chip_number - The chip select number to activate
+ * @retval FLASH_ERR_OK on success, <0 on failure
+ */
 FLASH_error_enum_t FLASH_reset(SPI_HandleTypeDef *hspi, uint8_t chip_number)
 {
     FLASH_activate_chip_select(chip_number);

--- a/firmware/Core/Src/littlefs/flash_testing_demos.c
+++ b/firmware/Core/Src/littlefs/flash_testing_demos.c
@@ -13,7 +13,7 @@ void demo_flash_write() {
     uint32_t num_bytes = strlen((char*)bytes_to_write);
 
     for (uint8_t i = 0; i < 2; i++) {
-        FLASH_error_enum_t result = FLASH_write(&hspi1, chip_num, flash_addr, bytes_to_write, num_bytes);
+        FLASH_error_enum_t result = FLASH_write_data(&hspi1, chip_num, flash_addr, bytes_to_write, num_bytes);
         if (result != 0) {
             DEBUG_uart_print_str("Error in FLASH_write\n");
             return;

--- a/firmware/Core/Src/littlefs/littlefs_benchmark.c
+++ b/firmware/Core/Src/littlefs/littlefs_benchmark.c
@@ -15,10 +15,6 @@
 /// @return 0 on success. >0 if there was an error.
 uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len, LFS_benchmark_mode mode) {
     char file_name[100];
-    const char dir_name[] = "benchmark_write_read";
-    // FIXME: check if we care about return value
-    lfs_mkdir(&LFS_filesystem, dir_name);
-
     
     if(mode == LFS_SINGLE_FILE) {
         snprintf(
@@ -27,6 +23,9 @@ uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk
             "benchmark_test.txt"
         );
     } else if(mode == LFS_NEW_FILE) {
+        const char dir_name[] = "benchmark_write_read";
+        // FIXME: check if we care about return value
+        lfs_mkdir(&LFS_filesystem, dir_name);
         snprintf(
             file_name,
             sizeof(file_name),

--- a/firmware/Core/Src/littlefs/littlefs_benchmark.c
+++ b/firmware/Core/Src/littlefs/littlefs_benchmark.c
@@ -14,16 +14,10 @@
 /// @param response_str_len
 /// @param mode Check to see if we are writing to a new file or the same file.
 /// @return 0 on success. >0 if there was an error.
-uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len, LFS_benchmark_mode mode) {
+uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len, LFS_benchmark_mode_enum_t mode) {
     char file_name[100];
     
-    if(mode == LFS_SINGLE_FILE) {
-        snprintf(
-            file_name,
-            sizeof(file_name),
-            "benchmark_test.txt"
-        );
-    } else if(mode == LFS_NEW_FILE) {
+    if(mode == LFS_NEW_FILE) {
         const char dir_name[] = "benchmark_write_read";
         // FIXME: check if we care about return value
         lfs_mkdir(&LFS_filesystem, dir_name);
@@ -33,6 +27,13 @@ uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk
             "%s/benchmark_test_%lu.txt",
             dir_name,
             HAL_GetTick()
+        );
+    } else {
+        // Default to single file mode
+        snprintf(
+            file_name,
+            sizeof(file_name),
+            "benchmark_test.txt"
         );
     }
 

--- a/firmware/Core/Src/littlefs/littlefs_benchmark.c
+++ b/firmware/Core/Src/littlefs/littlefs_benchmark.c
@@ -14,7 +14,18 @@
 /// @param response_str_len 
 /// @return 0 on success. >0 if there was an error.
 uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len) {
-    const char file_name[] = "benchmark_test.txt";
+    const char dir_name[] = "benchmark_write_read";
+    // TODO: check if dir exists first; currently it gives a warning
+    LFS_make_directory(dir_name);
+    
+    char file_name[100];
+    snprintf(
+        file_name,
+        sizeof(file_name),
+        "%s/benchmark_test_%lu.txt",
+        dir_name,
+        HAL_GetTick()
+    );
     response_str[0] = '\0';
 
     uint8_t expected_checksum = 0;

--- a/firmware/Core/Src/littlefs/littlefs_benchmark.c
+++ b/firmware/Core/Src/littlefs/littlefs_benchmark.c
@@ -11,7 +11,8 @@
 /// @param write_chunk_size Number of bytes to write in each chunk.
 /// @param write_chunk_count Number of chunks to write.
 /// @param response_str 
-/// @param response_str_len 
+/// @param response_str_len
+/// @param mode Check to see if we are writing to a new file or the same file.
 /// @return 0 on success. >0 if there was an error.
 uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk_count, char* response_str, uint16_t response_str_len, LFS_benchmark_mode mode) {
     char file_name[100];

--- a/firmware/Core/Src/littlefs/littlefs_driver.c
+++ b/firmware/Core/Src/littlefs/littlefs_driver.c
@@ -21,7 +21,7 @@ int LFS_block_device_read(const struct lfs_config *c, lfs_block_t block, lfs_off
 	return FLASH_read_data(
 		hspi_lfs_ptr,
 		LFS_get_chip_number(block),
-		(((block * c->block_size) + off)/2048),
+		((block * c->block_size) + off)/2048,
 		(uint8_t *)buffer,
 		size
 	);
@@ -37,7 +37,7 @@ int LFS_block_device_prog(const struct lfs_config *c, lfs_block_t block, lfs_off
 	return FLASH_write_data(
 		hspi_lfs_ptr,
 		LFS_get_chip_number(block),
-		(((block * c->block_size) + off)/2048),
+		((block * c->block_size) + off)/2048,
 		(uint8_t *)buffer,
 		size
 	);

--- a/firmware/Core/Src/littlefs/littlefs_driver.c
+++ b/firmware/Core/Src/littlefs/littlefs_driver.c
@@ -21,7 +21,7 @@ int LFS_block_device_read(const struct lfs_config *c, lfs_block_t block, lfs_off
 	return FLASH_read_data(
 		hspi_lfs_ptr,
 		LFS_get_chip_number(block),
-		(block * c->block_size + off),
+		(((block * c->block_size) + off)/2048),
 		(uint8_t *)buffer,
 		size
 	);
@@ -37,7 +37,7 @@ int LFS_block_device_prog(const struct lfs_config *c, lfs_block_t block, lfs_off
 	return FLASH_write_data(
 		hspi_lfs_ptr,
 		LFS_get_chip_number(block),
-		(block * c->block_size + off),
+		(((block * c->block_size) + off)/2048),
 		(uint8_t *)buffer,
 		size
 	);
@@ -53,7 +53,7 @@ int LFS_block_device_erase(const struct lfs_config *c, lfs_block_t block)
 	return FLASH_erase(
 		hspi_lfs_ptr,
 		LFS_get_chip_number(block),
-		block * c->block_size
+		block * FLASH_CHIP_PAGES_PER_BLOCK
 	);
 }
 

--- a/firmware/Core/Src/littlefs/littlefs_driver.c
+++ b/firmware/Core/Src/littlefs/littlefs_driver.c
@@ -34,7 +34,7 @@ int LFS_block_device_read(const struct lfs_config *c, lfs_block_t block, lfs_off
  */
 int LFS_block_device_prog(const struct lfs_config *c, lfs_block_t block, lfs_off_t off, const void *buffer, lfs_size_t size)
 {
-	return FLASH_write(
+	return FLASH_write_data(
 		hspi_lfs_ptr,
 		LFS_get_chip_number(block),
 		(block * c->block_size + off),

--- a/firmware/Core/Src/littlefs/littlefs_driver.c
+++ b/firmware/Core/Src/littlefs/littlefs_driver.c
@@ -21,7 +21,7 @@ int LFS_block_device_read(const struct lfs_config *c, lfs_block_t block, lfs_off
 	return FLASH_read_data(
 		hspi_lfs_ptr,
 		LFS_get_chip_number(block),
-		((block * c->block_size) + off)/2048,
+		((block * c->block_size) + off)/FLASH_MAX_BYTES_PER_PAGE,
 		(uint8_t *)buffer,
 		size
 	);
@@ -37,7 +37,7 @@ int LFS_block_device_prog(const struct lfs_config *c, lfs_block_t block, lfs_off
 	return FLASH_write_data(
 		hspi_lfs_ptr,
 		LFS_get_chip_number(block),
-		((block * c->block_size) + off)/2048,
+		((block * c->block_size) + off)/FLASH_MAX_BYTES_PER_PAGE,
 		(uint8_t *)buffer,
 		size
 	);

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -214,10 +214,14 @@ int8_t LFS_make_directory(const char dir_name[])
         return 1;
     }
 
-    int8_t make_dir_result = lfs_mkdir(&LFS_filesystem, dir_name);
+    const int8_t make_dir_result = lfs_mkdir(&LFS_filesystem, dir_name);
     if (make_dir_result < 0)
     {
-        DEBUG_uart_print_str("Error creating directory.\n");
+        LOG_message(
+            LOG_SYSTEM_LFS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+            "Error %d creating directory.",
+            make_dir_result
+        );
         return make_dir_result;
     }
 

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -14,8 +14,9 @@
 // Variables to track LittleFS on Flash Memory Module
 uint8_t LFS_is_lfs_mounted = 0;
 
-#define FLASH_CHIP_PAGE_SIZE_BYTES 2176
-#define FLASH_CHIP_BLOCK_SIZE_BYTES 139264
+// NAND Flash Memory Datasheet https://www.farnell.com/datasheets/3151163.pdf
+#define FLASH_CHIP_PAGE_SIZE_BYTES 2048
+#define FLASH_CHIP_BLOCK_SIZE_BYTES FLASH_CHIP_PAGE_SIZE_BYTES * FLASH_CHIP_PAGES_PER_BLOCK
 #define FLASH_LOOKAHEAD_SIZE 16
 
 // LittleFS Buffers for reading and writing

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -14,8 +14,8 @@
 // Variables to track LittleFS on Flash Memory Module
 uint8_t LFS_is_lfs_mounted = 0;
 
-#define FLASH_CHIP_PAGE_SIZE_BYTES 512
-#define FLASH_CHIP_BLOCK_SIZE_BYTES 262144
+#define FLASH_CHIP_PAGE_SIZE_BYTES 2176
+#define FLASH_CHIP_BLOCK_SIZE_BYTES 139264
 #define FLASH_LOOKAHEAD_SIZE 16
 
 // LittleFS Buffers for reading and writing

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -15,6 +15,7 @@
 uint8_t LFS_is_lfs_mounted = 0;
 
 // NAND Flash Memory Datasheet https://www.farnell.com/datasheets/3151163.pdf
+// Each page is divided into a 2048-byte data storage region, and a 128 bytes spare area (2176 bytes total).
 #define FLASH_CHIP_PAGE_SIZE_BYTES 2048
 #define FLASH_CHIP_BLOCK_SIZE_BYTES FLASH_CHIP_PAGE_SIZE_BYTES * FLASH_CHIP_PAGES_PER_BLOCK
 #define FLASH_LOOKAHEAD_SIZE 16

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -165,7 +165,6 @@ uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_en
         return 3;
     }
 
-    //uint8_t read_buf[max_num_bytes];
     uint32_t num_bytes = (uint32_t)arg_num_bytes;
     FLASH_error_enum_t result = FLASH_read_data(&hspi1, chip_num, flash_addr, read_buf, num_bytes);
 
@@ -177,7 +176,7 @@ uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_en
     }
 
     // Convert read data to hex
-    // FIXME: This can't print whole page of data (2048 bytes)
+    // FIXME: This can't print whole page of data (2048 bytes). Fix so that it can.
     for (uint16_t i = 0; i < num_bytes; i++) {
         snprintf(
             &response_output_buf[strlen(response_output_buf)],

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -10,8 +10,8 @@
 #include <string.h>
 #include <inttypes.h>
 
-uint8_t read_buf[MAX_NUM_BYTES];
-uint8_t bytes_to_write[MAX_NUM_BYTES];
+uint8_t read_buf[FLASH_MAX_BYTES_PER_PAGE];
+uint8_t bytes_to_write[FLASH_MAX_BYTES_PER_PAGE];
 
 /// @brief Telecommand: Read bytes as hex from a flash address
 /// @param args_str No args.
@@ -119,11 +119,11 @@ uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_en
         return 2;
     }
 
-    if (arg_num_bytes > MAX_NUM_BYTES || arg_num_bytes == 0) {
+    if (arg_num_bytes > FLASH_MAX_BYTES_PER_PAGE || arg_num_bytes == 0) {
         snprintf(
             response_output_buf, response_output_buf_len,
             "Invalid number of bytes to read: %lu. Must be 1 to %d.",
-            (uint32_t)arg_num_bytes, MAX_NUM_BYTES); // TODO: fix this cast
+            (uint32_t)arg_num_bytes, FLASH_MAX_BYTES_PER_PAGE); // TODO: fix this cast
         return 3;
     }
 
@@ -172,7 +172,7 @@ uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_e
     const uint8_t arg0_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &chip_num_u64);
     const uint8_t arg1_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 1, &flash_addr_u64);
     const uint8_t arg2_result = TCMD_extract_hex_array_arg(
-        args_str, 2, bytes_to_write, MAX_NUM_BYTES, &num_bytes
+        args_str, 2, bytes_to_write, FLASH_MAX_BYTES_PER_PAGE, &num_bytes
     );
     
     if (arg0_result != 0 || arg1_result != 0 || arg2_result != 0) {

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -156,15 +156,15 @@ uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_en
             FLASH_NUMBER_OF_FLASH_DEVICES - 1);
         return 2;
     }
-/*
-    if (arg_num_bytes > max_num_bytes || arg_num_bytes == 0) {
+
+    if (arg_num_bytes > MAX_NUM_BYTES_TO_READ || arg_num_bytes == 0) {
         snprintf(
             response_output_buf, response_output_buf_len,
             "Invalid number of bytes to read: %lu. Must be 1 to %d.",
-            (uint32_t)arg_num_bytes, max_num_bytes); // TODO: fix this cast
+            (uint32_t)arg_num_bytes, MAX_NUM_BYTES_TO_READ); // TODO: fix this cast
         return 3;
     }
-*/
+
     //uint8_t read_buf[max_num_bytes];
     uint32_t num_bytes = (uint32_t)arg_num_bytes;
     FLASH_error_enum_t result = FLASH_read_data(&hspi1, chip_num, flash_addr, read_buf, num_bytes);
@@ -175,8 +175,9 @@ uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_en
             "Error reading flash: %d", result);
         return 4;
     }
-/*
+
     // Convert read data to hex
+    // FIXME: This can't print whole page of data (2048 bytes)
     for (uint16_t i = 0; i < num_bytes; i++) {
         snprintf(
             &response_output_buf[strlen(response_output_buf)],
@@ -191,7 +192,7 @@ uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_en
                 "\n");
         }
     }
-    */
+
     return 0;
 }
 
@@ -335,6 +336,10 @@ uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const char *args_str, TCMD_Tel
     return result;
 }
 
+/// @brief Telecommand: Reset the flash memory module.
+/// @param args_str 
+/// - Arg 0: Chip Number (CS number) as uint
+/// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_flash_reset(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t chip_num;

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -97,8 +97,6 @@ uint8_t TCMDEXEC_flash_each_is_reachable(const char *args_str, TCMD_TelecommandC
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
-    //const uint16_t max_num_bytes = 256;
-    //const uint16_t max_num_bytes = 2176;
     uint64_t chip_num, flash_addr, arg_num_bytes;
 
     uint8_t arg0_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &chip_num);
@@ -170,8 +168,6 @@ uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_e
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint16_t num_bytes;
     uint64_t chip_num_u64, flash_addr_u64;
-
-    // uint8_t bytes_to_write[MAX_NUM_BYTES];
 
     const uint8_t arg0_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &chip_num_u64);
     const uint8_t arg1_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 1, &flash_addr_u64);

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -202,7 +202,7 @@ uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_e
     uint32_t flash_addr = (uint32_t)flash_addr_u64;
 
 
-    FLASH_error_enum_t result = FLASH_write(&hspi1, chip_num, flash_addr, bytes_to_write, num_bytes);
+    FLASH_error_enum_t result = FLASH_write_data(&hspi1, chip_num, flash_addr, bytes_to_write, num_bytes);
 
     if (result != 0) {
         snprintf(

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -236,7 +236,7 @@ uint8_t TCMDEXEC_fs_benchmark_write_read(const char *args_str, TCMD_TelecommandC
         return 1;
     }
 
-    const int8_t benchmark_result = LFS_benchmark_write_read(arg_write_chunk_size, arg_write_chunk_count, response_output_buf, response_output_buf_len);
+    const int8_t benchmark_result = LFS_benchmark_write_read_single_and_new(arg_write_chunk_size, arg_write_chunk_count, response_output_buf, response_output_buf_len);
     response_output_buf[response_output_buf_len - 1] = '\0'; // ensure null-terminated
 
     if (benchmark_result != 0) {

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -202,12 +202,6 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_IN_PROGRESS,
     },
-    {
-        .tcmd_name = "flash_unblock_block_locks",
-        .tcmd_func = TCMDEXEC_flash_unblock_block_locks,
-        .number_of_args = 1,
-        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
-    },
     // ****************** END SECTION: flash_telecommand_defs ******************
 
     // ****************** SECTION: lfs_telecommand_defs ******************

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -196,6 +196,18 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .number_of_args = 3,
         .readiness_level = TCMD_READINESS_LEVEL_FLIGHT_TESTING,
     },
+    {
+        .tcmd_name = "flash_reset",
+        .tcmd_func = TCMDEXEC_flash_reset,
+        .number_of_args = 1,
+        .readiness_level = TCMD_READINESS_LEVEL_IN_PROGRESS,
+    },
+    {
+        .tcmd_name = "flash_unblock_block_locks",
+        .tcmd_func = TCMDEXEC_flash_unblock_block_locks,
+        .number_of_args = 1,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
     // ****************** END SECTION: flash_telecommand_defs ******************
 
     // ****************** SECTION: lfs_telecommand_defs ******************


### PR DESCRIPTION
Pull Request is based on issue #118. From Saksham's branch, a separate branch was made to work on separately. Flash driver functions are working properly as well as using them with LittleFS.