### PR TITLE
Initialise ADCS CRC8 in main

### DIFF
--- a/firmware/Core/Src/main.c
+++ b/firmware/Core/Src/main.c
@@ -155,7 +155,7 @@ int main(void)
   HAL_Init();
 
   /* USER CODE BEGIN Init */
-
+  ADCS_initialise_crc8_checksum(); // Initialise the ADCS CRC8 checksum (required for ADCS operation)
   /* USER CODE END Init */
 
   /* Configure the system clock */


### PR DESCRIPTION
Initialise ADCS CRC8 in main for correct operation per #190 

(No need to change the TODO; this is all that's needed in main)