### PR TITLE
Report flash memory module capacity in Mebibytes

### DIFF
--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -165,7 +165,7 @@ FLASH_error_enum_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
         // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
         if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_REGISTER_CHANGE_TIMEOUT_MS) {
             LOG_message(
-                LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                LOG_SYSTEM_FLASH, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
                 "Flash write enable timeout"
             );
             return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
@@ -225,7 +225,7 @@ FLASH_error_enum_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_num
         // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
         if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_REGISTER_CHANGE_TIMEOUT_MS) {
             LOG_message(
-                LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                LOG_SYSTEM_FLASH, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
                 "Flash write disable timeout",
                 status_reg_buffer[0]
             );
@@ -302,7 +302,7 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
         if ((status_reg_buffer[0] & FLASH_SR1_ERASE_ERROR_MASK) > 0) {
             // Flash module returned "erase error" via the status register.
             LOG_message(
-                LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                LOG_SYSTEM_FLASH, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
                 "Flash erase error"
             );
             return FLASH_ERR_STATUS_REG_ERROR;
@@ -316,7 +316,7 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
         // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
         if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_SECTOR_ERASE_TIMEOUT_MS) {
             LOG_message(
-                LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                LOG_SYSTEM_FLASH, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
                 "Flash erase timeout"
             );
             return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
@@ -403,7 +403,7 @@ FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
         if ((status_reg_buffer[0] & FLASH_SR1_PROGRAMMING_ERROR_MASK) > 0) {
             // Flash module returned "programming error" via the status register.
             LOG_message(
-                LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                LOG_SYSTEM_FLASH, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
                 "Flash programming error"
             );
             return FLASH_ERR_STATUS_REG_ERROR;
@@ -417,7 +417,7 @@ FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
         // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
         if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_WRITE_TIMEOUT_MS) {
             LOG_message(
-                LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                LOG_SYSTEM_FLASH, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
                 "Flash write timeout"
             );
             return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
@@ -542,7 +542,7 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
         are_bytes_correct = 1;
     } else {
         LOG_message(
-            LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            LOG_SYSTEM_FLASH, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
             "ERROR: FLASH_is_reachable received IDs: 0x%02X 0x%02X 0x%02X 0x%02X 0x%02X    Capacity: %lu MiB",
             rx_buffer[0],
             rx_buffer[1],

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -6,6 +6,9 @@
 
 #include "config/static_config.h"
 
+#include <stdio.h>
+#include <stdint.h>
+
 /// Timeout duration for HAL_SPI_READ/WRITE operations.
 // Note: FLASH_read_data has sporadic timeouts at 5ms; 10ms is a safe bet.
 // 512 bytes should take 2ms at 2Mbps.
@@ -506,8 +509,18 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
         are_bytes_correct = 0;
     }
 
+    // Extract memory capacity
+    uint32_t capacity_mib = (rx_buffer[2] * 512) / 32;  // Convert to Mebibytes (MiB)
+
+    // String to print capacity in MiB
+    char capacity_str[30];
+    snprintf(capacity_str, sizeof(capacity_str), "Capacity: %lu MiB", capacity_mib);
+
+    // Print out response and capacity in human-readable format MiB
     DEBUG_uart_print_array_hex(rx_buffer, 5);
-    DEBUG_uart_print_str("\n");
+    DEBUG_uart_print_str("\t");
+    DEBUG_uart_print_str(capacity_str);
+    DEBUG_uart_print_str("\n");    
 
     if (!are_bytes_correct) {
         // error: IDs don't match

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -491,7 +491,7 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     // TODO: confirm if this works with the CS2 logical chip on each physical FLASH chip;
     // ^ Seems as though it only works for CS1.
 
-    uint8_t tx_buffer[1] = {FLASH_CMD_READ_ID};
+    uint8_t tx_buffer[1] = {FLASH_CMD_READ_ID};     // TODO: Adjust based on new FLASH chip
     uint8_t rx_buffer[5];
     memset(rx_buffer, 0, 5);
 
@@ -526,31 +526,24 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     // rx_buffer[0] is the manufacturer ID, rx_buffer[1] is the memory type,
     // and rx_buffer[2] is the memory capacity (not checked, as we have a few different capacities).
     // rx_buffer[2] is 0x20=512 for 512 Mib (mebibits)
+    // TODO: Verify with new FLASH chip: For MICRON MT29F1G01 series FLASH, expected Manufacturer ID: 0x2C, Device ID: 0x14 is expected back from the READ ID command
     uint8_t are_bytes_correct = 0;
-    if (rx_buffer[0] == 0x01 && rx_buffer[1] == 0x02) {
+    if (rx_buffer[0] == 0x2C && rx_buffer[1] == 0x14) {
         LOG_message(
             LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
-            "SUCCESS: CS%d ID: 0x%02X 0x%02X 0x%02X 0x%02X 0x%02X - Capacity: %lu MiB",
+            "SUCCESS: CS%d ID: 0x%02X 0x%02X",
             chip_number,
             rx_buffer[0],
-            rx_buffer[1],
-            rx_buffer[2],
-            rx_buffer[3],
-            rx_buffer[4],
-            (rx_buffer[2] << 4)
+            rx_buffer[1]
         );
         are_bytes_correct = 1;
     } else {
         LOG_message(
             LOG_SYSTEM_FLASH, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
-            "ERROR: CS%d ID: 0x%02X 0x%02X 0x%02X 0x%02X 0x%02X - Capacity: %lu MiB",
+            "ERROR: CS%d ID: 0x%02X 0x%02X",
             chip_number,
             rx_buffer[0],
-            rx_buffer[1],
-            rx_buffer[2],
-            rx_buffer[3],
-            rx_buffer[4],
-            (rx_buffer[2] << 4)
+            rx_buffer[1]
         );
         are_bytes_correct = 0;
     }

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -526,12 +526,12 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     // rx_buffer[0] is the manufacturer ID, rx_buffer[1] is the memory type,
     // and rx_buffer[2] is the memory capacity (not checked, as we have a few different capacities).
     // rx_buffer[2] is 0x20=512 for 512 Mib (mebibits)
-    // TODO: maybe check the capacity as well here, esp. in deployment
     uint8_t are_bytes_correct = 0;
     if (rx_buffer[0] == 0x01 && rx_buffer[1] == 0x02) {
         LOG_message(
             LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
-            "SUCCESS: FLASH_is_reachable received IDs: 0x%02X 0x%02X 0x%02X 0x%02X 0x%02X    Capacity: %lu MiB",
+            "SUCCESS: CS%d ID: 0x%02X 0x%02X 0x%02X 0x%02X 0x%02X - Capacity: %lu MiB",
+            chip_number,
             rx_buffer[0],
             rx_buffer[1],
             rx_buffer[2],
@@ -543,7 +543,8 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     } else {
         LOG_message(
             LOG_SYSTEM_FLASH, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
-            "ERROR: FLASH_is_reachable received IDs: 0x%02X 0x%02X 0x%02X 0x%02X 0x%02X    Capacity: %lu MiB",
+            "ERROR: CS%d ID: 0x%02X 0x%02X 0x%02X 0x%02X 0x%02X - Capacity: %lu MiB",
+            chip_number,
             rx_buffer[0],
             rx_buffer[1],
             rx_buffer[2],

--- a/firmware/Core/Src/littlefs/flash_driver.c
+++ b/firmware/Core/Src/littlefs/flash_driver.c
@@ -2,7 +2,7 @@
 #include "main.h"
 
 #include "littlefs/flash_driver.h"
-#include "debug_tools/debug_uart.h"
+#include "log/log.h"
 
 #include "config/static_config.h"
 
@@ -164,14 +164,19 @@ FLASH_error_enum_t FLASH_write_enable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
 
         // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
         if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_REGISTER_CHANGE_TIMEOUT_MS) {
-            DEBUG_uart_print_str("Flash write enable timeout\n");
+            LOG_message(
+                LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                "Flash write enable timeout"
+            );
             return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
         }
 
         if (FLASH_enable_hot_path_debug_logs) {
-            DEBUG_uart_print_str("DEBUG: status_reg = 0x");
-            DEBUG_uart_print_array_hex(status_reg_buffer, 1);
-            DEBUG_uart_print_str("\n");
+            LOG_message(
+                LOG_SYSTEM_FLASH, LOG_SEVERITY_DEBUG, LOG_SINK_ALL,
+                "DEBUG: status_reg = 0x%02X",
+                status_reg_buffer[0]
+            );
         }
     }
 
@@ -219,13 +224,19 @@ FLASH_error_enum_t FLASH_write_disable(SPI_HandleTypeDef *hspi, uint8_t chip_num
 
         // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
         if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_REGISTER_CHANGE_TIMEOUT_MS) {
-            DEBUG_uart_print_str("Flash write disable timeout\n");
+            LOG_message(
+                LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                "Flash write disable timeout",
+                status_reg_buffer[0]
+            );
             return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
         }
 
-        DEBUG_uart_print_str("DEBUG: status_reg = 0x");
-        DEBUG_uart_print_array_hex(status_reg_buffer, 1);
-        DEBUG_uart_print_str("\n");
+        LOG_message(
+            LOG_SYSTEM_FLASH, LOG_SEVERITY_DEBUG, LOG_SINK_ALL,
+            "DEBUG: status_reg = 0x%02X",
+            status_reg_buffer[0]
+        );
     }
 
     // Should never be reached:
@@ -290,7 +301,10 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
 
         if ((status_reg_buffer[0] & FLASH_SR1_ERASE_ERROR_MASK) > 0) {
             // Flash module returned "erase error" via the status register.
-            DEBUG_uart_print_str("Flash erase error\n");
+            LOG_message(
+                LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                "Flash erase error"
+            );
             return FLASH_ERR_STATUS_REG_ERROR;
         }
 
@@ -301,13 +315,18 @@ FLASH_error_enum_t FLASH_erase(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
 
         // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
         if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_SECTOR_ERASE_TIMEOUT_MS) {
-            DEBUG_uart_print_str("Flash erase timeout\n");
+            LOG_message(
+                LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                "Flash erase timeout"
+            );
             return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
         }
 
-        DEBUG_uart_print_str("DEBUG: status_reg = 0x");
-        DEBUG_uart_print_array_hex(status_reg_buffer, 1);
-        DEBUG_uart_print_str("\n");
+        LOG_message(
+            LOG_SYSTEM_FLASH, LOG_SEVERITY_DEBUG, LOG_SINK_ALL,
+            "DEBUG: status_reg = 0x%02X",
+            status_reg_buffer[0]
+        );
     }
 
     // Should never be reached:
@@ -383,7 +402,10 @@ FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
 
         if ((status_reg_buffer[0] & FLASH_SR1_PROGRAMMING_ERROR_MASK) > 0) {
             // Flash module returned "programming error" via the status register.
-            DEBUG_uart_print_str("Flash programming error\n");
+            LOG_message(
+                LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                "Flash programming error"
+            );
             return FLASH_ERR_STATUS_REG_ERROR;
         }
 
@@ -394,13 +416,18 @@ FLASH_error_enum_t FLASH_write(SPI_HandleTypeDef *hspi, uint8_t chip_number, lfs
 
         // Do this comparison AFTER checking the success condition (for speed, and to avoid timing out on a success).
         if (HAL_GetTick() - start_loop_time_ms > FLASH_LOOP_WRITE_TIMEOUT_MS) {
-            DEBUG_uart_print_str("Flash write timeout\n");
+            LOG_message(
+                LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                "Flash write timeout"
+            );
             return FLASH_ERR_DEVICE_BUSY_TIMEOUT;
         }
 
-        DEBUG_uart_print_str("DEBUG: status_reg = 0x");
-        DEBUG_uart_print_array_hex(status_reg_buffer, 1);
-        DEBUG_uart_print_str("\n");
+        LOG_message(
+            LOG_SYSTEM_FLASH, LOG_SEVERITY_DEBUG, LOG_SINK_ALL,
+            "DEBUG: status_reg = 0x%02X",
+            status_reg_buffer[0]
+        );
     }
 
     // Should never be reached:
@@ -502,25 +529,30 @@ FLASH_error_enum_t FLASH_is_reachable(SPI_HandleTypeDef *hspi, uint8_t chip_numb
     // TODO: maybe check the capacity as well here, esp. in deployment
     uint8_t are_bytes_correct = 0;
     if (rx_buffer[0] == 0x01 && rx_buffer[1] == 0x02) {
-        DEBUG_uart_print_str("SUCCESS: FLASH_is_reachable received IDs: ");
+        LOG_message(
+            LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "SUCCESS: FLASH_is_reachable received IDs: 0x%02X 0x%02X 0x%02X 0x%02X 0x%02X    Capacity: %lu MiB",
+            rx_buffer[0],
+            rx_buffer[1],
+            rx_buffer[2],
+            rx_buffer[3],
+            rx_buffer[4],
+            (rx_buffer[2] << 4)
+        );
         are_bytes_correct = 1;
     } else {
-        DEBUG_uart_print_str("ERROR: FLASH_is_reachable received IDs: ");
+        LOG_message(
+            LOG_SYSTEM_FLASH, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "ERROR: FLASH_is_reachable received IDs: 0x%02X 0x%02X 0x%02X 0x%02X 0x%02X    Capacity: %lu MiB",
+            rx_buffer[0],
+            rx_buffer[1],
+            rx_buffer[2],
+            rx_buffer[3],
+            rx_buffer[4],
+            (rx_buffer[2] << 4)
+        );
         are_bytes_correct = 0;
     }
-
-    // Extract memory capacity
-    uint32_t capacity_mib = (rx_buffer[2] * 512) / 32;  // Convert to Mebibytes (MiB)
-
-    // String to print capacity in MiB
-    char capacity_str[30];
-    snprintf(capacity_str, sizeof(capacity_str), "Capacity: %lu MiB", capacity_mib);
-
-    // Print out response and capacity in human-readable format MiB
-    DEBUG_uart_print_array_hex(rx_buffer, 5);
-    DEBUG_uart_print_str("\t");
-    DEBUG_uart_print_str(capacity_str);
-    DEBUG_uart_print_str("\n");    
 
     if (!are_bytes_correct) {
         // error: IDs don't match


### PR DESCRIPTION
Implements #150 - Reports memory module's sizes as a 'human-readable' string (as Mebibytes MiB). Also updates to utilize `LOG_message` instead of `DEBUG_uart_print`.

**Success Output:**
```
========================= UART Telecommand Received =========================
CTS1+flash_each_is_reachable()!
=========================
Parsed telecommand (len=31): 'CTS1+flash_each_is_reachable()!'
0000000000000+0000000930_N [TELECOMMAND:NORMAL]: Executing telecommand from agenda slot 0, sent at tssent=0, scheduled for tsexec=0.
========================= Executing telecommand 'flash_each_is_reachable'=========================
0000000000000+0000000951_N [FLASH:NORMAL]: SUCCESS: FLASH_is_reachable received IDs: 0x01 0x02 0x20 0x00 0x00    Capacity: 512 MiB
0000000000000+0000000964_N [FLASH:NORMAL]: SUCCESS: FLASH_is_reachable received IDs: 0x01 0x02 0x20 0x00 0x00    Capacity: 512 MiB
0000000000000+0000000977_N [FLASH:NORMAL]: SUCCESS: FLASH_is_reachable received IDs: 0x01 0x02 0x20 0x00 0x00    Capacity: 512 MiB
0000000000000+0000000989_N [FLASH:NORMAL]: SUCCESS: FLASH_is_reachable received IDs: 0x01 0x02 0x20 0x00 0x00    Capacity: 512 MiB
0000000000000+0000001002_N [FLASH:NORMAL]: SUCCESS: FLASH_is_reachable received IDs: 0x01 0x02 0x20 0x00 0x00    Capacity: 512 MiB
0000000000000+0000001015_N [FLASH:NORMAL]: SUCCESS: FLASH_is_reachable received IDs: 0x01 0x02 0x20 0x00 0x00    Capacity: 512 MiB
0000000000000+0000001028_N [FLASH:NORMAL]: SUCCESS: FLASH_is_reachable received IDs: 0x01 0x02 0x20 0x00 0x00    Capacity: 512 MiB
0000000000000+0000001040_N [FLASH:NORMAL]: SUCCESS: FLASH_is_reachable received IDs: 0x01 0x02 0x20 0x00 0x00    Capacity: 512 MiB
========================= Response (duration=102ms, err=0) =========================
Chip 0 is reachable.
Chip 1 is reachable.
Chip 2 is reachable.
Chip 3 is reachable.
Chip 4 is reachable.
Chip 5 is reachable.
Chip 6 is reachable.
Chip 7 is reachable.
All chips are reachable.
```

**Failure Output:**
```
========================= UART Telecommand Received =========================
CTS1+flash_each_is_reachable()!
=========================
Parsed telecommand (len=31): 'CTS1+flash_each_is_reachable()!'
0000000000000+0000002930_N [TELECOMMAND:NORMAL]: Executing telecommand from agenda slot 0, sent at tssent=0, scheduled for tsexec=0.
========================= Executing telecommand 'flash_each_is_reachable'=========================
0000000000000+0000002951_N [FLASH:NORMAL]: ERROR: FLASH_is_reachable received IDs: 0x00 0x00 0x00 0x00 0x00    Capacity: 0 MiB
0000000000000+0000002964_N [FLASH:NORMAL]: ERROR: FLASH_is_reachable received IDs: 0x00 0x00 0x00 0x00 0x00    Capacity: 0 MiB
0000000000000+0000002976_N [FLASH:NORMAL]: ERROR: FLASH_is_reachable received IDs: 0x00 0x00 0x00 0x00 0x00    Capacity: 0 MiB
0000000000000+0000002988_N [FLASH:NORMAL]: ERROR: FLASH_is_reachable received IDs: 0x00 0x00 0x00 0x00 0x00    Capacity: 0 MiB
0000000000000+0000003001_N [FLASH:NORMAL]: ERROR: FLASH_is_reachable received IDs: 0x00 0x00 0x00 0x00 0x00    Capacity: 0 MiB
0000000000000+0000003013_N [FLASH:NORMAL]: ERROR: FLASH_is_reachable received IDs: 0x00 0x00 0x00 0x00 0x00    Capacity: 0 MiB
0000000000000+0000003026_N [FLASH:NORMAL]: ERROR: FLASH_is_reachable received IDs: 0x00 0x00 0x00 0x00 0x00    Capacity: 0 MiB
0000000000000+0000003038_N [FLASH:NORMAL]: ERROR: FLASH_is_reachable received IDs: 0x00 0x00 0x00 0x00 0x00    Capacity: 0 MiB
========================= Response (duration=102ms, err=1 !!!!!! ERROR !!!!!!) =========================
Chip 0 is not reachable. Error code: 3
Chip 1 is not reachable. Error code: 3
Chip 2 is not reachable. Error code: 3
Chip 3 is not reachable. Error code: 3
Chip 4 is not reachable. Error code: 3
Chip 5 is not reachable. Error code: 3
Chip 6 is not reachable. Error code: 3
Chip 7 is not reachable. Error code: 3
8/8 chips are not reachable.
```