### PR TITLE
Antenna deployment drivers

### DIFF
--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -31,14 +31,14 @@ static const uint8_t ANT_CMD_REPORT_ANT4_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB7;
 
 uint8_t ANT_CMD_reset();
 uint8_t ANT_CMD_arm_antenna_system();
-uint8_t ANT_CMD_disarm();
+uint8_t ANT_CMD_disarm_antenna_system();
 uint8_t ANT_CMD_deploy_antenna(uint8_t antenna, uint8_t activation_time_seconds);
 uint8_t ANT_CMD_start_automated_sequential_deployment(uint8_t activation_time_seconds);
 uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation_time_seconds);
 uint8_t ANT_CMD_cancel_deployment_system_activation();
 uint8_t ANT_CMD_measure_temp();
 uint8_t ANT_CMD_report_deployment_status(uint8_t response[2]);
-uint8_t report_antenna_deployment_activation_count(uint8_t antenna, uint8_t *response);
-uint8_t report_antenna_deployment_activation_time(uint8_t antenna, uint8_t response[2]);
+uint8_t ANT_CMD_report_antenna_deployment_activation_count(uint8_t antenna, uint8_t *response);
+uint8_t ANT_CMD_report_antenna_deployment_activation_time(uint8_t antenna, uint16_t *result);
 
 #endif /* __INCLUDE_GUARD_ANT_COMMANDS_H__ */

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -29,6 +29,24 @@ static const uint8_t ANT_CMD_REPORT_ANT2_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB5;
 static const uint8_t ANT_CMD_REPORT_ANT3_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB6;
 static const uint8_t ANT_CMD_REPORT_ANT4_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB7;
 
+struct Antenna_deployment_status {
+    int antenna_1_deployed;
+    int antenna_1_deployment_time_limit_reached;
+    int antenna_1_deployment_system_active;
+    int antenna_2_deployed;
+    int antenna_2_deployment_time_limit_reached;
+    int antenna_2_deployment_system_active;
+    int antenna_3_deployed;
+    int antenna_3_deployment_time_limit_reached;
+    int antenna_3_deployment_system_active;
+    int antenna_4_deployed;
+    int antenna_4_deployment_time_limit_reached;
+    int antenna_4_deployment_system_active;
+    int independent_burn;
+    int ignoring_deployment_switches;
+    int antenna_system_armed;
+};
+
 uint8_t ANT_CMD_reset();
 uint8_t ANT_CMD_arm_antenna_system();
 uint8_t ANT_CMD_disarm_antenna_system();
@@ -37,15 +55,11 @@ uint8_t ANT_CMD_start_automated_sequential_deployment(uint8_t activation_time_se
 uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation_time_seconds);
 uint8_t ANT_CMD_cancel_deployment_system_activation();
 uint8_t ANT_CMD_measure_temp();
-uint8_t ANT_CMD_report_deployment_status(uint8_t response[2]);
+uint8_t ANT_CMD_report_deployment_status(struct Antenna_deployment_status *response);
 uint8_t ANT_CMD_report_antenna_deployment_activation_count(uint8_t antenna, uint8_t *response);
 uint8_t ANT_CMD_report_antenna_deployment_activation_time(uint8_t antenna, uint16_t *result);
 
 
-struct Antenna_deployment_status {
-    int is_antenna_1_deployed;
-    int is_antenna_2_deployed;
-    int is_antenna_3_deployed;
-    int is_antenna_4_deployed;
-};
+
+    
 #endif /* __INCLUDE_GUARD_ANT_COMMANDS_H__ */

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -13,13 +13,12 @@ static const uint8_t ANT_CMD_DEPLOY_ANTENNA2 = 0xA2;
 static const uint8_t ANT_CMD_DEPLOY_ANTENNA3 = 0xA3;
 static const uint8_t ANT_CMD_DEPLOY_ANTENNA4 = 0xA4;
 static const uint8_t ANT_CMD_DEPLOY_ALL_ANTENNAS_SEQ = 0xA5;
-static const uint8_t ANT_CMD_DEPLOY_ANTENNA1_OVERIDE = 0xBA;
-static const uint8_t ANT_CMD_DEPLOY_ANTENNA2_OVERIDE = 0xBB;
-static const uint8_t ANT_CMD_DEPLOY_ANTENNA3_OVERIDE = 0xBC;
-static const uint8_t ANT_CMD_DEPLOY_ANTENNA4_OVERIDE = 0xBD;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA1_OVERRIDE = 0xBA;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA2_OVERRIDE = 0xBB;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA3_OVERRIDE = 0xBC;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA4_OVERRIDE = 0xBD;
 static const uint8_t ANT_CMD_CANCEL_DEPLOYMENT = 0xA9;
 static const uint8_t ANT_CMD_MEASURE_TEMP = 0xC0; // Measure the temperature of the antenna controller system
-
 static const uint8_t ANT_CMD_REPORT_DEPLOYMENT_STATUS = 0xC3;
 static const uint8_t ANT_CMD_REPORT_ANT1_DEPLOYMENT_COUNT = 0xB0;
 static const uint8_t ANT_CMD_REPORT_ANT2_DEPLOYMENT_COUNT = 0xB1;
@@ -30,8 +29,13 @@ static const uint8_t ANT_CMD_REPORT_ANT2_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB5;
 static const uint8_t ANT_CMD_REPORT_ANT3_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB6;
 static const uint8_t ANT_CMD_REPORT_ANT4_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB7;
 
+uint8_t ANT_CMD_reset();
 uint8_t ANT_CMD_arm_antenna_system();
-uint8_t ANT_CMD_deploy_antenna1(uint8_t ativation_time_seconds);
+uint8_t ANT_CMD_disarm();
+uint8_t ANT_CMD_deploy_antenna(uint8_t antenna, uint8_t activation_time_seconds);
+uint8_t ANT_CMD_start_automated_sequential_deployment(uint8_t activation_time_seconds);
+uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation_time_seconds);
+uint8_t ANT_CMD_cancel_deployment_system_activation();
 uint8_t ANT_CMD_measure_temp();
 
 #endif /* __INCLUDE_GUARD_ANT_COMMANDS_H__ */

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -5,10 +5,30 @@
 
 /*-----------------------------COMMAND VARIABLES-----------------------------*/
 // All commands in this section refer to the "ISIS.ANTS.UM.001" datasheet by ISISpace
-
+static const uint8_t ANT_CMD_RESET = 0xAA;
 static const uint8_t ANT_CMD_ARM_ANTENNA_SYSTEM = 0xAD; // Arm the antenna deploy system
+static const uint8_t ANT_CMD_DISARM_ANTENNA_SYSTEM = 0xAC;
 static const uint8_t ANT_CMD_DEPLOY_ANTENNA1 = 0xA1; // Deploy antenna 1
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA2 = 0xA2;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA3 = 0xA3;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA4 = 0xA4;
+static const uint8_t ANT_CMD_DEPLOY_ALL_ANTENNAS_SEQ = 0xA5;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA1_OVERIDE = 0xBA;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA2_OVERIDE = 0xBB;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA3_OVERIDE = 0xBC;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA4_OVERIDE = 0xBD;
+static const uint8_t ANT_CMD_CANCEL_DEPLOYMENT = 0xA9;
 static const uint8_t ANT_CMD_MEASURE_TEMP = 0xC0; // Measure the temperature of the antenna controller system
+
+static const uint8_t ANT_CMD_REPORT_DEPLOYMENT_STATUS = 0xC3;
+static const uint8_t ANT_CMD_REPORT_ANT1_DEPLOYMENT_COUNT = 0xB0;
+static const uint8_t ANT_CMD_REPORT_ANT2_DEPLOYMENT_COUNT = 0xB1;
+static const uint8_t ANT_CMD_REPORT_ANT3_DEPLOYMENT_COUNT = 0xB2;
+static const uint8_t ANT_CMD_REPORT_ANT4_DEPLOYMENT_COUNT = 0xB3;
+static const uint8_t ANT_CMD_REPORT_ANT1_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB4;
+static const uint8_t ANT_CMD_REPORT_ANT2_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB5;
+static const uint8_t ANT_CMD_REPORT_ANT3_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB6;
+static const uint8_t ANT_CMD_REPORT_ANT4_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB7;
 
 uint8_t ANT_CMD_arm_antenna_system();
 uint8_t ANT_CMD_deploy_antenna1(uint8_t ativation_time_seconds);

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -37,5 +37,8 @@ uint8_t ANT_CMD_start_automated_sequential_deployment(uint8_t activation_time_se
 uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation_time_seconds);
 uint8_t ANT_CMD_cancel_deployment_system_activation();
 uint8_t ANT_CMD_measure_temp();
+uint8_t ANT_CMD_report_deployment_status(uint16_t *response);
+uint8_t report_antenna_deployment_activation_count(uint8_t antenna, uint8_t *response);
+uint8_t report_antenna_deployment_activation_time(uint8_t antenna, uint16_t *response);
 
 #endif /* __INCLUDE_GUARD_ANT_COMMANDS_H__ */

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -41,4 +41,11 @@ uint8_t ANT_CMD_report_deployment_status(uint8_t response[2]);
 uint8_t ANT_CMD_report_antenna_deployment_activation_count(uint8_t antenna, uint8_t *response);
 uint8_t ANT_CMD_report_antenna_deployment_activation_time(uint8_t antenna, uint16_t *result);
 
+
+struct Antenna_deployment_status {
+    int is_antenna_1_deployed;
+    int is_antenna_2_deployed;
+    int is_antenna_3_deployed;
+    int is_antenna_4_deployed;
+};
 #endif /* __INCLUDE_GUARD_ANT_COMMANDS_H__ */

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -3,31 +3,6 @@
 
 #include <stdint.h>
 
-/*-----------------------------COMMAND VARIABLES-----------------------------*/
-// All commands in this section refer to the "ISIS.ANTS.UM.001" datasheet by ISISpace
-static const uint8_t ANT_CMD_RESET = 0xAA;
-static const uint8_t ANT_CMD_ARM_ANTENNA_SYSTEM = 0xAD; // Arm the antenna deploy system
-static const uint8_t ANT_CMD_DISARM_ANTENNA_SYSTEM = 0xAC;
-static const uint8_t ANT_CMD_DEPLOY_ANTENNA1 = 0xA1; // Deploy antenna 1
-static const uint8_t ANT_CMD_DEPLOY_ANTENNA2 = 0xA2;
-static const uint8_t ANT_CMD_DEPLOY_ANTENNA3 = 0xA3;
-static const uint8_t ANT_CMD_DEPLOY_ANTENNA4 = 0xA4;
-static const uint8_t ANT_CMD_DEPLOY_ALL_ANTENNAS_SEQ = 0xA5;
-static const uint8_t ANT_CMD_DEPLOY_ANTENNA1_OVERRIDE = 0xBA;
-static const uint8_t ANT_CMD_DEPLOY_ANTENNA2_OVERRIDE = 0xBB;
-static const uint8_t ANT_CMD_DEPLOY_ANTENNA3_OVERRIDE = 0xBC;
-static const uint8_t ANT_CMD_DEPLOY_ANTENNA4_OVERRIDE = 0xBD;
-static const uint8_t ANT_CMD_CANCEL_DEPLOYMENT = 0xA9;
-static const uint8_t ANT_CMD_MEASURE_TEMP = 0xC0; // Measure the temperature of the antenna controller system
-static const uint8_t ANT_CMD_REPORT_DEPLOYMENT_STATUS = 0xC3;
-static const uint8_t ANT_CMD_REPORT_ANT1_DEPLOYMENT_COUNT = 0xB0;
-static const uint8_t ANT_CMD_REPORT_ANT2_DEPLOYMENT_COUNT = 0xB1;
-static const uint8_t ANT_CMD_REPORT_ANT3_DEPLOYMENT_COUNT = 0xB2;
-static const uint8_t ANT_CMD_REPORT_ANT4_DEPLOYMENT_COUNT = 0xB3;
-static const uint8_t ANT_CMD_REPORT_ANT1_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB4;
-static const uint8_t ANT_CMD_REPORT_ANT2_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB5;
-static const uint8_t ANT_CMD_REPORT_ANT3_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB6;
-static const uint8_t ANT_CMD_REPORT_ANT4_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB7;
 
 struct Antenna_deployment_status {
     int antenna_1_deployed;
@@ -54,7 +29,7 @@ uint8_t ANT_CMD_deploy_antenna(uint8_t antenna, uint8_t activation_time_seconds)
 uint8_t ANT_CMD_start_automated_sequential_deployment(uint8_t activation_time_seconds);
 uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation_time_seconds);
 uint8_t ANT_CMD_cancel_deployment_system_activation();
-uint8_t ANT_CMD_measure_temp();
+uint8_t ANT_CMD_measure_temp(uint16_t *result);
 uint8_t ANT_CMD_report_deployment_status(struct Antenna_deployment_status *response);
 uint8_t ANT_CMD_report_antenna_deployment_activation_count(uint8_t antenna, uint8_t *response);
 uint8_t ANT_CMD_report_antenna_deployment_activation_time(uint8_t antenna, uint16_t *result);

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -5,21 +5,21 @@
 
 
 struct Antenna_deployment_status {
-    int antenna_1_deployed;
-    int antenna_1_deployment_time_limit_reached;
-    int antenna_1_deployment_system_active;
-    int antenna_2_deployed;
-    int antenna_2_deployment_time_limit_reached;
-    int antenna_2_deployment_system_active;
-    int antenna_3_deployed;
-    int antenna_3_deployment_time_limit_reached;
-    int antenna_3_deployment_system_active;
-    int antenna_4_deployed;
-    int antenna_4_deployment_time_limit_reached;
-    int antenna_4_deployment_system_active;
-    int independent_burn;
-    int ignoring_deployment_switches;
-    int antenna_system_armed;
+    uint8_t antenna_1_deployed;
+    uint8_t antenna_1_deployment_time_limit_reached;
+    uint8_t antenna_1_deployment_system_active;
+    uint8_t antenna_2_deployed;
+    uint8_t antenna_2_deployment_time_limit_reached;
+    uint8_t antenna_2_deployment_system_active;
+    uint8_t antenna_3_deployed;
+    uint8_t antenna_3_deployment_time_limit_reached;
+    uint8_t antenna_3_deployment_system_active;
+    uint8_t antenna_4_deployed;
+    uint8_t antenna_4_deployment_time_limit_reached;
+    uint8_t antenna_4_deployment_system_active;
+    uint8_t independent_burn;
+    uint8_t ignoring_deployment_switches;
+    uint8_t antenna_system_armed;
 };
 
 uint8_t ANT_CMD_reset();

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -37,8 +37,8 @@ uint8_t ANT_CMD_start_automated_sequential_deployment(uint8_t activation_time_se
 uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation_time_seconds);
 uint8_t ANT_CMD_cancel_deployment_system_activation();
 uint8_t ANT_CMD_measure_temp();
-uint8_t ANT_CMD_report_deployment_status(uint16_t *response);
+uint8_t ANT_CMD_report_deployment_status(uint8_t response[2]);
 uint8_t report_antenna_deployment_activation_count(uint8_t antenna, uint8_t *response);
-uint8_t report_antenna_deployment_activation_time(uint8_t antenna, uint16_t *response);
+uint8_t report_antenna_deployment_activation_time(uint8_t antenna, uint8_t response[2]);
 
 #endif /* __INCLUDE_GUARD_ANT_COMMANDS_H__ */

--- a/firmware/Core/Inc/telecommands/antenna_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/antenna_telecommand_defs.h
@@ -4,13 +4,38 @@
 #include <stdint.h>
 #include "telecommands/telecommand_definitions.h"
 
+uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
 uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_ant_deploy_antenna1(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_disarm(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
+
+
+uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
 
 uint8_t TCMDEXEC_ant_measure_temp(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
+uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
 #endif /* __INCLUDE_GUARD_ANTENNA_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Inc/telecommands/antenna_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/antenna_telecommand_defs.h
@@ -10,7 +10,7 @@ uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t 
 uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_ant_disarm(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
@@ -9,7 +9,7 @@
 #include <stdio.h>
 
 /// @brief Performs a reset of the antenna deployment systems microcontroller 
-/// @return 0 if successful, > 0 if error occurred
+/// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_reset() {
     const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
@@ -22,7 +22,7 @@ uint8_t ANT_CMD_reset() {
 
 //TODO: Some state should be kept when the antenna is armed so that deploy antenna fails when disarmed 
 /// @brief  Arm the antenna deploy system
-/// @return 0 if successful, >0 if error occurred
+/// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_arm_antenna_system() {
     uint8_t cmd_len = 1;
     uint8_t cmd_buf[cmd_len];
@@ -33,7 +33,7 @@ uint8_t ANT_CMD_arm_antenna_system() {
     return comms_err;
 }
 /// @brief Disarms the antenna deploy system
-/// @return 0 if successful, > 0 if error occurred
+/// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_disarm_antenna_system() {
     const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
@@ -47,7 +47,7 @@ uint8_t ANT_CMD_disarm_antenna_system() {
 /// @brief Deploys antenna 
 /// @param antenna The antenna number of the antenna to deploy, this is a number between 1-4.
 /// @param[in] activation_time_seconds Activation time in seconds
-/// @return 0 if successful, >0 if error occurred
+/// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_deploy_antenna(uint8_t antenna, uint8_t activation_time_seconds) {
     const uint8_t cmd_len = 2;
     uint8_t cmd_buf[cmd_len];
@@ -74,9 +74,10 @@ uint8_t ANT_CMD_deploy_antenna(uint8_t antenna, uint8_t activation_time_seconds)
     const uint8_t comms_err = ANT_send_cmd(cmd_buf, cmd_len);
     return comms_err;
 }
+
 /// @brief deploys all antennas one by one automatically
 /// @param activation_time_seconds the maximum activation time for each deployment system in seconds.  
-/// @return 0 if successful, > 0 otherwise. 
+/// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_start_automated_sequential_deployment(uint8_t activation_time_seconds) {
     const uint8_t CMD_BUF_LEN = 2;
     uint8_t cmd_buf[CMD_BUF_LEN];
@@ -88,6 +89,10 @@ uint8_t ANT_CMD_start_automated_sequential_deployment(uint8_t activation_time_se
     return send_status;
 }
 
+/// @brief initiates deployment of the selected antenna, ignoring whether the current status of that antenna is deployed
+/// @param antenna the antenna to deploy 
+/// @param activation_time_seconds the amount of time the deployment system should be active for
+/// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation_time_seconds) {
     const uint8_t CMD_BUF_LEN = 2;
     uint8_t cmd_buf[CMD_BUF_LEN];
@@ -115,6 +120,8 @@ uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation
     return send_status;
 }
 
+/// @brief cancels any active attempts to deploy an antenna
+/// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_cancel_deployment_system_activation() {
     const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
@@ -127,7 +134,7 @@ uint8_t ANT_CMD_cancel_deployment_system_activation() {
 }
 
 /// @brief Measure the temperature of the antenna controller system
-/// @return 0 if successful, >0 if error occurred
+/// @return 0 when the antenna deployment system has received the command, >0 otherwise
 /// @note Upon success, the temperature is printed to the debug UART
 uint8_t ANT_CMD_measure_temp() {
     const uint8_t cmd_len = 1;
@@ -151,7 +158,7 @@ uint8_t ANT_CMD_measure_temp() {
 /// @brief writes 2 bytes of information representing the deployment status of the antennas to the passed buffer,
 ///         information on interpreting the response may be found in the ISIS Antenna System user manual. Doc ID: ISIS.ANTS.UM.001 pg. 42
 /// @param response a two byte buffer where the status information is written to.
-/// @return 0 on success, > 0 on failure.
+/// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_report_deployment_status(uint8_t response[2]) {
     const uint8_t CMD_LEN  = 1;
     uint8_t cmd_buf[CMD_LEN];
@@ -169,7 +176,7 @@ uint8_t ANT_CMD_report_deployment_status(uint8_t response[2]) {
 /// @brief writes the number of times deployment has been attempted (for a specified antenna) in a response buffer.
 /// @param antenna the antenna to check
 /// @param response a 1 byte buffer where the count of attempted deployments will be written
-/// @return 0 on success, > 0 on failure
+/// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_report_antenna_deployment_activation_count(uint8_t antenna, uint8_t *response) {
     const uint8_t CMD_BUFF_SIZE = 1;
     uint8_t cmd_buf[CMD_BUFF_SIZE];
@@ -203,7 +210,7 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_count(uint8_t antenna, uint
 /// @brief writes the cumulative time (in 50ms increments) that the deployment system has been active (for a specified antenna) in a response buffer.
 /// @param antenna the antenna to check. A number between 1-4
 /// @param response a 2 byte buffer where the cumulative deployment time (in 50ms increments) will be written
-/// @return 0 on success, > 0 on failure
+/// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_report_antenna_deployment_activation_time(uint8_t antenna, uint16_t *result) {
     const uint8_t CMD_BUFF_SIZE = 1;
     uint8_t cmd_buf[CMD_BUFF_SIZE];

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
@@ -132,9 +132,96 @@ uint8_t ANT_CMD_measure_temp() {
         comms_err = ANT_get_response(rx_buf, rx_len);
     }
 
-
     DEBUG_uart_print_str("Received raw bytes: ");
     DEBUG_uart_print_array_hex(rx_buf, rx_len);
     DEBUG_uart_print_str("\n");
     return comms_err;
+}
+/// @brief writes 2 bytes of information representing the deployment status of the antennas to the passed buffer,
+///         information on interpereting the response may be found in the ISIS Antenna System user manual. Doc ID: ISIS.ANTS.UM.001 pg. 42
+/// @param response a two byte buffer where the status information is written to.
+/// @return 0 on success, > 0 on failure.
+uint8_t ANT_CMD_report_deployment_status(uint16_t *response) {
+    const uint8_t CMD_LEN  = 1;
+    uint8_t cmd_buf[CMD_LEN];
+
+    cmd_buf[0] = ANT_CMD_REPORT_DEPLOYMENT_STATUS;
+
+    uint8_t status = ant_send_cmd(cmd_buf, CMD_LEN); 
+    
+    if (status == 0) {
+        const uint8_t response_size = 2;
+        // TODO: careful about enidianness!!!
+        status = ANT_get_response(response, response_size);
+    }
+    return status;
+}
+/// @brief writes the number of times deployment has been attempted (for a specified antenna) in a response buffer.
+/// @param antenna the antenna to check
+/// @param response a 1 byte buffer where the count of attempted deployments will be writen
+/// @return 0 on success, > 0 on failure
+uint8_t report_antenna_deployment_activation_count(uint8_t antenna, uint8_t *response) {
+    const uint8_t CMD_BUFF_SIZE = 1;
+    uint8_t cmd_buf[CMD_BUFF_SIZE];
+
+    switch (antenna) {
+        case 1:
+            cmd_buf[0] = ANT_CMD_REPORT_ANT1_DEPLOYMENT_COUNT;
+            break;
+        case 2:
+            cmd_buf[0] = ANT_CMD_REPORT_ANT2_DEPLOYMENT_COUNT;
+            break;
+        case 3:
+            cmd_buf[0] = ANT_CMD_REPORT_ANT3_DEPLOYMENT_COUNT;
+            break;
+        case 4:
+            cmd_buf[0] = ANT_CMD_REPORT_ANT4_DEPLOYMENT_COUNT;
+            break;
+        default:
+            DEBUG_uart_print_str("Invalid choice for antenna: antenna must be between 1-4 inclusive.");
+            return 1;
+    }
+
+    uint8_t status = ant_send_cmd(cmd_buf, CMD_BUFF_SIZE); 
+    if(status == 0) {
+        const uint8_t response_len = 1;
+        // TODO: careful about enidianness!!!
+        status = ANT_get_response(response, response_len);
+    }
+    return status;
+}
+
+/// @brief writes the cumulative time (in 50ms incements) that the deployment system has been active (for a specified antenna) in a response buffer.
+/// @param antenna the antenna to check. A number between 1-4
+/// @param response a 2 byte buffer where the cumulative deployment time (in 50ms increments) will be writen
+/// @return 0 on success, > 0 on failure
+uint8_t report_antenna_deployment_activation_time(uint8_t antenna, uint16_t *response) {
+    const uint8_t CMD_BUFF_SIZE = 1;
+    uint8_t cmd_buf[CMD_BUFF_SIZE];
+
+    switch (antenna) {
+        case 1:
+            cmd_buf[0] = ANT_CMD_REPORT_ANT1_DEPLOYMENT_SYS_ACTIVATION_TIME;
+            break;
+        case 2:
+            cmd_buf[0] = ANT_CMD_REPORT_ANT2_DEPLOYMENT_SYS_ACTIVATION_TIME;
+            break;
+        case 3:
+            cmd_buf[0] = ANT_CMD_REPORT_ANT3_DEPLOYMENT_SYS_ACTIVATION_TIME;
+            break;
+        case 4:
+            cmd_buf[0] = ANT_CMD_REPORT_ANT4_DEPLOYMENT_SYS_ACTIVATION_TIME;
+            break;
+        default:
+            DEBUG_uart_print_str("Invalid choice for antenna: antenna must be between 1-4 inclusive.");
+            return 1;
+    }
+
+    uint8_t status = ant_send_cmd(cmd_buf, CMD_BUFF_SIZE); 
+    if(status == 0) {
+        const uint8_t response_len = 2; 
+        // TODO: careful about enidianness!!!
+        status = ANT_get_response(response, response_len);
+    }
+    return status;
 }

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
@@ -119,7 +119,7 @@ uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation
 /// @return 0 if successful, >0 if error occurred
 /// @note Upon success, the temperature is printed to the debug UART
 uint8_t ANT_CMD_measure_temp() {
-    uint8_t cmd_len = 1;
+    const uint8_t cmd_len = 1;
     uint8_t cmd_buf[cmd_len];
 
     cmd_buf[0] = ANT_CMD_MEASURE_TEMP;
@@ -138,10 +138,10 @@ uint8_t ANT_CMD_measure_temp() {
     return comms_err;
 }
 /// @brief writes 2 bytes of information representing the deployment status of the antennas to the passed buffer,
-///         information on interpereting the response may be found in the ISIS Antenna System user manual. Doc ID: ISIS.ANTS.UM.001 pg. 42
+///         information on interpreting the response may be found in the ISIS Antenna System user manual. Doc ID: ISIS.ANTS.UM.001 pg. 42
 /// @param response a two byte buffer where the status information is written to.
 /// @return 0 on success, > 0 on failure.
-uint8_t ANT_CMD_report_deployment_status(uint16_t *response) {
+uint8_t ANT_CMD_report_deployment_status(uint8_t response[2]) {
     const uint8_t CMD_LEN  = 1;
     uint8_t cmd_buf[CMD_LEN];
 
@@ -151,14 +151,13 @@ uint8_t ANT_CMD_report_deployment_status(uint16_t *response) {
     
     if (status == 0) {
         const uint8_t response_size = 2;
-        // TODO: careful about enidianness!!!
-        status = ANT_get_response((uint8_t *)response, response_size);
+        status = ANT_get_response(response, response_size);
     }
     return status;
 }
 /// @brief writes the number of times deployment has been attempted (for a specified antenna) in a response buffer.
 /// @param antenna the antenna to check
-/// @param response a 1 byte buffer where the count of attempted deployments will be writen
+/// @param response a 1 byte buffer where the count of attempted deployments will be written
 /// @return 0 on success, > 0 on failure
 uint8_t report_antenna_deployment_activation_count(uint8_t antenna, uint8_t *response) {
     const uint8_t CMD_BUFF_SIZE = 1;
@@ -185,17 +184,16 @@ uint8_t report_antenna_deployment_activation_count(uint8_t antenna, uint8_t *res
     uint8_t status = ANT_send_cmd(cmd_buf, CMD_BUFF_SIZE); 
     if(status == 0) {
         const uint8_t response_len = 1;
-        // TODO: careful about enidianness!!!
         status = ANT_get_response(response, response_len);
     }
     return status;
 }
 
-/// @brief writes the cumulative time (in 50ms incements) that the deployment system has been active (for a specified antenna) in a response buffer.
+/// @brief writes the cumulative time (in 50ms increments) that the deployment system has been active (for a specified antenna) in a response buffer.
 /// @param antenna the antenna to check. A number between 1-4
-/// @param response a 2 byte buffer where the cumulative deployment time (in 50ms increments) will be writen
+/// @param response a 2 byte buffer where the cumulative deployment time (in 50ms increments) will be written
 /// @return 0 on success, > 0 on failure
-uint8_t report_antenna_deployment_activation_time(uint8_t antenna, uint16_t *response) {
+uint8_t report_antenna_deployment_activation_time(uint8_t antenna, uint8_t response[2]) {
     const uint8_t CMD_BUFF_SIZE = 1;
     uint8_t cmd_buf[CMD_BUFF_SIZE];
 
@@ -220,8 +218,7 @@ uint8_t report_antenna_deployment_activation_time(uint8_t antenna, uint16_t *res
     uint8_t status = ANT_send_cmd(cmd_buf, CMD_BUFF_SIZE); 
     if(status == 0) {
         const uint8_t response_len = 2; 
-        // TODO: careful about enidianness!!!
-        status = ANT_get_response((uint8_t *)response, response_len);
+        status = ANT_get_response(response, response_len);
     }
     return status;
 }

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
@@ -11,12 +11,12 @@
 /// @brief Performs a reset of the antenna deployment systems microcontroller 
 /// @return 0 if successful, > 0 if error occurred
 uint8_t ANT_CMD_reset() {
-    #define CMD_BUF_LEN 1
+    const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
     cmd_buf[0] = ANT_CMD_RESET;
 
-    const uint8_t send_status = ant_send_cmd(cmd_buf, CMD_BUF_LEN); 
+    const uint8_t send_status = ANT_send_cmd(cmd_buf, CMD_BUF_LEN); 
     return send_status;
 }
 
@@ -34,12 +34,12 @@ uint8_t ANT_CMD_arm_antenna_system() {
 /// @brief Disarms the antenna deploy system
 /// @return 0 if successful, > 0 if error occurred
 uint8_t ANT_CMD_disarm() {
-    #define CMD_BUF_LEN 1
+    const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
     cmd_buf[0] = ANT_CMD_DISARM_ANTENNA_SYSTEM;
 
-    const uint8_t send_status = ant_send_cmd(cmd_buf, CMD_BUF_LEN); 
+    const uint8_t send_status = ANT_send_cmd(cmd_buf, CMD_BUF_LEN); 
     return send_status;
 }
 
@@ -77,18 +77,18 @@ uint8_t ANT_CMD_deploy_antenna(uint8_t antenna, uint8_t activation_time_seconds)
 /// @param activation_time_seconds the maximum activation time for each deployment system in seconds.  
 /// @return 0 if successful, > 0 otherwise. 
 uint8_t ANT_CMD_start_automated_sequential_deployment(uint8_t activation_time_seconds) {
-    #define CMD_BUF_LEN 2
+    const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
     cmd_buf[0] = ANT_CMD_DISARM_ANTENNA_SYSTEM;
     cmd_buf[1] = activation_time_seconds;
 
-    const uint8_t send_status = ant_send_cmd(cmd_buf, CMD_BUF_LEN); 
+    const uint8_t send_status = ANT_send_cmd(cmd_buf, CMD_BUF_LEN); 
     return send_status;
 }
 
 uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation_time_seconds) {
-    #define CMD_BUF_LEN 2
+    const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
     switch (antenna) {
@@ -110,7 +110,7 @@ uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation
     }
     cmd_buf[1] = activation_time_seconds;
 
-    const uint8_t send_status = ant_send_cmd(cmd_buf, CMD_BUF_LEN); 
+    const uint8_t send_status = ANT_send_cmd(cmd_buf, CMD_BUF_LEN); 
     return send_status;
 }
 
@@ -147,12 +147,12 @@ uint8_t ANT_CMD_report_deployment_status(uint16_t *response) {
 
     cmd_buf[0] = ANT_CMD_REPORT_DEPLOYMENT_STATUS;
 
-    uint8_t status = ant_send_cmd(cmd_buf, CMD_LEN); 
+    uint8_t status = ANT_send_cmd(cmd_buf, CMD_LEN); 
     
     if (status == 0) {
         const uint8_t response_size = 2;
         // TODO: careful about enidianness!!!
-        status = ANT_get_response(response, response_size);
+        status = ANT_get_response((uint8_t *)response, response_size);
     }
     return status;
 }
@@ -182,7 +182,7 @@ uint8_t report_antenna_deployment_activation_count(uint8_t antenna, uint8_t *res
             return 1;
     }
 
-    uint8_t status = ant_send_cmd(cmd_buf, CMD_BUFF_SIZE); 
+    uint8_t status = ANT_send_cmd(cmd_buf, CMD_BUFF_SIZE); 
     if(status == 0) {
         const uint8_t response_len = 1;
         // TODO: careful about enidianness!!!
@@ -217,11 +217,11 @@ uint8_t report_antenna_deployment_activation_time(uint8_t antenna, uint16_t *res
             return 1;
     }
 
-    uint8_t status = ant_send_cmd(cmd_buf, CMD_BUFF_SIZE); 
+    uint8_t status = ANT_send_cmd(cmd_buf, CMD_BUFF_SIZE); 
     if(status == 0) {
         const uint8_t response_len = 2; 
         // TODO: careful about enidianness!!!
-        status = ANT_get_response(response, response_len);
+        status = ANT_get_response((uint8_t *)response, response_len);
     }
     return status;
 }

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
@@ -8,6 +8,34 @@
 #include <stdint.h>
 #include <stdio.h>
 
+/*-----------------------------COMMAND VARIABLES-----------------------------*/
+// All commands in this section refer to the "ISIS.ANTS.UM.001" datasheet by ISISpace
+static const uint8_t ANT_CMD_RESET = 0xAA;
+static const uint8_t ANT_CMD_ARM_ANTENNA_SYSTEM = 0xAD; // Arm the antenna deploy system
+static const uint8_t ANT_CMD_DISARM_ANTENNA_SYSTEM = 0xAC;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA1 = 0xA1; // Deploy antenna 1
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA2 = 0xA2;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA3 = 0xA3;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA4 = 0xA4;
+static const uint8_t ANT_CMD_DEPLOY_ALL_ANTENNAS_SEQ = 0xA5;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA1_OVERRIDE = 0xBA;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA2_OVERRIDE = 0xBB;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA3_OVERRIDE = 0xBC;
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA4_OVERRIDE = 0xBD;
+static const uint8_t ANT_CMD_CANCEL_DEPLOYMENT = 0xA9;
+static const uint8_t ANT_CMD_MEASURE_TEMP = 0xC0; // Measure the temperature of the antenna controller system
+static const uint8_t ANT_CMD_REPORT_DEPLOYMENT_STATUS = 0xC3;
+static const uint8_t ANT_CMD_REPORT_ANT1_DEPLOYMENT_COUNT = 0xB0;
+static const uint8_t ANT_CMD_REPORT_ANT2_DEPLOYMENT_COUNT = 0xB1;
+static const uint8_t ANT_CMD_REPORT_ANT3_DEPLOYMENT_COUNT = 0xB2;
+static const uint8_t ANT_CMD_REPORT_ANT4_DEPLOYMENT_COUNT = 0xB3;
+static const uint8_t ANT_CMD_REPORT_ANT1_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB4;
+static const uint8_t ANT_CMD_REPORT_ANT2_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB5;
+static const uint8_t ANT_CMD_REPORT_ANT3_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB6;
+static const uint8_t ANT_CMD_REPORT_ANT4_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB7;
+/*-----------------------------COMMAND VARIABLES-----------------------------*/
+
+
 /// @brief Performs a reset of the antenna deployment systems microcontroller 
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_reset() {
@@ -20,7 +48,7 @@ uint8_t ANT_CMD_reset() {
     return send_status;
 }
 
-//TODO: Some state should be kept when the antenna is armed so that deploy antenna fails when disarmed 
+
 /// @brief  Arm the antenna deploy system
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_arm_antenna_system() {
@@ -32,6 +60,7 @@ uint8_t ANT_CMD_arm_antenna_system() {
     const uint8_t comms_err = ANT_send_cmd(cmd_buf, cmd_len);
     return comms_err;
 }
+
 /// @brief Disarms the antenna deploy system
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_disarm_antenna_system() {
@@ -44,10 +73,10 @@ uint8_t ANT_CMD_disarm_antenna_system() {
     return send_status;
 }
 
-/// @brief Deploys antenna 
+/// @brief activates the deployment system for the selected antenna for the specified amount of time
 /// @param antenna The antenna number of the antenna to deploy, this is a number between 1-4.
-/// @param[in] activation_time_seconds Activation time in seconds
-/// @return 0 when the antenna deployment system has received the command, >0 otherwise
+/// @param[in] activation_time_seconds the amount of time the deployment system should be active for in seconds.
+/// @return 0 when the antenna deployment system has received the command, >0 otherwise.
 uint8_t ANT_CMD_deploy_antenna(uint8_t antenna, uint8_t activation_time_seconds) {
     const uint8_t cmd_len = 2;
     uint8_t cmd_buf[cmd_len];
@@ -75,14 +104,14 @@ uint8_t ANT_CMD_deploy_antenna(uint8_t antenna, uint8_t activation_time_seconds)
     return comms_err;
 }
 
-/// @brief deploys all antennas one by one automatically
-/// @param activation_time_seconds the maximum activation time for each deployment system in seconds.  
+/// @brief deploys all antennas one by one sequentially.
+/// @param activation_time_seconds the amount of time the deployment system for each antenna should be active for in seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_start_automated_sequential_deployment(uint8_t activation_time_seconds) {
     const uint8_t CMD_BUF_LEN = 2;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
-    cmd_buf[0] = ANT_CMD_DISARM_ANTENNA_SYSTEM;
+    cmd_buf[0] = ANT_CMD_DEPLOY_ALL_ANTENNAS_SEQ;
     cmd_buf[1] = activation_time_seconds;
 
     const uint8_t send_status = ANT_send_cmd(cmd_buf, CMD_BUF_LEN); 
@@ -91,8 +120,8 @@ uint8_t ANT_CMD_start_automated_sequential_deployment(uint8_t activation_time_se
 
 /// @brief initiates deployment of the selected antenna, ignoring whether the current status of that antenna is deployed
 /// @param antenna the antenna to deploy 
-/// @param activation_time_seconds the amount of time the deployment system should be active for
-/// @return 0 when the antenna deployment system has received the command, >0 otherwise
+/// @param activation_time_seconds the amount of time the deployment system should be active for in seconds.
+/// @return 0 when the antenna deployment system has received the command, >0 otherwise.
 uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation_time_seconds) {
     const uint8_t CMD_BUF_LEN = 2;
     uint8_t cmd_buf[CMD_BUF_LEN];
@@ -127,16 +156,17 @@ uint8_t ANT_CMD_cancel_deployment_system_activation() {
     uint8_t cmd_buf[CMD_BUF_LEN];
 
     cmd_buf[0] = ANT_CMD_CANCEL_DEPLOYMENT;
-    
 
     const uint8_t send_status = ANT_send_cmd(cmd_buf, CMD_BUF_LEN); 
     return send_status;
 }
 
-/// @brief Measure the temperature of the antenna controller system
-/// @return 0 when the antenna deployment system has received the command, >0 otherwise
-/// @note Upon success, the temperature is printed to the debug UART
-uint8_t ANT_CMD_measure_temp() {
+//TODO: validate this is working correctly
+/// @brief Measures the temperature at the antenna controller system.
+/// @param result a pointer to a 16 bit unsigned integer where the temperature measurement is written. Refer to the 
+/// "ISIS.ANTS.UM.001" datasheet by ISISpace for information on interpreting this measurement
+/// @return 0 when the antenna deployment system has received the command, > 0 otherwise.
+uint8_t ANT_CMD_measure_temp(uint16_t *result) {
     const uint8_t cmd_len = 1;
     uint8_t cmd_buf[cmd_len];
 
@@ -148,11 +178,8 @@ uint8_t ANT_CMD_measure_temp() {
     uint8_t comms_err = ANT_send_cmd(cmd_buf, cmd_len);
     if (comms_err == 0) {
         comms_err = ANT_get_response(rx_buf, rx_len);
+        *result = (rx_buf[1] << 8) | rx_buf[0];
     }
-
-    DEBUG_uart_print_str("Received raw bytes: ");
-    DEBUG_uart_print_array_hex(rx_buf, rx_len);
-    DEBUG_uart_print_str("\n");
     return comms_err;
 }
 
@@ -163,6 +190,7 @@ static uint8_t extract_bit(uint8_t byte, uint8_t position) {return byte >> posit
 ///         information on interpreting the response may be found in the ISIS Antenna System user manual. Doc ID: ISIS.ANTS.UM.001 pg. 42
 /// @param response a two byte buffer where the status information is written to.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
+/// @note data written to the response struct is only valid if 0 was returned. One should check this before using the response.
 uint8_t ANT_CMD_report_deployment_status(struct Antenna_deployment_status *response) {
     const uint8_t CMD_LEN  = 1;
     uint8_t cmd_buf[CMD_LEN];
@@ -202,6 +230,7 @@ uint8_t ANT_CMD_report_deployment_status(struct Antenna_deployment_status *respo
 /// @param antenna the antenna to check
 /// @param response a 1 byte buffer where the count of attempted deployments will be written
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
+/// @note data written to the response buffer is only valid if 0 was returned. One should check this before using the response.
 uint8_t ANT_CMD_report_antenna_deployment_activation_count(uint8_t antenna, uint8_t *response) {
     const uint8_t CMD_BUFF_SIZE = 1;
     uint8_t cmd_buf[CMD_BUFF_SIZE];
@@ -234,8 +263,9 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_count(uint8_t antenna, uint
 
 /// @brief writes the cumulative time (in 50ms increments) that the deployment system has been active (for a specified antenna) in a response buffer.
 /// @param antenna the antenna to check. A number between 1-4
-/// @param response a 2 byte buffer where the cumulative deployment time (in 50ms increments) will be written
+/// @param response a 2 byte buffer where the cumulative deployment time (in 50ms increments) will be written. divide the response by 20 to get seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
+/// @note data written to the result buffer is only valid if 0 was returned. One should check this before using the result.
 uint8_t ANT_CMD_report_antenna_deployment_activation_time(uint8_t antenna, uint16_t *result) {
     const uint8_t CMD_BUFF_SIZE = 1;
     uint8_t cmd_buf[CMD_BUFF_SIZE];
@@ -264,10 +294,7 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_time(uint8_t antenna, uint1
         uint8_t response[2];
         status = ANT_get_response(response, response_len);
 
-        *result = response[0] + (response[1] << 8);
-        // time is reported in increments of 50ms, divide by 20 to get seconds
-        *result = *result / 20;
+        *result = (response[1] << 8) | response[0];
     }
     return status;
 }
-

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
@@ -8,6 +8,18 @@
 #include <stdint.h>
 #include <stdio.h>
 
+/// @brief Performs a reset of the antenna deployment systems microcontroller 
+/// @return 0 if successful, > 0 if error occurred
+uint8_t ANT_CMD_reset() {
+    #define CMD_BUF_LEN 1
+    uint8_t cmd_buf[CMD_BUF_LEN];
+
+    cmd_buf[0] = ANT_CMD_RESET;
+
+    const uint8_t send_status = ant_send_cmd(cmd_buf, CMD_BUF_LEN); 
+    return send_status;
+}
+
 /// @brief  Arm the antenna deploy system
 /// @return 0 if successful, >0 if error occurred
 uint8_t ANT_CMD_arm_antenna_system() {
@@ -19,20 +31,89 @@ uint8_t ANT_CMD_arm_antenna_system() {
     const uint8_t comms_err = ANT_send_cmd(cmd_buf, cmd_len);
     return comms_err;
 }
+/// @brief Disarms the antenna deploy system
+/// @return 0 if successful, > 0 if error occurred
+uint8_t ANT_CMD_disarm() {
+    #define CMD_BUF_LEN 1
+    uint8_t cmd_buf[CMD_BUF_LEN];
 
-/// @brief Deploys antenna 1
+    cmd_buf[0] = ANT_CMD_DISARM_ANTENNA_SYSTEM;
+
+    const uint8_t send_status = ant_send_cmd(cmd_buf, CMD_BUF_LEN); 
+    return send_status;
+}
+
+/// @brief Deploys antenna 
+/// @param antenna The antenna number of the antenna to deploy, this is a number between 1-4.
 /// @param[in] activation_time_seconds Activation time in seconds
 /// @return 0 if successful, >0 if error occurred
-uint8_t ANT_CMD_deploy_antenna1(uint8_t activation_time_seconds) {
-    uint8_t cmd_len = 2;
+uint8_t ANT_CMD_deploy_antenna(uint8_t antenna, uint8_t activation_time_seconds) {
+    const uint8_t cmd_len = 2;
     uint8_t cmd_buf[cmd_len];
 
-    cmd_buf[0] = ANT_CMD_DEPLOY_ANTENNA1;
+    switch (antenna) {
+        case 1:
+            cmd_buf[0] = ANT_CMD_DEPLOY_ANTENNA1;
+            break;
+        case 2:
+            cmd_buf[0] = ANT_CMD_DEPLOY_ANTENNA2;
+            break;
+        case 3:
+            cmd_buf[0] = ANT_CMD_DEPLOY_ANTENNA3;
+            break;
+        case 4:
+            cmd_buf[0] = ANT_CMD_DEPLOY_ANTENNA4;
+            break;
+        default:
+            DEBUG_uart_print_str("Invalid choice for antenna: antenna must be between 1-4 inclusive.");
+            return 1;
+    }
     cmd_buf[1] = activation_time_seconds;
 
     const uint8_t comms_err = ANT_send_cmd(cmd_buf, cmd_len);
     return comms_err;
 }
+/// @brief deploys all antennas one by one automatically
+/// @param activation_time_seconds the maximum activation time for each deployment system in seconds.  
+/// @return 0 if successful, > 0 otherwise. 
+uint8_t ANT_CMD_start_automated_sequential_deployment(uint8_t activation_time_seconds) {
+    #define CMD_BUF_LEN 2
+    uint8_t cmd_buf[CMD_BUF_LEN];
+
+    cmd_buf[0] = ANT_CMD_DISARM_ANTENNA_SYSTEM;
+    cmd_buf[1] = activation_time_seconds;
+
+    const uint8_t send_status = ant_send_cmd(cmd_buf, CMD_BUF_LEN); 
+    return send_status;
+}
+
+uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation_time_seconds) {
+    #define CMD_BUF_LEN 2
+    uint8_t cmd_buf[CMD_BUF_LEN];
+
+    switch (antenna) {
+        case 1:
+            cmd_buf[0] = ANT_CMD_DEPLOY_ANTENNA1_OVERRIDE;
+            break;
+        case 2:
+            cmd_buf[0] = ANT_CMD_DEPLOY_ANTENNA2_OVERRIDE;
+            break;
+        case 3:
+            cmd_buf[0] = ANT_CMD_DEPLOY_ANTENNA3_OVERRIDE;
+            break;
+        case 4:
+            cmd_buf[0] = ANT_CMD_DEPLOY_ANTENNA4_OVERRIDE;
+            break;
+        default:
+            DEBUG_uart_print_str("Invalid choice for antenna: antenna must be between 1-4 inclusive.");
+            return 1;
+    }
+    cmd_buf[1] = activation_time_seconds;
+
+    const uint8_t send_status = ant_send_cmd(cmd_buf, CMD_BUF_LEN); 
+    return send_status;
+}
+
 
 /// @brief Measure the temperature of the antenna controller system
 /// @return 0 if successful, >0 if error occurred

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
@@ -161,7 +161,6 @@ uint8_t ANT_CMD_cancel_deployment_system_activation() {
     return send_status;
 }
 
-//TODO: validate this is working correctly
 /// @brief Measures the temperature at the antenna controller system.
 /// @param result a pointer to a 16 bit unsigned integer where the temperature measurement is written. Refer to the 
 /// "ISIS.ANTS.UM.001" datasheet by ISISpace for information on interpreting this measurement

--- a/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
@@ -217,14 +217,57 @@ uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, T
 uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     
-    uint8_t response[2];
-    const uint8_t comms_err = ANT_CMD_report_deployment_status(response);
+    struct Antenna_deployment_status response;
+    const uint8_t comms_err = ANT_CMD_report_deployment_status(&response);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: failed to report status.");
         return comms_err;
     }
 
-    snprintf(response_output_buf, response_output_buf_len, "Success, deployment status: %x %x", response[0], response[1]);
+    snprintf(
+        response_output_buf, 
+        response_output_buf_len, 
+        "Success, deployment status ----- \n Antenna 1: %u \n Antenna 2: %u \n Antenna 3: %u \n Antenna 4: %u \n",
+         response.antenna_1_deployed,
+         response.antenna_2_deployed,
+         response.antenna_3_deployed,
+         response.antenna_4_deployed
+        );
+        //remove the newline characters at the end of the strings to get a proper JSON string
+    snprintf(response_output_buf, response_output_buf_len,
+        "{"
+        "\"antenna_1_deployed\": %d,"   "\n"
+        "\"antenna_1_deployment_time_limit_reached\": %d," "\n"
+        "\"antenna_1_deployment_system_active\": %d," "\n"
+        "\"antenna_2_deployed\": %d," "\n"
+        "\"antenna_2_deployment_time_limit_reached\": %d," "\n"
+        "\"antenna_2_deployment_system_active\": %d," "\n"
+        "\"antenna_3_deployed\": %d," "\n"
+        "\"antenna_3_deployment_time_limit_reached\": %d," "\n"
+        "\"antenna_3_deployment_system_active\": %d," "\n"
+        "\"antenna_4_deployed\": %d," "\n"
+        "\"antenna_4_deployment_time_limit_reached\": %d," "\n"
+        "\"antenna_4_deployment_system_active\": %d," "\n"
+        "\"independent_burn\": %d," "\n"
+        "\"ignoring_deployment_switches\": %d," "\n"
+        "\"antenna_system_armed\": %d" "\n"
+        "}",
+        response.antenna_1_deployed,
+        response.antenna_1_deployment_time_limit_reached,
+        response.antenna_1_deployment_system_active,
+        response.antenna_2_deployed,
+        response.antenna_2_deployment_time_limit_reached,
+        response.antenna_2_deployment_system_active,
+        response.antenna_3_deployed,
+        response.antenna_3_deployment_time_limit_reached,
+        response.antenna_3_deployment_system_active,
+        response.antenna_4_deployed,
+        response.antenna_4_deployment_time_limit_reached,
+        response.antenna_4_deployment_system_active,
+        response.independent_burn,
+        response.ignoring_deployment_switches,
+        response.antenna_system_armed
+    );
     return 0;
 }
 

--- a/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
@@ -113,7 +113,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChanne
 
 /// @brief begins deployment of all antennas, one by one.
 /// @param args_str 
-/// Arg 0: Activation time in seconds
+/// - Arg 0: Activation time in seconds
 /// @return returns 0 on success, > 0 otherwise
 uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) 
@@ -273,7 +273,7 @@ uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_Telecom
 
 /// @brief Prints the number of times deployment was attempted on the selected antenna
 /// @param args_str 
-/// Arg 0: the antenna to check, between 1-4 
+/// - Arg 0: the antenna to check, between 1-4 
 /// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -315,7 +315,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args
 
 /// @brief Prints amount of time the deployment system has been active for for the selected antenna
 /// @param args_str 
-/// Arg 0: the antenna to check, between 1-4 
+/// - Arg 0: the antenna to check, between 1-4 
 /// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -359,11 +359,13 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_ant_measure_temp(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
-    const uint8_t comms_err = ANT_CMD_measure_temp();
+    uint16_t result;
+    const uint8_t comms_err = ANT_CMD_measure_temp(&result);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", comms_err);
         return comms_err;
     }
 
+    snprintf(response_output_buf, response_output_buf_len, "Success, Temp measurement: %u", result);
     return 0;
 }

--- a/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
@@ -10,6 +10,9 @@
 #include <string.h>
 #include "inttypes.h"
 
+/// @brief Resets the antenna deployment system's microcontroller
+/// @param args_str no arguments
+/// @return 0 on success, > 0 otherwise
 uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) 
 {
@@ -37,6 +40,9 @@ uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandCh
     return 0;
 }
 
+/// @brief Disarms the antenna system
+/// @param args_str No arguments
+/// @return 0 on success, 0 > otherwise
 uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     const uint8_t status = ANT_CMD_disarm_antenna_system();
@@ -49,7 +55,7 @@ uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_Telecomman
     return 0;
 }
 
-/// @brief  Telecommand: Deploy antenna 
+/// @brief  Telecommand: Initiates deployment of the selected antenna
 /// @param args_str 
 /// - Arg 0: antenna number. between 1-4
 /// - Arg 1: Activation time in seconds
@@ -105,6 +111,10 @@ uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChanne
     return 0;
 }
 
+/// @brief begins deployment of all antennas, one by one.
+/// @param args_str 
+/// Arg 0: Activation time in seconds
+/// @return returns 0 on success, > 0 otherwise
 uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) 
 {
@@ -128,6 +138,11 @@ uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TC
     return 0;
 }
 
+/// @brief  Telecommand: Initiates deployment of the selected antenna, ignoring whether the antennas current status is deployed. 
+/// @param args_str 
+/// - Arg 0: antenna number. between 1-4
+/// - Arg 1: Activation time in seconds
+/// @return 0 on successful communication, >0 on communications error 
 uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
 
@@ -179,6 +194,9 @@ uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_Tel
     return 0;
 }
 
+/// @brief Cancels any active attempts to deploy an antenna
+/// @param args_str No arguments 
+/// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     
@@ -193,6 +211,9 @@ uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, T
 }
 
 
+/// @brief Prints the deployment status of all antennas
+/// @param args_str No arguments 
+/// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     
@@ -207,6 +228,10 @@ uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_Telecom
     return 0;
 }
 
+/// @brief Prints the number of times deployment was attempted on the selected antenna
+/// @param args_str 
+/// Arg 0: the antenna to check, between 1-4 
+/// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t antenna;
@@ -245,6 +270,10 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args
     return 0;
 }
 
+/// @brief Prints amount of time the deployment system has been active for for the selected antenna
+/// @param args_str 
+/// Arg 0: the antenna to check, between 1-4 
+/// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t antenna;

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -372,15 +372,45 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
 
     // ****************** SECTION: antenna_telecommand_defs ******************
     {
+        .tcmd_name = "ant_reset",
+        .tcmd_func = TCMDEXEC_ant_reset,
+        .number_of_args = 0,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+    {
         .tcmd_name = "ant_arm_antenna_system",
         .tcmd_func = TCMDEXEC_ant_arm_antenna_system,
         .number_of_args = 0,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {
-        .tcmd_name = "ant_deploy_antenna1",
-        .tcmd_func = TCMDEXEC_ant_deploy_antenna1,
+        .tcmd_name = "ant_disarm_antenna_system",
+        .tcmd_func = TCMDEXEC_ant_disarm_antenna_system,
+        .number_of_args = 0,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+    {
+        .tcmd_name = "ant_deploy_antenna",
+        .tcmd_func = TCMDEXEC_ant_deploy_antenna,
+        .number_of_args = 2,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+    {
+        .tcmd_name = "ant_start_automated_antenna_deployment",
+        .tcmd_func = TCMDEXEC_ant_start_automated_antenna_deployment,
         .number_of_args = 1,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+    {
+        .tcmd_name = "ant_deploy_antenna_with_override",
+        .tcmd_func = TCMDEXEC_ant_deploy_antenna_with_override,
+        .number_of_args = 2,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+    {
+        .tcmd_name = "ant_cancel_deployment_system_activation",
+        .tcmd_func = TCMDEXEC_ant_cancel_deployment_system_activation,
+        .number_of_args = 0,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {
@@ -388,7 +418,24 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .tcmd_func = TCMDEXEC_ant_measure_temp,
         .number_of_args = 0,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
-    
+    },
+    {
+        .tcmd_name = "ant_report_deployment_status",
+        .tcmd_func = TCMDEXEC_ant_report_deployment_status,
+        .number_of_args = 0,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+    {
+        .tcmd_name = "ant_report_antenna_deployment_activation_count",
+        .tcmd_func = TCMDEXEC_ant_report_antenna_deployment_activation_count,
+        .number_of_args = 1,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+    {
+        .tcmd_name = "ant_report_antenna_deployment_activation_time",
+        .tcmd_func = TCMDEXEC_ant_report_antenna_deployment_activation_time,
+        .number_of_args = 1,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     // ****************** END SECTION: antenna_telecommand_defs ******************
 };


### PR DESCRIPTION
- Test plan is complete. 
- Had a strange issue with the electrical model resetting occasionally. 
- Regardless of this all implemented functions work correctly.  

Sorry for the large pr, i'll try to keep them smaller in the future 🙃 

Testing done as per the test plan.
1. Set all of the switches on the electrical model to the stowed position. 
2. Run “ant_report_deployment_status()”. Ensure fields in the response are 0 at this point. ✅ 
3. Run “ant_arm_antenna_system()”, followed by “ant_report_deployment_status()”. Verify that the “antenna_system_armed” field is now set to 1 ✅ 
4. Run “ant_report_antenna_deployment_activation_count(1)”. Ensure the result is 0. ✅ 
5. Run “ant_report_antenna_deployment_activation_time(1)”. Ensure the result is 0. ✅ 
6. Run “ant_deploy_antenna(1, 10)” the green light corresponding to antenna 1 on the electrical model should now be on. ✅ 
7. While the green light is still flashing, run “ant_report_deployment_status()”. “Antenna_1_deployment_system_active” should now be set to 1. ✅ 
8. After the light goes out, run “ant_report_deployment_status()”. “Antenna_1_deployment_time_limit_reached” should now be set to 1 and “Antenna_1_deployment_system_active” should return to 0 . ✅ 
9. Run “ant_report_antenna_deployment_activation_count(1)”. Ensure the result is now 1. ✅ 
10. Run “ant_report_antenna_deployment_activation_time(1)”. Ensure the result is 200. ✅ 
11. Repeat steps 4 - 10 for the remaining 3 antennas . ✅ 
12.Run “ant_measure_temp”. Ensure a number is printed. One can convert this number to a temperature (using a table and formula found at the end of the Antenna System User Manual) to verify it is reasonably close to room temperature. ✅ 
```
measure temp returned 556 which converts to ~28 C
```
13. Run “ant_start_automated_antenna_deployment(5)”. The green light should turn on for 5 seconds then turn off, starting with antenna 1 followed by 2, 3 and 4. ✅ 
14. Run “ant_deploy_antenna(1,60)” followed by “ant_cancel_deployment_system_activation()” The green LED which was turned on by the first command should turn off immediately after transmission of the second command. ✅ 
15. Run  “ant_arm_antenna_system()” followed by “ant_disarm_antenna_system()”. Then run “ant_report_deployment_status()” and ensure “antenna_system_armed” is 0. ✅ 
16. Run “ant_reset()” followed by  “ant_report_deployment_status()”. Ensure all entries are set to 0. ✅ 
17. Now set all of the four switches on the electrical model to the open (deployed) state. ✅ 
18. Run  “ant_arm_antenna_system()” ✅ 
19 Run “ant_report_deployment_status()”. All four antennas should be showing as deployed. ✅ 
20. Run “ant_deploy_antenna(1,10)”. This time the LED should not turn on as the antenna is already marked as deployed. ✅ 
21. Run “ant_deploy_antenna_with_override(1,10). The LED should light up now. ✅ 
Repeat step 21 for the remaining three antennas. ✅ 

