### PR TITLE
FreeRTOS Thread to monitor high stack watermarks

### DIFF
--- a/docs/C_Namespaces.md
+++ b/docs/C_Namespaces.md
@@ -21,6 +21,7 @@ following uppercase identifiers to indicate which subsystem/region of code it be
 * `TEST_EXEC_`: unit test and integration test functions
 * `GEN_`: general-purpose functions which don't fit into any other category
 	* For example, byte manipulation functions.
+* `FREERTOS_`: related to FreeRTOS tasks/threads/metadata
 
 ## Satellite Subsystems
 

--- a/docs/Non-Critical_Notes/Deployment_Final_Checks.md
+++ b/docs/Non-Critical_Notes/Deployment_Final_Checks.md
@@ -40,6 +40,7 @@ The following checks involve executing code and/or telecommands.
     GOLDEN_COPY (xrw) : ORIGIN = 0x8100000, LENGTH = 1024K
     ```
     This is the linker script. The length can change.
+5. Ensure all tasks are registered in the `FREERTOS_task_info_struct_t FREERTOS_task_handles_array []` array. Consider a unit test for this check, maybe.
 
 
 ## Management Checks

--- a/firmware/Core/Inc/config/configuration.h
+++ b/firmware/Core/Inc/config/configuration.h
@@ -21,6 +21,9 @@ static const uint8_t CONFIG_MAX_VARIABLE_NAME_LENGTH = 50;
 static const uint8_t CONFIG_MAX_JSON_STRING_LENGTH = UINT8_MAX;
 
 // extern
+extern uint32_t CONFIG_highstack_watermark_percentage_threshold;
+
+// extern
 extern CONFIG_integer_config_entry_t CONFIG_int_config_variables[];
 
 // extern

--- a/firmware/Core/Inc/config/configuration.h
+++ b/firmware/Core/Inc/config/configuration.h
@@ -21,7 +21,7 @@ static const uint8_t CONFIG_MAX_VARIABLE_NAME_LENGTH = 50;
 static const uint8_t CONFIG_MAX_JSON_STRING_LENGTH = UINT8_MAX;
 
 // extern
-extern const uint32_t CONFIG_highstack_watermark_percentage_threshold;
+extern const uint32_t CONFIG_freertos_min_remaining_stack_percent;
 
 // extern
 extern CONFIG_integer_config_entry_t CONFIG_int_config_variables[];

--- a/firmware/Core/Inc/config/configuration.h
+++ b/firmware/Core/Inc/config/configuration.h
@@ -21,7 +21,7 @@ static const uint8_t CONFIG_MAX_VARIABLE_NAME_LENGTH = 50;
 static const uint8_t CONFIG_MAX_JSON_STRING_LENGTH = UINT8_MAX;
 
 // extern
-extern uint32_t CONFIG_highstack_watermark_percentage_threshold;
+extern const uint32_t CONFIG_highstack_watermark_percentage_threshold;
 
 // extern
 extern CONFIG_integer_config_entry_t CONFIG_int_config_variables[];

--- a/firmware/Core/Inc/main.h
+++ b/firmware/Core/Inc/main.h
@@ -60,9 +60,9 @@ extern TIM_HandleTypeDef htim16;
 /* Exported constants --------------------------------------------------------*/
 /* USER CODE BEGIN EC */
 
-extern Task_Info_t task_handles_array [];
+extern Task_Info_t FREERTOS_task_handles_array [];
 
-extern const uint32_t task_handles_array_size;
+extern const uint32_t FREERTOS_task_handles_array_size;
 
 /* USER CODE END EC */
 

--- a/firmware/Core/Inc/main.h
+++ b/firmware/Core/Inc/main.h
@@ -31,6 +31,7 @@ extern "C" {
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
+#include "rtos_tasks/rtos_task_helpers.h"
 
 /* USER CODE END Includes */
 
@@ -58,6 +59,10 @@ extern TIM_HandleTypeDef htim16;
 
 /* Exported constants --------------------------------------------------------*/
 /* USER CODE BEGIN EC */
+
+extern const Task_Info_t task_handles_array [];
+
+extern const uint32_t task_handles_array_size;
 
 /* USER CODE END EC */
 

--- a/firmware/Core/Inc/main.h
+++ b/firmware/Core/Inc/main.h
@@ -60,7 +60,7 @@ extern TIM_HandleTypeDef htim16;
 /* Exported constants --------------------------------------------------------*/
 /* USER CODE BEGIN EC */
 
-extern const Task_Info_t task_handles_array [];
+extern Task_Info_t task_handles_array [];
 
 extern const uint32_t task_handles_array_size;
 

--- a/firmware/Core/Inc/main.h
+++ b/firmware/Core/Inc/main.h
@@ -60,7 +60,7 @@ extern TIM_HandleTypeDef htim16;
 /* Exported constants --------------------------------------------------------*/
 /* USER CODE BEGIN EC */
 
-extern Task_Info_t FREERTOS_task_handles_array [];
+extern FREERTOS_task_info_struct_t FREERTOS_task_handles_array [];
 
 extern const uint32_t FREERTOS_task_handles_array_size;
 

--- a/firmware/Core/Inc/rtos_tasks/rtos_task_helpers.h
+++ b/firmware/Core/Inc/rtos_tasks/rtos_task_helpers.h
@@ -2,6 +2,12 @@
 #ifndef __INCLUDE_GUARD__RTOS_TASK_HELPERS_H__
 #define __INCLUDE_GUARD__RTOS_TASK_HELPERS_H__
 
+#include "cmsis_os.h"
+typedef struct {
+    osThreadId_t *task_handle;
+    uint32_t stack_size_bytes;
+} Task_Info_t;
+
 // This function shall be called at the start of each task.
 void TASK_HELP_start_of_task(void);
 

--- a/firmware/Core/Inc/rtos_tasks/rtos_task_helpers.h
+++ b/firmware/Core/Inc/rtos_tasks/rtos_task_helpers.h
@@ -3,10 +3,14 @@
 #define __INCLUDE_GUARD__RTOS_TASK_HELPERS_H__
 
 #include "cmsis_os.h"
+
+/// @brief Register all tasks in an array to track their worst/highest stack usage.
 typedef struct {
     osThreadId_t *task_handle;
     const osThreadAttr_t *task_attribute;
-    uint32_t lowest_highstack_watermark_bytes;
+
+    /// @brief The lowest amount of stack space remaining in bytes, as of the last warning log call.
+    uint32_t lowest_stack_bytes_remaining;
 } Task_Info_t;
 
 // This function shall be called at the start of each task.

--- a/firmware/Core/Inc/rtos_tasks/rtos_task_helpers.h
+++ b/firmware/Core/Inc/rtos_tasks/rtos_task_helpers.h
@@ -11,7 +11,7 @@ typedef struct {
 
     /// @brief The lowest amount of stack space remaining in bytes, as of the last warning log call.
     uint32_t lowest_stack_bytes_remaining;
-} Task_Info_t;
+} FREERTOS_task_info_struct_t;
 
 // This function shall be called at the start of each task.
 void TASK_HELP_start_of_task(void);

--- a/firmware/Core/Inc/rtos_tasks/rtos_task_helpers.h
+++ b/firmware/Core/Inc/rtos_tasks/rtos_task_helpers.h
@@ -6,6 +6,7 @@
 typedef struct {
     osThreadId_t *task_handle;
     const osThreadAttr_t *task_attribute;
+    uint32_t lowest_highstack_watermark_bytes;
 } Task_Info_t;
 
 // This function shall be called at the start of each task.

--- a/firmware/Core/Inc/rtos_tasks/rtos_task_helpers.h
+++ b/firmware/Core/Inc/rtos_tasks/rtos_task_helpers.h
@@ -5,7 +5,7 @@
 #include "cmsis_os.h"
 typedef struct {
     osThreadId_t *task_handle;
-    uint32_t stack_size_bytes;
+    const osThreadAttr_t *task_attribute;
 } Task_Info_t;
 
 // This function shall be called at the start of each task.

--- a/firmware/Core/Inc/rtos_tasks/rtos_tasks.h
+++ b/firmware/Core/Inc/rtos_tasks/rtos_tasks.h
@@ -14,6 +14,7 @@ void TASK_handle_uart_telecommands(void *argument);
 void TASK_execute_telecommands(void *argument);
 
 void TASK_service_eps_watchdog(void *argument);
+
 void TASK_monitor_freertos_highstack_watermarks(void *argument);
 
 #endif // __INCLUDE_GUARD__RTOS_TASKS_H__

--- a/firmware/Core/Inc/rtos_tasks/rtos_tasks.h
+++ b/firmware/Core/Inc/rtos_tasks/rtos_tasks.h
@@ -16,5 +16,4 @@ void TASK_execute_telecommands(void *argument);
 void TASK_service_eps_watchdog(void *argument);
 void TASK_monitor_freertos_highstack_watermarks(void *argument);
 
-
 #endif // __INCLUDE_GUARD__RTOS_TASKS_H__

--- a/firmware/Core/Inc/rtos_tasks/rtos_tasks.h
+++ b/firmware/Core/Inc/rtos_tasks/rtos_tasks.h
@@ -15,6 +15,6 @@ void TASK_execute_telecommands(void *argument);
 
 void TASK_service_eps_watchdog(void *argument);
 
-void TASK_monitor_freertos_highstack_watermarks(void *argument);
+void TASK_monitor_freertos_memory(void *argument);
 
 #endif // __INCLUDE_GUARD__RTOS_TASKS_H__

--- a/firmware/Core/Inc/rtos_tasks/rtos_tasks.h
+++ b/firmware/Core/Inc/rtos_tasks/rtos_tasks.h
@@ -14,4 +14,7 @@ void TASK_handle_uart_telecommands(void *argument);
 void TASK_execute_telecommands(void *argument);
 
 void TASK_service_eps_watchdog(void *argument);
+void TASK_monitor_freertos_highstack_watermarks(void *argument);
+
+
 #endif // __INCLUDE_GUARD__RTOS_TASKS_H__

--- a/firmware/Core/Src/config/configuration.c
+++ b/firmware/Core/Src/config/configuration.c
@@ -10,7 +10,10 @@ uint32_t CONFIG_int_demo_var_1 = 13345;
 uint32_t CONFIG_int_demo_var_2 = 242344;
 
 // extern
-const uint32_t CONFIG_highstack_watermark_percentage_threshold = 20;
+
+/// @brief The percentage of the stack space that should remain free. If the free space falls
+/// below this percentage, a warning will be logged.
+const uint32_t CONFIG_freertos_min_remaining_stack_percent = 20;
 
 // extern
 CONFIG_integer_config_entry_t CONFIG_int_config_variables[] = {

--- a/firmware/Core/Src/config/configuration.c
+++ b/firmware/Core/Src/config/configuration.c
@@ -8,6 +8,10 @@ extern uint32_t TASK_heartbeat_period_ms;
 
 uint32_t CONFIG_int_demo_var_1 = 13345;
 uint32_t CONFIG_int_demo_var_2 = 242344;
+
+// extern
+uint32_t CONFIG_highstack_watermark_percentage_threshold;
+
 // extern
 CONFIG_integer_config_entry_t CONFIG_int_config_variables[] = {
     {

--- a/firmware/Core/Src/config/configuration.c
+++ b/firmware/Core/Src/config/configuration.c
@@ -10,7 +10,7 @@ uint32_t CONFIG_int_demo_var_1 = 13345;
 uint32_t CONFIG_int_demo_var_2 = 242344;
 
 // extern
-uint32_t CONFIG_highstack_watermark_percentage_threshold;
+const uint32_t CONFIG_highstack_watermark_percentage_threshold = 20;
 
 // extern
 CONFIG_integer_config_entry_t CONFIG_int_config_variables[] = {

--- a/firmware/Core/Src/main.c
+++ b/firmware/Core/Src/main.c
@@ -109,9 +109,34 @@ const osThreadAttr_t TASK_execute_telecommands_Attributes = {
 osThreadId_t TASK_monitor_freertos_highstack_watermarks_Handle;
 const osThreadAttr_t TASK_monitor_freertos_highstack_watermarks_Attributes = {
   .name = "TASK_monitor_freertos_highstack_watermarks",
-  .stack_size = 512,
-  .priority = (osPriority_t) osPriorityNormal,
+  .stack_size = 1024,
+  .priority = (osPriority_t) osPriorityBelowNormal6,
 };
+
+const Task_Info_t task_handles_array [] = {
+  {
+    .task_handle = &defaultTaskHandle,
+    .stack_size_bytes = 128 * 4
+  },
+  {
+    .task_handle = &TASK_DEBUG_print_heartbeat_Handle,
+    .stack_size_bytes = 256
+  },
+  {
+    .task_handle = &TASK_handle_uart_telecommands_Handle,
+    .stack_size_bytes = 8192
+  },
+  {
+    .task_handle = &TASK_execute_telecommands_Handle,
+    .stack_size_bytes = 8192
+  },
+  {
+    .task_handle = &TASK_monitor_freertos_highstack_watermarks_Handle,
+    .stack_size_bytes = 1024
+  },
+};
+
+const uint32_t task_handles_array_size = sizeof(task_handles_array)/ sizeof(Task_Info_t);
 
 
 /* USER CODE END PV */

--- a/firmware/Core/Src/main.c
+++ b/firmware/Core/Src/main.c
@@ -116,23 +116,23 @@ const osThreadAttr_t TASK_monitor_freertos_highstack_watermarks_Attributes = {
 const Task_Info_t task_handles_array [] = {
   {
     .task_handle = &defaultTaskHandle,
-    .stack_size_bytes = 128 * 4
+    .task_attribute = &defaultTask_attributes
   },
   {
     .task_handle = &TASK_DEBUG_print_heartbeat_Handle,
-    .stack_size_bytes = 256
+    .task_attribute = &TASK_DEBUG_print_heartbeat_Attributes
   },
   {
     .task_handle = &TASK_handle_uart_telecommands_Handle,
-    .stack_size_bytes = 8192
+    .task_attribute = &TASK_handle_uart_telecommands_Attributes
   },
   {
     .task_handle = &TASK_execute_telecommands_Handle,
-    .stack_size_bytes = 8192
+    .task_attribute = &TASK_execute_telecommands_Attributes
   },
   {
     .task_handle = &TASK_monitor_freertos_highstack_watermarks_Handle,
-    .stack_size_bytes = 1024
+    .task_attribute = &TASK_monitor_freertos_highstack_watermarks_Attributes
   },
 };
 

--- a/firmware/Core/Src/main.c
+++ b/firmware/Core/Src/main.c
@@ -106,6 +106,13 @@ const osThreadAttr_t TASK_execute_telecommands_Attributes = {
   .priority = (osPriority_t) osPriorityNormal,
 };
 
+osThreadId_t TASK_service_eps_watchdog_Handle;
+const osThreadAttr_t TASK_service_eps_watchdog_Attributes = {
+  .name = "TASK_service_eps_watchdog",
+  .stack_size = 512, //in bytes
+  .priority = (osPriority_t) osPriorityNormal, //TODO: Figure out which priority makes sense for this task
+};
+
 osThreadId_t TASK_monitor_freertos_highstack_watermarks_Handle;
 const osThreadAttr_t TASK_monitor_freertos_highstack_watermarks_Attributes = {
   .name = "TASK_monitor_freertos_highstack_watermarks",

--- a/firmware/Core/Src/main.c
+++ b/firmware/Core/Src/main.c
@@ -120,26 +120,36 @@ const osThreadAttr_t TASK_monitor_freertos_highstack_watermarks_Attributes = {
   .priority = (osPriority_t) osPriorityBelowNormal6,
 };
 
-const Task_Info_t task_handles_array [] = {
+Task_Info_t task_handles_array [] = {
   {
     .task_handle = &defaultTaskHandle,
-    .task_attribute = &defaultTask_attributes
+    .task_attribute = &defaultTask_attributes,
+    .lowest_highstack_watermark_bytes = UINT32_MAX
   },
   {
     .task_handle = &TASK_DEBUG_print_heartbeat_Handle,
-    .task_attribute = &TASK_DEBUG_print_heartbeat_Attributes
+    .task_attribute = &TASK_DEBUG_print_heartbeat_Attributes,
+    .lowest_highstack_watermark_bytes = UINT32_MAX
   },
   {
     .task_handle = &TASK_handle_uart_telecommands_Handle,
-    .task_attribute = &TASK_handle_uart_telecommands_Attributes
+    .task_attribute = &TASK_handle_uart_telecommands_Attributes,
+    .lowest_highstack_watermark_bytes = UINT32_MAX
   },
   {
     .task_handle = &TASK_execute_telecommands_Handle,
-    .task_attribute = &TASK_execute_telecommands_Attributes
+    .task_attribute = &TASK_execute_telecommands_Attributes,
+    .lowest_highstack_watermark_bytes = UINT32_MAX
+  },
+  {
+    .task_handle = &TASK_service_eps_watchdog_Handle,
+    .task_attribute = &TASK_service_eps_watchdog_Attributes,
+    .lowest_highstack_watermark_bytes = UINT32_MAX
   },
   {
     .task_handle = &TASK_monitor_freertos_highstack_watermarks_Handle,
-    .task_attribute = &TASK_monitor_freertos_highstack_watermarks_Attributes
+    .task_attribute = &TASK_monitor_freertos_highstack_watermarks_Attributes,
+    .lowest_highstack_watermark_bytes = UINT32_MAX
   },
 };
 

--- a/firmware/Core/Src/main.c
+++ b/firmware/Core/Src/main.c
@@ -109,7 +109,7 @@ const osThreadAttr_t TASK_execute_telecommands_Attributes = {
 osThreadId_t TASK_monitor_freertos_highstack_watermarks_Handle;
 const osThreadAttr_t TASK_monitor_freertos_highstack_watermarks_Attributes = {
   .name = "TASK_monitor_freertos_highstack_watermarks",
-  .stack_size = 256,
+  .stack_size = 512,
   .priority = (osPriority_t) osPriorityNormal,
 };
 
@@ -234,7 +234,7 @@ int main(void)
 
   TASK_execute_telecommands_Handle = osThreadNew(TASK_execute_telecommands, NULL, &TASK_execute_telecommands_Attributes);
 
-  TASK_monitor_freertos_highstack_watermarks_Handle = osThreadNew(TASK_execute_telecommands, NULL, &TASK_monitor_freertos_highstack_watermarks_Attributes);
+  TASK_monitor_freertos_highstack_watermarks_Handle = osThreadNew(TASK_monitor_freertos_highstack_watermarks, NULL, &TASK_monitor_freertos_highstack_watermarks_Attributes);
   
   TASK_service_eps_watchdog_Handle = osThreadNew(TASK_service_eps_watchdog, NULL, &TASK_service_eps_watchdog_Attributes);
 

--- a/firmware/Core/Src/main.c
+++ b/firmware/Core/Src/main.c
@@ -113,9 +113,9 @@ const osThreadAttr_t TASK_service_eps_watchdog_Attributes = {
   .priority = (osPriority_t) osPriorityNormal, //TODO: Figure out which priority makes sense for this task
 };
 
-osThreadId_t TASK_monitor_freertos_highstack_watermarks_Handle;
-const osThreadAttr_t TASK_monitor_freertos_highstack_watermarks_Attributes = {
-  .name = "TASK_monitor_freertos_highstack_watermarks",
+osThreadId_t TASK_monitor_freertos_memory_Handle;
+const osThreadAttr_t TASK_monitor_freertos_memory_Attributes = {
+  .name = "TASK_monitor_freertos_memory",
   .stack_size = 1024,
   .priority = (osPriority_t) osPriorityBelowNormal6,
 };
@@ -147,8 +147,8 @@ Task_Info_t task_handles_array [] = {
     .lowest_highstack_watermark_bytes = UINT32_MAX
   },
   {
-    .task_handle = &TASK_monitor_freertos_highstack_watermarks_Handle,
-    .task_attribute = &TASK_monitor_freertos_highstack_watermarks_Attributes,
+    .task_handle = &TASK_monitor_freertos_memory_Handle,
+    .task_attribute = &TASK_monitor_freertos_memory_Attributes,
     .lowest_highstack_watermark_bytes = UINT32_MAX
   },
 };
@@ -276,7 +276,7 @@ int main(void)
 
   TASK_execute_telecommands_Handle = osThreadNew(TASK_execute_telecommands, NULL, &TASK_execute_telecommands_Attributes);
 
-  TASK_monitor_freertos_highstack_watermarks_Handle = osThreadNew(TASK_monitor_freertos_highstack_watermarks, NULL, &TASK_monitor_freertos_highstack_watermarks_Attributes);
+  TASK_monitor_freertos_memory_Handle = osThreadNew(TASK_monitor_freertos_memory, NULL, &TASK_monitor_freertos_memory_Attributes);
   
   TASK_service_eps_watchdog_Handle = osThreadNew(TASK_service_eps_watchdog, NULL, &TASK_service_eps_watchdog_Attributes);
 

--- a/firmware/Core/Src/main.c
+++ b/firmware/Core/Src/main.c
@@ -106,13 +106,12 @@ const osThreadAttr_t TASK_execute_telecommands_Attributes = {
   .priority = (osPriority_t) osPriorityNormal,
 };
 
-osThreadId_t TASK_service_eps_watchdog_Handle;
-const osThreadAttr_t TASK_service_eps_watchdog_Attributes = {
-  .name = "TASK_service_eps_watchdog",
-  .stack_size = 512, //in bytes
-  .priority = (osPriority_t) osPriorityNormal, //TODO: Figure out which priority makes sense for this task
+osThreadId_t TASK_monitor_freertos_highstack_watermarks_Handle;
+const osThreadAttr_t TASK_monitor_freertos_highstack_watermarks_Attributes = {
+  .name = "TASK_monitor_freertos_highstack_watermarks",
+  .stack_size = 256,
+  .priority = (osPriority_t) osPriorityNormal,
 };
-
 
 
 /* USER CODE END PV */
@@ -234,6 +233,8 @@ int main(void)
   TASK_handle_uart_telecommands_Handle = osThreadNew(TASK_handle_uart_telecommands, NULL, &TASK_handle_uart_telecommands_Attributes);
 
   TASK_execute_telecommands_Handle = osThreadNew(TASK_execute_telecommands, NULL, &TASK_execute_telecommands_Attributes);
+
+  TASK_monitor_freertos_highstack_watermarks_Handle = osThreadNew(TASK_execute_telecommands, NULL, &TASK_monitor_freertos_highstack_watermarks_Attributes);
   
   TASK_service_eps_watchdog_Handle = osThreadNew(TASK_service_eps_watchdog, NULL, &TASK_service_eps_watchdog_Attributes);
 

--- a/firmware/Core/Src/main.c
+++ b/firmware/Core/Src/main.c
@@ -120,7 +120,7 @@ const osThreadAttr_t TASK_monitor_freertos_memory_Attributes = {
   .priority = (osPriority_t) osPriorityBelowNormal6,
 };
 
-Task_Info_t FREERTOS_task_handles_array [] = {
+FREERTOS_task_info_struct_t FREERTOS_task_handles_array [] = {
   {
     .task_handle = &defaultTaskHandle,
     .task_attribute = &defaultTask_attributes,
@@ -153,7 +153,7 @@ Task_Info_t FREERTOS_task_handles_array [] = {
   },
 };
 
-const uint32_t FREERTOS_task_handles_array_size = sizeof(FREERTOS_task_handles_array) / sizeof(Task_Info_t);
+const uint32_t FREERTOS_task_handles_array_size = sizeof(FREERTOS_task_handles_array) / sizeof(FREERTOS_task_info_struct_t);
 
 
 /* USER CODE END PV */

--- a/firmware/Core/Src/main.c
+++ b/firmware/Core/Src/main.c
@@ -120,40 +120,40 @@ const osThreadAttr_t TASK_monitor_freertos_memory_Attributes = {
   .priority = (osPriority_t) osPriorityBelowNormal6,
 };
 
-Task_Info_t task_handles_array [] = {
+Task_Info_t FREERTOS_task_handles_array [] = {
   {
     .task_handle = &defaultTaskHandle,
     .task_attribute = &defaultTask_attributes,
-    .lowest_highstack_watermark_bytes = UINT32_MAX
+    .lowest_stack_bytes_remaining = UINT32_MAX
   },
   {
     .task_handle = &TASK_DEBUG_print_heartbeat_Handle,
     .task_attribute = &TASK_DEBUG_print_heartbeat_Attributes,
-    .lowest_highstack_watermark_bytes = UINT32_MAX
+    .lowest_stack_bytes_remaining = UINT32_MAX
   },
   {
     .task_handle = &TASK_handle_uart_telecommands_Handle,
     .task_attribute = &TASK_handle_uart_telecommands_Attributes,
-    .lowest_highstack_watermark_bytes = UINT32_MAX
+    .lowest_stack_bytes_remaining = UINT32_MAX
   },
   {
     .task_handle = &TASK_execute_telecommands_Handle,
     .task_attribute = &TASK_execute_telecommands_Attributes,
-    .lowest_highstack_watermark_bytes = UINT32_MAX
+    .lowest_stack_bytes_remaining = UINT32_MAX
   },
   {
     .task_handle = &TASK_service_eps_watchdog_Handle,
     .task_attribute = &TASK_service_eps_watchdog_Attributes,
-    .lowest_highstack_watermark_bytes = UINT32_MAX
+    .lowest_stack_bytes_remaining = UINT32_MAX
   },
   {
     .task_handle = &TASK_monitor_freertos_memory_Handle,
     .task_attribute = &TASK_monitor_freertos_memory_Attributes,
-    .lowest_highstack_watermark_bytes = UINT32_MAX
+    .lowest_stack_bytes_remaining = UINT32_MAX
   },
 };
 
-const uint32_t task_handles_array_size = sizeof(task_handles_array)/ sizeof(Task_Info_t);
+const uint32_t FREERTOS_task_handles_array_size = sizeof(FREERTOS_task_handles_array) / sizeof(Task_Info_t);
 
 
 /* USER CODE END PV */

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -240,7 +240,14 @@ void TASK_monitor_freertos_highstack_watermarks(void *argument) {
 				// Get the highstack watermark
 				uint32_t task_highstack_watermark_bytes = uxTaskGetStackHighWaterMark(dereferenced_task_handle) * 4;
 
-				if(task_highstack_watermark_bytes < task_threshold_bytes){
+				// Initializing the lowest highstack watermark bytes
+				if(task_handles_array[x].lowest_highstack_watermark_bytes == UINT32_MAX){
+					task_handles_array[x].lowest_highstack_watermark_bytes = task_highstack_watermark_bytes;
+				}
+
+				if(task_highstack_watermark_bytes < task_threshold_bytes && task_highstack_watermark_bytes < task_handles_array[x].lowest_highstack_watermark_bytes){
+					
+					task_handles_array[x].lowest_highstack_watermark_bytes = task_highstack_watermark_bytes;
 					LOG_message(
 						LOG_SYSTEM_OBC, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
 						"Warning: Task '%s' approached a stack overflow. Worst remaining stack size was: %lu bytes.",

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -11,6 +11,7 @@
 #include "stm32/stm32_reboot_reason.h"
 #include "log/log.h"
 #include "config/configuration.h"
+#include "eps_drivers/eps_commands.h"
 
 #include "cmsis_os.h"
 

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -220,12 +220,14 @@ void TASK_service_eps_watchdog(void *argument) {
 		osDelay(sleep_duration_ms);
 	}
 }
+
 void TASK_monitor_freertos_highstack_watermarks(void *argument) {
 	TASK_HELP_start_of_task();
 
-	while (1) {
+	const uint32_t highstack_watermark_threshold = 50;
+	uint32_t total_run_time;
 
-		uint32_t total_run_time;
+	while (1) {
 
 		// Get the number of tasks
 		const UBaseType_t number_of_tasks = uxTaskGetNumberOfTasks();

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -224,10 +224,10 @@ void TASK_service_eps_watchdog(void *argument) {
 void TASK_monitor_freertos_highstack_watermarks(void *argument) {
 	TASK_HELP_start_of_task();
 
-	const uint32_t highstack_watermark_threshold = 50;
-	uint32_t total_run_time;
-
 	while (1) {
+
+		const uint32_t highstack_watermark_threshold = 50;
+		uint32_t total_run_time;
 
 		// Get the number of tasks
 		const UBaseType_t number_of_tasks = uxTaskGetNumberOfTasks();

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -234,17 +234,17 @@ void TASK_monitor_freertos_highstack_watermarks(void *argument) {
 				osThreadId_t dereferenced_task_handle = *(task_handles_array[x].task_handle);
 
 				// Determine the threshold of the task
-				uint32_t task_threshold_words = (task_handles_array[x].stack_size_bytes * CONFIG_highstack_watermark_percentage_threshold) / 400;
+				uint32_t task_threshold_bytes = (task_handles_array[x].task_attribute->stack_size * CONFIG_highstack_watermark_percentage_threshold) / 100;
 
 				// Get the highstack watermark
-				uint32_t task_highstack_watermark_words = uxTaskGetStackHighWaterMark(dereferenced_task_handle);
+				uint32_t task_highstack_watermark_bytes = uxTaskGetStackHighWaterMark(dereferenced_task_handle) * 4;
 
-				if(task_highstack_watermark_words < task_threshold_words){
+				if(task_highstack_watermark_bytes < task_threshold_bytes){
 					LOG_message(
 						LOG_SYSTEM_OBC, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
-						"Warning: Task '%s' approached a stack overflow. Worst remaining stack size was: %lu words.",
+						"Warning: Task '%s' approached a stack overflow. Worst remaining stack size was: %lu bytes.",
 						pcTaskGetName(dereferenced_task_handle),
-						task_highstack_watermark_words
+						task_highstack_watermark_bytes
 						);
 				}	
 			}

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -222,7 +222,7 @@ void TASK_service_eps_watchdog(void *argument) {
 	}
 }
 
-void TASK_monitor_freertos_highstack_watermarks(void *argument) {
+void TASK_monitor_freertos_memory(void *argument) {
 	TASK_HELP_start_of_task();
 
 	while (1) {

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -225,39 +225,45 @@ void TASK_service_eps_watchdog(void *argument) {
 void TASK_monitor_freertos_memory(void *argument) {
 	TASK_HELP_start_of_task();
 
+	osDelay(12000); // Delay for 12 seconds to allow other tasks to start up.
+
 	while (1) {
+		// Place the main delay at the top to avoid a "continue" statement skipping it.
+		osDelay(5000);
 
-		for(uint32_t x = 0; x < task_handles_array_size; x++){
+		for (uint16_t task_num = 0; task_num < FREERTOS_task_handles_array_size; task_num++) {
+			if (FREERTOS_task_handles_array[task_num].task_handle == NULL) {
+				continue; // Safety check. Should never happen.
+			}
+	
+			// Dereferencing the task_handle pointer
+			const osThreadId_t task_handle = *(FREERTOS_task_handles_array[task_num].task_handle);
 
-			if(task_handles_array[x].task_handle != NULL)
-			{
-				// Dereferencing the task_handle pointer
-				osThreadId_t dereferenced_task_handle = *(task_handles_array[x].task_handle);
+			// Get the highstack watermark
+			const uint32_t task_min_bytes_remaining = uxTaskGetStackHighWaterMark(task_handle) * 4;
+
+			if (task_min_bytes_remaining < FREERTOS_task_handles_array[task_num].lowest_stack_bytes_remaining) {
+				// If this is the new "lowest free space", update that value.
+				FREERTOS_task_handles_array[task_num].lowest_stack_bytes_remaining = task_min_bytes_remaining;
 
 				// Determine the threshold of the task
-				uint32_t task_threshold_bytes = (task_handles_array[x].task_attribute->stack_size * CONFIG_highstack_watermark_percentage_threshold) / 100;
-
-				// Get the highstack watermark
-				uint32_t task_highstack_watermark_bytes = uxTaskGetStackHighWaterMark(dereferenced_task_handle) * 4;
-
-				// Initializing the lowest highstack watermark bytes
-				if(task_handles_array[x].lowest_highstack_watermark_bytes == UINT32_MAX){
-					task_handles_array[x].lowest_highstack_watermark_bytes = task_highstack_watermark_bytes;
-				}
-
-				if(task_highstack_watermark_bytes < task_threshold_bytes && task_highstack_watermark_bytes < task_handles_array[x].lowest_highstack_watermark_bytes){
-					
-					task_handles_array[x].lowest_highstack_watermark_bytes = task_highstack_watermark_bytes;
+				const uint32_t task_threshold_bytes = (
+					FREERTOS_task_handles_array[task_num].task_attribute->stack_size
+					* CONFIG_freertos_min_remaining_stack_percent
+					/ 100
+				);
+				
+				// If this new "lowest free space" is below the threshold, warn the user.
+				if (task_min_bytes_remaining < task_threshold_bytes) {
 					LOG_message(
 						LOG_SYSTEM_OBC, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
 						"Warning: Task '%s' approached a stack overflow. Worst remaining stack size was: %lu bytes.",
-						pcTaskGetName(dereferenced_task_handle),
-						task_highstack_watermark_bytes
-						);
-				}	
+						pcTaskGetName(task_handle),
+						task_min_bytes_remaining
+					);
+				}
 			}
 		}
-		osDelay(5000);
 
 	} /* End Task's Main Loop */
 }

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -223,10 +223,10 @@ void TASK_service_eps_watchdog(void *argument) {
 void TASK_monitor_freertos_highstack_watermarks(void *argument) {
 	TASK_HELP_start_of_task();
 
-	const uint32_t highstack_watermark_threshold = 50;
-	uint32_t total_run_time;
-
 	while (1) {
+
+		const uint32_t highstack_watermark_threshold = 50;
+		uint32_t total_run_time;
 
 		// Get the number of tasks
 		const UBaseType_t number_of_tasks = uxTaskGetNumberOfTasks();
@@ -245,7 +245,7 @@ void TASK_monitor_freertos_highstack_watermarks(void *argument) {
 			{
 				LOG_message(
 					LOG_SYSTEM_OBC, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
-					"Warning: Task %s is nearing stack overflow. Remaining stack size is: %u bytes.",
+					"Warning: Task '%s' approached a stack overflow. Worst remaining stack size was: %u words.",
 					task_statuses[x].pcTaskName,
 					task_statuses[x].usStackHighWaterMark
 					);

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -10,7 +10,7 @@
 #include "transforms/arrays.h"
 #include "stm32/stm32_reboot_reason.h"
 #include "log/log.h"
-#include "configuration.h"
+#include "config/configuration.h"
 
 #include "cmsis_os.h"
 

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -10,7 +10,7 @@
 #include "transforms/arrays.h"
 #include "stm32/stm32_reboot_reason.h"
 #include "log/log.h"
-#include "eps_drivers/eps_commands.h"
+#include "configuration.h"
 
 #include "cmsis_os.h"
 
@@ -225,7 +225,6 @@ void TASK_monitor_freertos_highstack_watermarks(void *argument) {
 
 	while (1) {
 
-		const uint32_t highstack_watermark_threshold = 50;
 		uint32_t total_run_time;
 
 		// Get the number of tasks
@@ -241,7 +240,7 @@ void TASK_monitor_freertos_highstack_watermarks(void *argument) {
 
 		//Check the highstack watermarks for each task
 		for(UBaseType_t x = 0; x < number_of_tasks; x++){
-			if(task_statuses[x].usStackHighWaterMark < highstack_watermark_threshold)
+			if(task_statuses[x].usStackHighWaterMark < CONFIG_highstack_watermark_percentage_threshold)
 			{
 				LOG_message(
 					LOG_SYSTEM_OBC, LOG_SEVERITY_WARNING, LOG_SINK_ALL,

--- a/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
@@ -61,7 +61,8 @@ uint8_t TCMDEXEC_freetos_list_tasks_jsonl(const char *args_str, TCMD_Telecommand
             task_statuses[x].uxCurrentPriority,
             // `usStackHighWaterMark`: The minimum amount of stack space that has remained for the task since the task was created.
             // The closer this value is to zero the closer the task has come to overflowing its stack.
-            task_statuses[x].usStackHighWaterMark,
+            // The return value of `usStackHighWaterMark` is in words, thus multiplying by 4 to get the bytes equivalent
+            (task_statuses[x].usStackHighWaterMark * 4),
             task_statuses[x].ulRunTimeCounter
         );
           


### PR DESCRIPTION
## Related Issues

Closes #128 

## Summary

This PR creates an osThread that will periodically check the high stack watermark to see if it is below a defined threshold. This is done to note when a potential stack overflow may occur.

## Changes Made

The changes made to realize this were as follows:
- Created a thread called `TASK_monitor_freertos_highstack_watermarks` in `rtos_tasks.c` and added the function definition in `rtos_tasks.h`
- Created a osThreadId_t,  osThreadAttr_t and thread for `TASK_monitor_freertos_highstack_watermarks`  in main

## Special Notes for Your Reviewer(s)
During the implementation of the above steps, I noticed that each task has varying stack sizes ranging from 256-8192. Therefore my `highstack_watermark_threshold` may not be large enough for specific tasks like `TASK_execute_telecommands_Handle`. I was aiming to have a threshold value of 20% for their allocated stack size.

I was thinking of creating a wrapper function, let's say called `createThread`, that will be used to create the threads so I can dynamically allocate a threshold value. I'd create a struct called `TaskInfo_t` that contains the task name and the stack size. I would then have a global array of the struct which would be populated during the creation of the thread. Do a string comparison of each task name and then dynamically allocate a 20% threshold for each task based on their stack size.

I was wondering if this was a little too complex for the simplicity of this ticket. Let me know what you think, otherwise, I can just modify the threshold value that I already have in place to be something higher than 50, which is what I have right now.

