### PR TITLE
Fix timekeeping format bug (#180), update format to `sync+offset_source` for better sorting

### DIFF
--- a/docs/40_Logging.md
+++ b/docs/40_Logging.md
@@ -100,7 +100,7 @@ The system time is stored in "unix timestamp format" (seconds since 1970-01-01).
 
 In the log printouts, each log is shown in the format of the following example:
 ```
-1723331067154_T_0000018056 [TELECOMMAND:NORMAL]: Hello, world!
+1723331067154+0000018056_T [TELECOMMAND:NORMAL]: Hello, world!
 ```
 
 The timestamp on logs is stored in "sync time + source + offset" format. In the example above, the fields are:

--- a/docs/Non-Critical_Notes/Timestamp_Format_Rationale.md
+++ b/docs/Non-Critical_Notes/Timestamp_Format_Rationale.md
@@ -2,7 +2,7 @@
 
 Ensure you've read the [/docs/40_Logging.md](/docs/40_Logging.md) document, which explains the logging timestamp format, before reading this one.
 
-The following example, copied from [a discussion when designing the logging system](https://github.com/CalgaryToSpace/CTS-SAT-1-OBC-Firmware/pull/106#discussion_r1685270996), provides an example of why the sync+source+offset timestamp format is useful.
+The following example, copied from [a discussion when designing the logging system](https://github.com/CalgaryToSpace/CTS-SAT-1-OBC-Firmware/pull/106#discussion_r1685270996), provides an example of why the sync+offset+source timestamp format is useful.
 
 ## Example
 
@@ -15,67 +15,67 @@ The following example, copied from [a discussion when designing the logging syst
 1. Satellite powers on at time 1712345000, but assumes it's 1970. 
 2. Over the next 300 seconds, a few logs are generated.
 ```
-0000000000_N_0001 [INFO] Satellite Boots
-0000000000_N_0010 [INFO] Satellite mounts LittleFS.
-0000000000_N_0290 [INFO] Satellite sends radio beacon.
+0000000000+0001_N [INFO] Satellite Boots
+0000000000+0010_N [INFO] Satellite mounts LittleFS.
+0000000000+0290_N [INFO] Satellite sends radio beacon.
 ```
 3. A telecommand timesync happens, and sets the time to `1712345300`.
 4. The satellite logs the time sync:
 ```
-1712345300_T_0001 [INFO] Satellite time synced via telecommand to 1712345300 sec since 1970.
+1712345300+0001_T [INFO] Satellite time synced via telecommand to 1712345300 sec since 1970.
 ```
 5. 500 real seconds pass. The satellite clock ticks fast, and thinks 510 secs pass (this would normally be a huge anomaly, but pretend it's a small discrepancy).
 ```
-1712345300_T_0511 [INFO] A cool action happened and a log message was made
+1712345300+0511_T [INFO] A cool action happened and a log message was made
 ```
 6. A second later, a telecommand syncs the time.
 ```
-1712345801_T_0001 [INFO] Satellite time synced via telecommand to 1712345801 sec since 1970
+1712345801+0001_T [INFO] Satellite time synced via telecommand to 1712345801 sec since 1970
 ```
 7. Observe: Time from Log 5 is 1712345811, and time from log 6 is 1712345802 (when summing the sync+offset). It would seem as though time has "gone backwards", if not for the 2-part logging. However, we can clearly see that the situation is actually just that the clock was running about 10 seconds fast over the 500 secs between syncs, by sorting first by the sync time and then by the offset in the ground station log viewer software (or perhaps Excel haha). This is the non-problematic example of clock drift, and should not generate a warning, as we've designed the logging architecture to handle it.
 8. At real time 1712346000, a new operator comes on shift. This operator is really excited, but has fat fingers, and sends a sync command to 1719346000. This is a big jump forward, but it happens anyway. A warning about a large time shift is logged, but the operator misses it. 
 ```
-1719346000_T_0001 [INFO] Satellite time synced via telecommand to 1719346000 sec since 1970
-1719346000_T_0001 [WARNING] Satellite observed a large time shift during the resync (this warning is not yet implement, but should be)
+1719346000+0001_T [INFO] Satellite time synced via telecommand to 1719346000 sec since 1970
+1719346000+0001_T [WARNING] Satellite observed a large time shift during the resync (this warning is not yet implement, but should be)
 ```
 9. The satellite logs some telemetry/routine actions over the next 200 seconds.
 ```
-1719346000_T_0003 [INFO] Routine action 1
-1719346000_T_0020 [INFO] Routine action 2
-1719346000_T_0200 [INFO] Routine action 2
+1719346000+0003_T [INFO] Routine action 1
+1719346000+0020_T [INFO] Routine action 2
+1719346000+0200_T [INFO] Routine action 2
 ```
 10. At real time 1712346200, a periodic resync is performed, this time more carefully. 
 ```
-1712346200_T_0001 [INFO] Satellite time synced via telecommand to 1712346200 sec since 1970
-1712346200_T_0001 [WARNING] Satellite observed a large time shift during the resync (this warning is not yet implement, but should be)
-1712346200_T_0001 [WARNING] (my warning) Setting current time to before the last sync.
+1712346200+0001_T [INFO] Satellite time synced via telecommand to 1712346200 sec since 1970
+1712346200+0001_T [WARNING] Satellite observed a large time shift during the resync (this warning is not yet implement, but should be)
+1712346200+0001_T [WARNING] (my warning) Setting current time to before the last sync.
 ```
 11. Another 200 seconds pass, and some routine non-telecommand actions on the satellite are logged.
 ```
-1712346200_T_0010 [INFO] Routine action 10
-1712346200_T_0020 [INFO] Routine action 11
-1712346200_T_0030 [INFO] Routine action 12
+1712346200+0010_T [INFO] Routine action 10
+1712346200+0020_T [INFO] Routine action 11
+1712346200+0030_T [INFO] Routine action 12
 ```
 12. Three days pass. Another operator wants to look at the logs from the past three days, and downlinks them. Due to the lossy nature of the communication link, and automatic repeat requests, the order of the logs is mixed up. Naturally, the logs are re-sorted on the ground using their timestamps.  Sorted, the logs look like:
 
 ```
-0000000000_N_0001 [INFO] Satellite Boots
-0000000000_N_0010 [INFO] Satellite mounts LittleFS.
-0000000000_N_0290 [INFO] Satellite sends radio beacon.
-1712345300_T_0001 [INFO] Satellite time synced via telecommand to 1712345300 sec since 1970.
-1712345300_T_0511 [INFO] A cool action happened and a log message was made
-1712345801_T_0001 [INFO] Satellite time synced via telecommand to 1712345801 sec since 1970
-1712346200_T_0001 [INFO] Satellite time synced via telecommand to 1712346200 sec since 1970
-1712346200_T_0001 [WARNING] (my warning) Setting current time to before the last sync.
-1712346200_T_0001 [WARNING] Satellite observed a large time shift during the resync (this warning is not yet implement, but should be)
-1712346200_T_0010 [INFO] Routine action 10
-1712346200_T_0020 [INFO] Routine action 11
-1712346200_T_0030 [INFO] Routine action 12
-1719346000_T_0001 [INFO] Satellite time synced via telecommand to 1719346000 sec since 1970
-1719346000_T_0001 [WARNING] Satellite observed a large time shift during the resync (this warning is not yet implement, but should be)
-1719346000_T_0003 [INFO] Routine action 1
-1719346000_T_0020 [INFO] Routine action 2
-1719346000_T_0200 [INFO] Routine action 2
+0000000000+0001_N [INFO] Satellite Boots
+0000000000+0010_N [INFO] Satellite mounts LittleFS.
+0000000000+0290_N [INFO] Satellite sends radio beacon.
+1712345300+0001_T [INFO] Satellite time synced via telecommand to 1712345300 sec since 1970.
+1712345300+0511_T [INFO] A cool action happened and a log message was made
+1712345801+0001_T [INFO] Satellite time synced via telecommand to 1712345801 sec since 1970
+1712346200+0001_T [INFO] Satellite time synced via telecommand to 1712346200 sec since 1970
+1712346200+0001_T [WARNING] (my warning) Setting current time to before the last sync.
+1712346200+0001_T [WARNING] Satellite observed a large time shift during the resync (this warning is not yet implement, but should be)
+1712346200+0010_T [INFO] Routine action 10
+1712346200+0020_T [INFO] Routine action 11
+1712346200+0030_T [INFO] Routine action 12
+1719346000+0001_T [INFO] Satellite time synced via telecommand to 1719346000 sec since 1970
+1719346000+0001_T [WARNING] Satellite observed a large time shift during the resync (this warning is not yet implement, but should be)
+1719346000+0003_T [INFO] Routine action 1
+1719346000+0020_T [INFO] Routine action 2
+1719346000+0200_T [INFO] Routine action 2
 ```
 
 See that Routine Actions 1,2,3 appear to have happened _after_ 10,11,12. When analyzing the logs, we see the `Setting current time to before the last sync.` message, which gives a hint that the logs are likely out-of-order due to that time sync. 

--- a/firmware/Core/Inc/timekeeping/timekeeping.h
+++ b/firmware/Core/Inc/timekeeping/timekeeping.h
@@ -1,15 +1,16 @@
-#ifndef __INCLUDE_GUARD__TIMEKEEPING_H_
-#define __INCLUDE_GUARD__TIMEKEEPING_H_
+#ifndef INCLUDE_GUARD__TIMEKEEPING_H_
+#define INCLUDE_GUARD__TIMEKEEPING_H_
 
 #include <stdint.h>
 #include <stdlib.h>
 
-#define TIM_EPOCH_DECIMAL_STRING_LEN 14
+#define TIM_EPOCH_DECIMAL_STRING_LEN 13
 
 typedef enum TIM_SYNC_SOURCE {
     TIM_SOURCE_NONE = 0,
     TIM_SOURCE_GNSS,
-    TIM_SOURCE_TELECOMMAND,
+    TIM_SOURCE_TELECOMMAND_ABSOLUTE,
+    TIM_SOURCE_TELECOMMAND_CORRECTION,
 } TIM_sync_source_t;
 
 uint32_t TIM_get_current_system_uptime_ms(void);
@@ -18,11 +19,10 @@ uint64_t TIM_get_current_unix_epoch_time_ms();
 
 void TIM_get_timestamp_string(char *log_str, size_t max_len); 
 void TIM_get_timestamp_string_datetime(char *log_str, size_t max_len);
-char TIM_synchronization_source_letter(TIM_sync_source_t source);
-void TIM_epoch_ms_to_decimal_string(char *str, size_t len);
+char TIME_sync_source_enum_to_letter_char(TIM_sync_source_t source);
 
 extern uint64_t TIM_unix_epoch_time_at_last_time_resync_ms;
 extern uint32_t TIM_system_uptime_at_last_time_resync_ms;
 extern TIM_sync_source_t TIM_last_synchronization_source;
 
-#endif // __INCLUDE_GUARD__TIMEKEEPING_H_
+#endif // INCLUDE_GUARD__TIMEKEEPING_H_

--- a/firmware/Core/Inc/transforms/arrays.h
+++ b/firmware/Core/Inc/transforms/arrays.h
@@ -6,6 +6,7 @@
 int16_t GEN_get_index_of_substring_in_array(const char *haystack_arr, int16_t haystack_arr_len, const char *needle_str);
 
 void GEN_uint64_to_str(uint64_t value, char *buffer);
+void GEN_uint64_to_padded_str(uint64_t value, uint8_t padding_len, char *buffer);
 
 uint8_t GEN_hex_str_to_byte_array(const char *hex_str, uint8_t output_byte_array[],
     uint16_t output_byte_array_size, uint16_t *output_byte_array_len);

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -609,7 +609,7 @@ uint8_t TCMDEXEC_core_system_stats(const char *args_str, TCMD_TelecommandChannel
         time_of_last_tcmd_sent_ms_string, // time_of_last_tcmd_sent_ms
         TCMD_total_tcmd_queued_count, // total_tcmd_count
         LFS_is_lfs_mounted, // is_lfs_mounted
-        TIM_synchronization_source_letter(TIM_last_synchronization_source), // last_time_sync_source
+        TIME_sync_source_enum_to_letter_char(TIM_last_synchronization_source), // last_time_sync_source
         STM32_reset_cause_name // reboot_reason
     ); 
 

--- a/firmware/Core/Src/telecommands/timekeeping_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/timekeeping_telecommand_defs.c
@@ -25,7 +25,9 @@ uint8_t TCMDEXEC_set_system_time(const char *args_str, TCMD_TelecommandChannel_e
     if (result != 0) {
         return 1;
     }
-    TIM_set_current_unix_epoch_time_ms(ms, TIM_SOURCE_TELECOMMAND);
+    TIM_set_current_unix_epoch_time_ms(
+        ms, TIM_SOURCE_TELECOMMAND_ABSOLUTE
+    );
     snprintf(response_output_buf, response_output_buf_len, "Updated system time");
     return 0;
 }
@@ -45,7 +47,10 @@ uint8_t TCMDEXEC_correct_system_time(const char *args_str, TCMD_TelecommandChann
         return 1;
     }
 
-    TIM_set_current_unix_epoch_time_ms(TIM_get_current_unix_epoch_time_ms()+correction_time_ms, TIM_SOURCE_TELECOMMAND);
+    TIM_set_current_unix_epoch_time_ms(
+        TIM_get_current_unix_epoch_time_ms() + correction_time_ms,
+        TIM_SOURCE_TELECOMMAND_CORRECTION
+    );
     snprintf(response_output_buf, response_output_buf_len, "Updated system time");
     
     return 0;

--- a/firmware/Core/Src/timekeeping/timekeeping.c
+++ b/firmware/Core/Src/timekeeping/timekeeping.c
@@ -1,5 +1,6 @@
 #include "timekeeping/timekeeping.h"
 #include "debug_tools/debug_uart.h"
+#include "transforms/arrays.h"
 #include "stm32l4xx_hal.h"
 
 #include <stdio.h>
@@ -8,6 +9,9 @@
 #include <time.h>
 
 uint64_t TIM_unix_epoch_time_at_last_time_resync_ms = 0;
+// 13 digits, plus terminator. Represents TIM_unix_epoch_time_at_last_time_resync_ms. Updated every
+// time TIM_unix_epoch_time_at_last_time_resync_ms is updated.
+char TIM_unix_epoch_time_at_last_time_resync_ms_str[14] = "0000000000000";
 uint32_t TIM_system_uptime_at_last_time_resync_ms = 0;
 TIM_sync_source_t TIM_last_synchronization_source = TIM_SOURCE_NONE;
 
@@ -23,14 +27,20 @@ void TIM_set_current_unix_epoch_time_ms(uint64_t current_unix_epoch_time_ms, TIM
     const uint8_t is_this_sync_before_the_last_sync = current_unix_epoch_time_ms < TIM_unix_epoch_time_at_last_time_resync_ms;
 
     // Update the time.
-    TIM_unix_epoch_time_at_last_time_resync_ms = current_unix_epoch_time_ms;
     TIM_system_uptime_at_last_time_resync_ms = HAL_GetTick();
+    TIM_unix_epoch_time_at_last_time_resync_ms = current_unix_epoch_time_ms;
     TIM_last_synchronization_source = source;
+
+    // Convert the time into a string, zero-padded.
+    // Format: 13 digits, plus terminator
+    GEN_uint64_to_padded_str(
+        TIM_unix_epoch_time_at_last_time_resync_ms,
+        TIM_EPOCH_DECIMAL_STRING_LEN,
+        TIM_unix_epoch_time_at_last_time_resync_ms_str
+    );
 
     // Log a warning if the current sync time is before the last sync time.
     if (is_this_sync_before_the_last_sync) {
-        char log_str[TIM_EPOCH_DECIMAL_STRING_LEN];
-        TIM_epoch_ms_to_decimal_string(log_str, TIM_EPOCH_DECIMAL_STRING_LEN);
         DEBUG_uart_print_str("WARNING: setting current time to before the last sync.");
         // TODO: use the logger warning function, and add other data with a format string here.
     }
@@ -44,19 +54,28 @@ uint64_t TIM_get_current_unix_epoch_time_ms() {
 /// @brief Returns a computer-friendly timestamp string. 
 /// @param log_str - Pointer to buffer that stores the log string 
 /// @param max_len - Maximum length of log_str buffer
-/// @detail The string identifies the current Unix time, and the
-/// synchronization source (N - none; G - GNSS/GPS; T - telecommand), 
+/// @detail The string identifies the timestamp of the last time synchronization,
+/// the synchronization source (N - none; G - GNSS/GPS; T - telecommand), 
 /// and the time passed in ms since the last synchronization.
-/// Example: "1719169299720_G_0000042000"
+/// Added together, the two numbers represent the current timestamp in ms.
+/// Example: "1719169299720+0000042000_N"
 void TIM_get_timestamp_string(char *log_str, size_t max_len) {
-
     if (max_len < TIM_EPOCH_DECIMAL_STRING_LEN) {
         return;
     }
-    char source = TIM_synchronization_source_letter(TIM_last_synchronization_source);
-    uint32_t delta_uptime = TIM_get_current_system_uptime_ms() - TIM_system_uptime_at_last_time_resync_ms;
-    TIM_epoch_ms_to_decimal_string(log_str, max_len);
-    snprintf(log_str + TIM_EPOCH_DECIMAL_STRING_LEN - 1, max_len - TIM_EPOCH_DECIMAL_STRING_LEN, "_%c_%010lu", source, delta_uptime); 
+    const char source = TIME_sync_source_enum_to_letter_char(TIM_last_synchronization_source);
+    const uint32_t delta_uptime = (
+        TIM_get_current_system_uptime_ms()
+        - TIM_system_uptime_at_last_time_resync_ms
+    );
+    snprintf(
+        log_str,
+        max_len,
+        "%s+%010lu_%c",
+        TIM_unix_epoch_time_at_last_time_resync_ms_str,
+        delta_uptime,
+        source
+    );
 
     return;
 }
@@ -83,13 +102,13 @@ void TIM_get_timestamp_string(char *log_str, size_t max_len) {
 /// rrr... milliseconds since last time synchronization
 /// Example output: 20240623T180132.142_T_420204
 void TIM_get_timestamp_string_datetime(char *log_str, size_t max_len) {
-    uint64_t epoch = TIM_get_current_unix_epoch_time_ms();
-    time_t seconds = (time_t)(epoch/ 1000U);
-    uint16_t ms = epoch - 1000U * seconds;
+    const uint64_t epoch = TIM_get_current_unix_epoch_time_ms();
+    const time_t seconds = (time_t)(epoch/ 1000U);
+    const uint16_t ms = epoch - 1000U * seconds;
     struct tm *time_info = gmtime(&seconds);
 
-    char source = TIM_synchronization_source_letter(TIM_last_synchronization_source);
-    uint32_t delta_uptime = TIM_get_current_system_uptime_ms() - TIM_system_uptime_at_last_time_resync_ms;
+    const char source = TIME_sync_source_enum_to_letter_char(TIM_last_synchronization_source);
+    const uint32_t delta_uptime = TIM_get_current_system_uptime_ms() - TIM_system_uptime_at_last_time_resync_ms;
     snprintf(
         log_str, 
         max_len, 
@@ -104,89 +123,19 @@ void TIM_get_timestamp_string_datetime(char *log_str, size_t max_len) {
         source,
         delta_uptime
     );
-
-    return;
 }
 
-char TIM_synchronization_source_letter(TIM_sync_source_t source) {
-
-    char source_letter;
+char TIME_sync_source_enum_to_letter_char(TIM_sync_source_t source) {
     switch (TIM_last_synchronization_source) {
         case TIM_SOURCE_GNSS:
-            source_letter = 'G';
-            break;
-        case TIM_SOURCE_TELECOMMAND:
-            source_letter = 'T';
-            break;
+            return 'G';
+        case TIM_SOURCE_TELECOMMAND_ABSOLUTE:
+            return 'T';
+        case TIM_SOURCE_TELECOMMAND_CORRECTION:
+            return 'C';
         case TIM_SOURCE_NONE:
-            source_letter = 'N';
-            break;
-        default:
-            source_letter = 'E';
-            break;
+            return 'N';
     }
 
-    return source_letter;
-}
-
-/// @brief Efficient conversion of the synchronized epoch in ms to a decimal
-/// string
-/// @param str - buffer to store result in 
-/// @param len - size of result buffer 
-/// @detail Strategy: Keep track of the previous large part of ms
-/// This will change rarely, and most of the time only the 9 least significant
-/// decimal digits need to be updated.
-///
-/// 100 years from 1 Jan 2024, the value of ms will be 2_019_686_400_000. 
-/// For the timestamp string, let's set aside 13 digits of the possible 20 for 
-/// an unsigned 64-bit number needed to store ms since the 1970 epoch. 
-///
-/// We use snprintf to print the least-significant digits of ms on every call.
-/// With the "%lu" format string, 32 bits can be printed in one go, i.e. up to
-/// the number 4_294_967_295. We will have to restrict printing the 9
-/// right-most digits with "%09lu", leaving the remaining digits to be
-/// calculated individually.
-///
-/// The remaining digits to the left will have to be printed only every 
-/// 3.4 days.
-///
-/// Characters of ms_digits[] in order of most significant to least:
-///      12 11 10  9        8  7  6  5  4  3  2  1  0 '\0'
-/// Array index
-///       0  1  2  3        4  5  6  7  8  9 10 11 12 13
-/// --  updated at sync  -- |  -- updated every call  -- 
-///      or typically 
-///     every 3.4 days
-void TIM_epoch_ms_to_decimal_string(char *str, size_t len) {
-
-    static uint64_t last_ms_large_part = 0;
-    static char ms_digits[TIM_EPOCH_DECIMAL_STRING_LEN] = "0000000000000";
-
-    uint64_t ms = TIM_get_current_unix_epoch_time_ms();
-    
-    uint32_t ms_small_part = ms % 1000000000;
-
-    // On every call to this function, update the right-most 9 digits
-    snprintf(ms_digits + 4, 10, "%09lu", ms_small_part);
-
-    // Return if there is nothing else to do
-    uint64_t ms_large_part = ms / 1000000000;
-    if (ms_large_part == last_ms_large_part) {
-        snprintf(str, len, "%s", ms_digits);
-        return;
-    }
-
-    // Update the large part, one digit at a time
-    uint8_t digit = 0;
-    uint64_t working_large_part = ms_large_part;
-    for (int8_t d = 3; d >= 0; d--) {
-        digit = working_large_part % 10;
-        // ASCII '0' is 48 (decimal)
-        ms_digits[d] = (char)(48 + digit);
-        working_large_part /= 10;
-    }
-    last_ms_large_part = ms_large_part;
-    snprintf(str, len, "%s", ms_digits);
-    return;
-
+    return '?';
 }

--- a/firmware/Core/Src/transforms/arrays.c
+++ b/firmware/Core/Src/transforms/arrays.c
@@ -63,6 +63,43 @@ void GEN_uint64_to_str(uint64_t value, char *buffer) {
     buffer[index] = '\0';
 }
 
+
+/// @brief Converts a uint64_t to a string, with leading zeros.
+/// @param value The input value to convert.
+/// @param padding_len The expected length of the output string.
+/// @param buffer The output buffer to write the string to. Must be `padding_len` bytes long.
+void GEN_uint64_to_padded_str(uint64_t value, uint8_t padding_len, char *buffer) {
+    // Ensure the buffer is valid and large enough
+    if (buffer == NULL) {
+        return;
+    }
+
+    char temp[32];
+    int index = 0;
+
+    // Handle the case where the value is 0
+    if (value == 0) {
+        temp[index++] = '0';
+    } else {
+        // Convert the uint64_t value to a string in reverse order
+        while (value > 0) {
+            temp[index++] = '0' + (value % 10);
+            value /= 10;
+        }
+    }
+
+    // Add padding if necessary
+    while (index < padding_len) {
+        temp[index++] = '0';
+    }
+
+    // Reverse the string to correct the order and copy to buffer
+    for (int i = 0; i < index; ++i) {
+        buffer[i] = temp[index - i - 1];
+    }
+    buffer[index] = '\0';  // Null-terminate the buffer
+}
+
 /// @brief Converts a hex string to a byte array
 /// @param hex_str  The input hex string. Can be upper or lower case. Can contain spaces and underscores between bytes.
 /// @param output_byte_array Pointer to the output destination byte array.


### PR DESCRIPTION
* Fixed the timekeeping bug, where the first part of timestamps should be the unix timestamp of the last sync, but was displaying the current unix timestamp, per the documentation.

* Updated the format to be `sync+offset` instead of having the source in the middle of the `sync+offset` string.

* Updated the docs to the new re-ordered format.
* Fixes #180.