### PR TITLE
Antenna deploy: use both I2C lines

### DIFF
--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -22,18 +22,18 @@ struct Antenna_deployment_status {
     uint8_t antenna_system_armed;
 };
 
-uint8_t ANT_CMD_reset();
-uint8_t ANT_CMD_arm_antenna_system();
-uint8_t ANT_CMD_disarm_antenna_system();
-uint8_t ANT_CMD_deploy_antenna(uint8_t antenna, uint8_t activation_time_seconds);
-uint8_t ANT_CMD_start_automated_sequential_deployment(uint8_t activation_time_seconds);
-uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation_time_seconds);
-uint8_t ANT_CMD_cancel_deployment_system_activation();
-uint8_t ANT_CMD_measure_temp(uint16_t *result);
+uint8_t ANT_CMD_reset(enum Ant_i2c_bus i2c_bus);
+uint8_t ANT_CMD_arm_antenna_system(enum Ant_i2c_bus i2c_bus);
+uint8_t ANT_CMD_disarm_antenna_system(enum Ant_i2c_bus i2c_bus);
+uint8_t ANT_CMD_deploy_antenna(enum Ant_i2c_bus i2c_bus, uint8_t antenna, uint8_t activation_time_seconds);
+uint8_t ANT_CMD_start_automated_sequential_deployment(enum Ant_i2c_bus i2c_bus, uint8_t activation_time_seconds);
+uint8_t ANT_CMD_deploy_antenna_with_override(enum Ant_i2c_bus i2c_bus, uint8_t antenna, uint8_t activation_time_seconds);
+uint8_t ANT_CMD_cancel_deployment_system_activation(enum Ant_i2c_bus i2c_bus);
+uint8_t ANT_CMD_measure_temp(enum Ant_i2c_bus i2c_bus, uint16_t *result);
 int16_t ANT_convert_raw_temp_to_cCelsius(uint16_t measurement);
-uint8_t ANT_CMD_report_deployment_status(struct Antenna_deployment_status *response);
-uint8_t ANT_CMD_report_antenna_deployment_activation_count(uint8_t antenna, uint8_t *response);
-uint8_t ANT_CMD_report_antenna_deployment_activation_time(uint8_t antenna, uint16_t *result);
+uint8_t ANT_CMD_report_deployment_status(enum Ant_i2c_bus i2c_bus, struct Antenna_deployment_status *response);
+uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum Ant_i2c_bus i2c_bus, uint8_t antenna, uint8_t *response);
+uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum Ant_i2c_bus i2c_bus, uint8_t antenna, uint16_t *result);
 
 
 

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -22,18 +22,18 @@ struct Antenna_deployment_status {
     uint8_t antenna_system_armed;
 };
 
-uint8_t ANT_CMD_reset(enum Ant_i2c_bus_mcu i2c_bus_mcu);
-uint8_t ANT_CMD_arm_antenna_system(enum Ant_i2c_bus_mcu i2c_bus_mcu);
-uint8_t ANT_CMD_disarm_antenna_system(enum Ant_i2c_bus_mcu i2c_bus_mcu);
-uint8_t ANT_CMD_deploy_antenna(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint8_t activation_time_seconds);
-uint8_t ANT_CMD_start_automated_sequential_deployment(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t activation_time_seconds);
-uint8_t ANT_CMD_deploy_antenna_with_override(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint8_t activation_time_seconds);
-uint8_t ANT_CMD_cancel_deployment_system_activation(enum Ant_i2c_bus_mcu i2c_bus_mcu);
-uint8_t ANT_CMD_measure_temp(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint16_t *result);
+uint8_t ANT_CMD_reset(enum ANT_i2c_bus_mcu i2c_bus_mcu);
+uint8_t ANT_CMD_arm_antenna_system(enum ANT_i2c_bus_mcu i2c_bus_mcu);
+uint8_t ANT_CMD_disarm_antenna_system(enum ANT_i2c_bus_mcu i2c_bus_mcu);
+uint8_t ANT_CMD_deploy_antenna(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint8_t activation_time_seconds);
+uint8_t ANT_CMD_start_automated_sequential_deployment(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t activation_time_seconds);
+uint8_t ANT_CMD_deploy_antenna_with_override(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint8_t activation_time_seconds);
+uint8_t ANT_CMD_cancel_deployment_system_activation(enum ANT_i2c_bus_mcu i2c_bus_mcu);
+uint8_t ANT_CMD_measure_temp(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint16_t *result);
 int16_t ANT_convert_raw_temp_to_cCelsius(uint16_t measurement);
-uint8_t ANT_CMD_report_deployment_status(enum Ant_i2c_bus_mcu i2c_bus_mcu, struct Antenna_deployment_status *response);
-uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint8_t *response);
-uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint16_t *result);
+uint8_t ANT_CMD_report_deployment_status(enum ANT_i2c_bus_mcu i2c_bus_mcu, struct Antenna_deployment_status *response);
+uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint8_t *response);
+uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint16_t *result);
 
 
 

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -2,7 +2,7 @@
 #define __INCLUDE_GUARD_ANT_COMMANDS_H__
 
 #include <stdint.h>
-
+#include <ant_internal_drivers.h>
 
 struct Antenna_deployment_status {
     uint8_t antenna_1_deployed;

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -22,18 +22,18 @@ struct Antenna_deployment_status {
     uint8_t antenna_system_armed;
 };
 
-uint8_t ANT_CMD_reset(enum Ant_i2c_bus i2c_bus);
-uint8_t ANT_CMD_arm_antenna_system(enum Ant_i2c_bus i2c_bus);
-uint8_t ANT_CMD_disarm_antenna_system(enum Ant_i2c_bus i2c_bus);
-uint8_t ANT_CMD_deploy_antenna(enum Ant_i2c_bus i2c_bus, uint8_t antenna, uint8_t activation_time_seconds);
-uint8_t ANT_CMD_start_automated_sequential_deployment(enum Ant_i2c_bus i2c_bus, uint8_t activation_time_seconds);
-uint8_t ANT_CMD_deploy_antenna_with_override(enum Ant_i2c_bus i2c_bus, uint8_t antenna, uint8_t activation_time_seconds);
-uint8_t ANT_CMD_cancel_deployment_system_activation(enum Ant_i2c_bus i2c_bus);
-uint8_t ANT_CMD_measure_temp(enum Ant_i2c_bus i2c_bus, uint16_t *result);
+uint8_t ANT_CMD_reset(enum Ant_i2c_bus_mcu i2c_bus_mcu);
+uint8_t ANT_CMD_arm_antenna_system(enum Ant_i2c_bus_mcu i2c_bus_mcu);
+uint8_t ANT_CMD_disarm_antenna_system(enum Ant_i2c_bus_mcu i2c_bus_mcu);
+uint8_t ANT_CMD_deploy_antenna(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint8_t activation_time_seconds);
+uint8_t ANT_CMD_start_automated_sequential_deployment(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t activation_time_seconds);
+uint8_t ANT_CMD_deploy_antenna_with_override(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint8_t activation_time_seconds);
+uint8_t ANT_CMD_cancel_deployment_system_activation(enum Ant_i2c_bus_mcu i2c_bus_mcu);
+uint8_t ANT_CMD_measure_temp(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint16_t *result);
 int16_t ANT_convert_raw_temp_to_cCelsius(uint16_t measurement);
-uint8_t ANT_CMD_report_deployment_status(enum Ant_i2c_bus i2c_bus, struct Antenna_deployment_status *response);
-uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum Ant_i2c_bus i2c_bus, uint8_t antenna, uint8_t *response);
-uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum Ant_i2c_bus i2c_bus, uint8_t antenna, uint16_t *result);
+uint8_t ANT_CMD_report_deployment_status(enum Ant_i2c_bus_mcu i2c_bus_mcu, struct Antenna_deployment_status *response);
+uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint8_t *response);
+uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint16_t *result);
 
 
 

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -2,7 +2,7 @@
 #define __INCLUDE_GUARD_ANT_COMMANDS_H__
 
 #include <stdint.h>
-#include <ant_internal_drivers.h>
+#include "antenna_deploy_drivers/ant_internal_drivers.h"
 
 struct Antenna_deployment_status {
     uint8_t antenna_1_deployed;

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_internal_drivers.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_internal_drivers.h
@@ -5,11 +5,15 @@
 
 #define ANT_DEFAULT_RX_LEN_MIN 5 // for commands with no response params, 5 bytes are returned
 
-enum Ant_i2c_bus {
-    ANT_I2C_BUS_A,
-    ANT_I2C_BUS_B
+
+/// @brief the antenna deployment module has two different i2c connections and two different
+/// microcontrollers. The values of this enum represent a combination of the i2c line to
+/// use in transmission and the microcontroller to transmit to.
+enum Ant_i2c_bus_mcu {
+    ANT_I2C_BUS_A_MCU_A,
+    ANT_I2C_BUS_A_MCU_B
 };
-uint8_t ANT_send_cmd(enum Ant_i2c_bus i2c_bus, uint8_t cmd_buf[], uint8_t cmd_len);
-uint8_t ANT_get_response(enum Ant_i2c_bus i2c_bus, uint8_t rx_buf[], uint16_t rx_len);
+uint8_t ANT_send_cmd(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t cmd_buf[], uint8_t cmd_len);
+uint8_t ANT_get_response(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t rx_buf[], uint16_t rx_len);
 
 #endif /* __INCLUDE_GUARD_ANT_INTERNAL_DRIVERS_H__ */

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_internal_drivers.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_internal_drivers.h
@@ -9,11 +9,11 @@
 /// @brief the antenna deployment module has two different i2c connections and two different
 /// microcontrollers. The values of this enum represent a combination of the i2c line to
 /// use in transmission and the microcontroller to transmit to.
-enum Ant_i2c_bus_mcu {
+enum ANT_i2c_bus_mcu {
     ANT_I2C_BUS_A_MCU_A,
     ANT_I2C_BUS_B_MCU_B
 };
-uint8_t ANT_send_cmd(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t cmd_buf[], uint8_t cmd_len);
-uint8_t ANT_get_response(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t rx_buf[], uint16_t rx_len);
+uint8_t ANT_send_cmd(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t cmd_buf[], uint8_t cmd_len);
+uint8_t ANT_get_response(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t rx_buf[], uint16_t rx_len);
 
 #endif /* __INCLUDE_GUARD_ANT_INTERNAL_DRIVERS_H__ */

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_internal_drivers.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_internal_drivers.h
@@ -5,7 +5,11 @@
 
 #define ANT_DEFAULT_RX_LEN_MIN 5 // for commands with no response params, 5 bytes are returned
 
-uint8_t ANT_send_cmd(uint8_t cmd_buf[], uint8_t cmd_len);
+enum Ant_i2c_bus {
+    ANT_I2C_BUS_A,
+    ANT_I2C_BUS_B
+};
+uint8_t ANT_send_cmd(enum Ant_i2c_bus i2c_bus, uint8_t cmd_buf[], uint8_t cmd_len);
 uint8_t ANT_get_response(uint8_t rx_buf[], uint16_t rx_len);
 
 #endif /* __INCLUDE_GUARD_ANT_INTERNAL_DRIVERS_H__ */

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_internal_drivers.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_internal_drivers.h
@@ -10,6 +10,6 @@ enum Ant_i2c_bus {
     ANT_I2C_BUS_B
 };
 uint8_t ANT_send_cmd(enum Ant_i2c_bus i2c_bus, uint8_t cmd_buf[], uint8_t cmd_len);
-uint8_t ANT_get_response(uint8_t rx_buf[], uint16_t rx_len);
+uint8_t ANT_get_response(enum Ant_i2c_bus i2c_bus, uint8_t rx_buf[], uint16_t rx_len);
 
 #endif /* __INCLUDE_GUARD_ANT_INTERNAL_DRIVERS_H__ */

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_internal_drivers.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_internal_drivers.h
@@ -11,7 +11,7 @@
 /// use in transmission and the microcontroller to transmit to.
 enum Ant_i2c_bus_mcu {
     ANT_I2C_BUS_A_MCU_A,
-    ANT_I2C_BUS_A_MCU_B
+    ANT_I2C_BUS_B_MCU_B
 };
 uint8_t ANT_send_cmd(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t cmd_buf[], uint8_t cmd_len);
 uint8_t ANT_get_response(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t rx_buf[], uint16_t rx_len);

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
@@ -39,7 +39,7 @@ static const uint8_t ANT_CMD_REPORT_ANT4_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB7;
 /// @brief Performs a reset of the antenna deployment systems microcontroller which is specified 
 /// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to reset, and which i2c bus to use
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
-uint8_t ANT_CMD_reset(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
+uint8_t ANT_CMD_reset(enum ANT_i2c_bus_mcu i2c_bus_mcu) {
     const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
@@ -54,7 +54,7 @@ uint8_t ANT_CMD_reset(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
 /// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to arm, and which i2c bus to use
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 /// @note arming one mcu does not arm the other. Each mcu must be armed before it can be used to deploy
-uint8_t ANT_CMD_arm_antenna_system(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
+uint8_t ANT_CMD_arm_antenna_system(enum ANT_i2c_bus_mcu i2c_bus_mcu) {
     uint8_t cmd_len = 1;
     uint8_t cmd_buf[cmd_len];
 
@@ -67,7 +67,7 @@ uint8_t ANT_CMD_arm_antenna_system(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
 /// @brief Disarms the antenna deploy system
 /// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to disarm, and which i2c bus to use
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
-uint8_t ANT_CMD_disarm_antenna_system(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
+uint8_t ANT_CMD_disarm_antenna_system(enum ANT_i2c_bus_mcu i2c_bus_mcu) {
     const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
@@ -82,7 +82,7 @@ uint8_t ANT_CMD_disarm_antenna_system(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
 /// @param antenna The antenna number of the antenna to deploy, this is a number between 1-4.
 /// @param activation_time_seconds the amount of time the deployment system should be active for in seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise.
-uint8_t ANT_CMD_deploy_antenna(enum Ant_i2c_bus_mcu i2c_bus_mcu ,uint8_t antenna, uint8_t activation_time_seconds) {
+uint8_t ANT_CMD_deploy_antenna(enum ANT_i2c_bus_mcu i2c_bus_mcu ,uint8_t antenna, uint8_t activation_time_seconds) {
     const uint8_t cmd_len = 2;
     uint8_t cmd_buf[cmd_len];
 
@@ -102,7 +102,7 @@ uint8_t ANT_CMD_deploy_antenna(enum Ant_i2c_bus_mcu i2c_bus_mcu ,uint8_t antenna
         default:
             LOG_message(
                 LOG_SYSTEM_ANTENNA_DEPLOY,
-                LOG_SEVERITY_WARNING,
+                LOG_SEVERITY_ERROR,
                 LOG_SINK_ALL, 
                 "Invalid choice for antenna: antenna must be between 1-4 inclusive."
             );
@@ -118,7 +118,7 @@ uint8_t ANT_CMD_deploy_antenna(enum Ant_i2c_bus_mcu i2c_bus_mcu ,uint8_t antenna
 /// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to use, and which i2c bus to use
 /// @param activation_time_seconds the amount of time the deployment system for each antenna should be active for in seconds
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
-uint8_t ANT_CMD_start_automated_sequential_deployment(enum Ant_i2c_bus_mcu i2c_bus_mcu,uint8_t activation_time_seconds) {
+uint8_t ANT_CMD_start_automated_sequential_deployment(enum ANT_i2c_bus_mcu i2c_bus_mcu,uint8_t activation_time_seconds) {
     const uint8_t CMD_BUF_LEN = 2;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
@@ -134,7 +134,7 @@ uint8_t ANT_CMD_start_automated_sequential_deployment(enum Ant_i2c_bus_mcu i2c_b
 /// @param antenna the antenna to deploy 
 /// @param activation_time_seconds the amount of time the deployment system should be active for in seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise.
-uint8_t ANT_CMD_deploy_antenna_with_override(enum Ant_i2c_bus_mcu i2c_bus_mcu,uint8_t antenna, uint8_t activation_time_seconds) {
+uint8_t ANT_CMD_deploy_antenna_with_override(enum ANT_i2c_bus_mcu i2c_bus_mcu,uint8_t antenna, uint8_t activation_time_seconds) {
     const uint8_t CMD_BUF_LEN = 2;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
@@ -154,7 +154,7 @@ uint8_t ANT_CMD_deploy_antenna_with_override(enum Ant_i2c_bus_mcu i2c_bus_mcu,ui
         default:
             LOG_message(
                 LOG_SYSTEM_ANTENNA_DEPLOY,
-                LOG_SEVERITY_WARNING,
+                LOG_SEVERITY_ERROR,
                 LOG_SINK_ALL, 
                 "Invalid choice for antenna: antenna must be between 1-4 inclusive."
             );
@@ -169,7 +169,7 @@ uint8_t ANT_CMD_deploy_antenna_with_override(enum Ant_i2c_bus_mcu i2c_bus_mcu,ui
 /// @brief cancels any active attempts to deploy an antenna
 /// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
-uint8_t ANT_CMD_cancel_deployment_system_activation(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
+uint8_t ANT_CMD_cancel_deployment_system_activation(enum ANT_i2c_bus_mcu i2c_bus_mcu) {
     const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
@@ -184,7 +184,7 @@ uint8_t ANT_CMD_cancel_deployment_system_activation(enum Ant_i2c_bus_mcu i2c_bus
 /// @param result a pointer to a 16 bit unsigned integer where the temperature measurement is written. Refer to the 
 /// "ISIS.ANTS.UM.001" datasheet by ISISpace for information on interpreting this measurement
 /// @return 0 when the antenna deployment system has received the command, > 0 otherwise.
-uint8_t ANT_CMD_measure_temp(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint16_t *result) {
+uint8_t ANT_CMD_measure_temp(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint16_t *result) {
     const uint8_t cmd_len = 1;
     uint8_t cmd_buf[cmd_len];
 
@@ -218,7 +218,7 @@ static uint8_t extract_bit(uint8_t byte, uint8_t position) {return byte >> posit
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 /// @note - Data written to the response struct is only valid if 0 was returned. One should check this before using the response.
 /// @note - This command probes the micro controller specified. data from each mcu may differ.
-uint8_t ANT_CMD_report_deployment_status(enum Ant_i2c_bus_mcu i2c_bus_mcu, struct Antenna_deployment_status *response) {
+uint8_t ANT_CMD_report_deployment_status(enum ANT_i2c_bus_mcu i2c_bus_mcu, struct Antenna_deployment_status *response) {
     const uint8_t CMD_LEN  = 1;
     uint8_t cmd_buf[CMD_LEN];
 
@@ -259,7 +259,7 @@ uint8_t ANT_CMD_report_deployment_status(enum Ant_i2c_bus_mcu i2c_bus_mcu, struc
 /// @param response a 1 byte buffer where the count of attempted deployments will be written
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 /// @note data written to the response buffer is only valid if 0 was returned. One should check this before using the response.
-uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint8_t *response) {
+uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint8_t *response) {
     const uint8_t CMD_BUFF_SIZE = 1;
     uint8_t cmd_buf[CMD_BUFF_SIZE];
 
@@ -279,7 +279,7 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum Ant_i2c_bus_mcu 
         default:
             LOG_message(
                 LOG_SYSTEM_ANTENNA_DEPLOY,
-                LOG_SEVERITY_WARNING,
+                LOG_SEVERITY_ERROR,
                 LOG_SINK_ALL, 
                 "Invalid choice for antenna: antenna must be between 1-4 inclusive."
             );
@@ -300,7 +300,7 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum Ant_i2c_bus_mcu 
 /// @param response a 2 byte buffer where the cumulative deployment time (in 50ms increments) will be written. divide the response by 20 to get seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 /// @note data written to the result buffer is only valid if 0 was returned. One should check this before using the result.
-uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint16_t *result) {
+uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint16_t *result) {
     const uint8_t CMD_BUFF_SIZE = 1;
     uint8_t cmd_buf[CMD_BUFF_SIZE];
 
@@ -320,7 +320,7 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum Ant_i2c_bus_mcu i
         default:
             LOG_message(
                 LOG_SYSTEM_ANTENNA_DEPLOY,
-                LOG_SEVERITY_WARNING,
+                LOG_SEVERITY_ERROR,
                 LOG_SINK_ALL, 
                 "Invalid choice for antenna: antenna must be between 1-4 inclusive."
             );

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
@@ -38,38 +38,38 @@ static const uint8_t ANT_CMD_REPORT_ANT4_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB7;
 
 /// @brief Performs a reset of the antenna deployment systems microcontroller 
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
-uint8_t ANT_CMD_reset() {
+uint8_t ANT_CMD_reset(enum Ant_i2c_bus i2c_bus) {
     const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
     cmd_buf[0] = ANT_CMD_RESET;
 
-    const uint8_t send_status = ANT_send_cmd(cmd_buf, CMD_BUF_LEN); 
+    const uint8_t send_status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_BUF_LEN); 
     return send_status;
 }
 
 
 /// @brief  Arm the antenna deploy system
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
-uint8_t ANT_CMD_arm_antenna_system() {
+uint8_t ANT_CMD_arm_antenna_system(enum Ant_i2c_bus i2c_bus) {
     uint8_t cmd_len = 1;
     uint8_t cmd_buf[cmd_len];
 
     cmd_buf[0] = ANT_CMD_ARM_ANTENNA_SYSTEM;
 
-    const uint8_t comms_err = ANT_send_cmd(cmd_buf, cmd_len);
+    const uint8_t comms_err = ANT_send_cmd(i2c_bus, cmd_buf, cmd_len);
     return comms_err;
 }
 
 /// @brief Disarms the antenna deploy system
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
-uint8_t ANT_CMD_disarm_antenna_system() {
+uint8_t ANT_CMD_disarm_antenna_system(enum Ant_i2c_bus i2c_bus) {
     const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
     cmd_buf[0] = ANT_CMD_DISARM_ANTENNA_SYSTEM;
 
-    const uint8_t send_status = ANT_send_cmd(cmd_buf, CMD_BUF_LEN); 
+    const uint8_t send_status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_BUF_LEN); 
     return send_status;
 }
 
@@ -77,7 +77,7 @@ uint8_t ANT_CMD_disarm_antenna_system() {
 /// @param antenna The antenna number of the antenna to deploy, this is a number between 1-4.
 /// @param[in] activation_time_seconds the amount of time the deployment system should be active for in seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise.
-uint8_t ANT_CMD_deploy_antenna(uint8_t antenna, uint8_t activation_time_seconds) {
+uint8_t ANT_CMD_deploy_antenna(enum Ant_i2c_bus i2c_bus ,uint8_t antenna, uint8_t activation_time_seconds) {
     const uint8_t cmd_len = 2;
     uint8_t cmd_buf[cmd_len];
 
@@ -100,21 +100,21 @@ uint8_t ANT_CMD_deploy_antenna(uint8_t antenna, uint8_t activation_time_seconds)
     }
     cmd_buf[1] = activation_time_seconds;
 
-    const uint8_t comms_err = ANT_send_cmd(cmd_buf, cmd_len);
+    const uint8_t comms_err = ANT_send_cmd(i2c_bus, cmd_buf, cmd_len);
     return comms_err;
 }
 
 /// @brief deploys all antennas one by one sequentially.
 /// @param activation_time_seconds the amount of time the deployment system for each antenna should be active for in seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
-uint8_t ANT_CMD_start_automated_sequential_deployment(uint8_t activation_time_seconds) {
+uint8_t ANT_CMD_start_automated_sequential_deployment(enum Ant_i2c_bus i2c_bus,uint8_t activation_time_seconds) {
     const uint8_t CMD_BUF_LEN = 2;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
     cmd_buf[0] = ANT_CMD_DEPLOY_ALL_ANTENNAS_SEQ;
     cmd_buf[1] = activation_time_seconds;
 
-    const uint8_t send_status = ANT_send_cmd(cmd_buf, CMD_BUF_LEN); 
+    const uint8_t send_status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_BUF_LEN); 
     return send_status;
 }
 
@@ -122,7 +122,7 @@ uint8_t ANT_CMD_start_automated_sequential_deployment(uint8_t activation_time_se
 /// @param antenna the antenna to deploy 
 /// @param activation_time_seconds the amount of time the deployment system should be active for in seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise.
-uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation_time_seconds) {
+uint8_t ANT_CMD_deploy_antenna_with_override(enum Ant_i2c_bus i2c_bus,uint8_t antenna, uint8_t activation_time_seconds) {
     const uint8_t CMD_BUF_LEN = 2;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
@@ -145,19 +145,19 @@ uint8_t ANT_CMD_deploy_antenna_with_override(uint8_t antenna, uint8_t activation
     }
     cmd_buf[1] = activation_time_seconds;
 
-    const uint8_t send_status = ANT_send_cmd(cmd_buf, CMD_BUF_LEN); 
+    const uint8_t send_status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_BUF_LEN); 
     return send_status;
 }
 
 /// @brief cancels any active attempts to deploy an antenna
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
-uint8_t ANT_CMD_cancel_deployment_system_activation() {
+uint8_t ANT_CMD_cancel_deployment_system_activation(enum Ant_i2c_bus i2c_bus) {
     const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
     cmd_buf[0] = ANT_CMD_CANCEL_DEPLOYMENT;
 
-    const uint8_t send_status = ANT_send_cmd(cmd_buf, CMD_BUF_LEN); 
+    const uint8_t send_status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_BUF_LEN); 
     return send_status;
 }
 
@@ -165,7 +165,7 @@ uint8_t ANT_CMD_cancel_deployment_system_activation() {
 /// @param result a pointer to a 16 bit unsigned integer where the temperature measurement is written. Refer to the 
 /// "ISIS.ANTS.UM.001" datasheet by ISISpace for information on interpreting this measurement
 /// @return 0 when the antenna deployment system has received the command, > 0 otherwise.
-uint8_t ANT_CMD_measure_temp(uint16_t *result) {
+uint8_t ANT_CMD_measure_temp(enum Ant_i2c_bus i2c_bus, uint16_t *result) {
     const uint8_t cmd_len = 1;
     uint8_t cmd_buf[cmd_len];
 
@@ -174,9 +174,9 @@ uint8_t ANT_CMD_measure_temp(uint16_t *result) {
     uint8_t rx_len = 2;
     uint8_t rx_buf[rx_len];
 
-    uint8_t comms_err = ANT_send_cmd(cmd_buf, cmd_len);
+    uint8_t comms_err = ANT_send_cmd(i2c_bus, cmd_buf, cmd_len);
     if (comms_err == 0) {
-        comms_err = ANT_get_response(rx_buf, rx_len);
+        comms_err = ANT_get_response(i2c_bus, rx_buf, rx_len);
         *result = (rx_buf[1] << 8) | rx_buf[0];
     }
     return comms_err;
@@ -197,18 +197,18 @@ static uint8_t extract_bit(uint8_t byte, uint8_t position) {return byte >> posit
 /// @param response a two byte buffer where the status information is written to.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 /// @note data written to the response struct is only valid if 0 was returned. One should check this before using the response.
-uint8_t ANT_CMD_report_deployment_status(struct Antenna_deployment_status *response) {
+uint8_t ANT_CMD_report_deployment_status(enum Ant_i2c_bus i2c_bus, struct Antenna_deployment_status *response) {
     const uint8_t CMD_LEN  = 1;
     uint8_t cmd_buf[CMD_LEN];
 
     cmd_buf[0] = ANT_CMD_REPORT_DEPLOYMENT_STATUS;
 
-    uint8_t status = ANT_send_cmd(cmd_buf, CMD_LEN); 
+    uint8_t status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_LEN); 
     
     if (status == 0) {
         const uint8_t response_size = 2;
         uint8_t raw_bytes[response_size];
-        status = ANT_get_response(raw_bytes, response_size);
+        status = ANT_get_response(i2c_bus, raw_bytes, response_size);
 
         response->antenna_1_deployed= !extract_bit(raw_bytes[1], 7);       
         response->antenna_1_deployment_time_limit_reached= extract_bit(raw_bytes[1], 6);       
@@ -237,7 +237,7 @@ uint8_t ANT_CMD_report_deployment_status(struct Antenna_deployment_status *respo
 /// @param response a 1 byte buffer where the count of attempted deployments will be written
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 /// @note data written to the response buffer is only valid if 0 was returned. One should check this before using the response.
-uint8_t ANT_CMD_report_antenna_deployment_activation_count(uint8_t antenna, uint8_t *response) {
+uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum Ant_i2c_bus i2c_bus, uint8_t antenna, uint8_t *response) {
     const uint8_t CMD_BUFF_SIZE = 1;
     uint8_t cmd_buf[CMD_BUFF_SIZE];
 
@@ -259,10 +259,10 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_count(uint8_t antenna, uint
             return 1;
     }
 
-    uint8_t status = ANT_send_cmd(cmd_buf, CMD_BUFF_SIZE); 
+    uint8_t status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_BUFF_SIZE); 
     if(status == 0) {
         const uint8_t response_len = 1;
-        status = ANT_get_response(response, response_len);
+        status = ANT_get_response(i2c_bus, response, response_len);
     }
     return status;
 }
@@ -272,7 +272,7 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_count(uint8_t antenna, uint
 /// @param response a 2 byte buffer where the cumulative deployment time (in 50ms increments) will be written. divide the response by 20 to get seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 /// @note data written to the result buffer is only valid if 0 was returned. One should check this before using the result.
-uint8_t ANT_CMD_report_antenna_deployment_activation_time(uint8_t antenna, uint16_t *result) {
+uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum Ant_i2c_bus i2c_bus, uint8_t antenna, uint16_t *result) {
     const uint8_t CMD_BUFF_SIZE = 1;
     uint8_t cmd_buf[CMD_BUFF_SIZE];
 
@@ -294,11 +294,11 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_time(uint8_t antenna, uint1
             return 1;
     }
 
-    uint8_t status = ANT_send_cmd(cmd_buf, CMD_BUFF_SIZE); 
+    uint8_t status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_BUFF_SIZE); 
     if(status == 0) {
         const uint8_t response_len = 2; 
         uint8_t response[2];
-        status = ANT_get_response(response, response_len);
+        status = ANT_get_response(i2c_bus, response, response_len);
 
         *result = (response[1] << 8) | response[0];
     }

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
@@ -1,7 +1,7 @@
 #include "main.h"
 
-#include "antenna_deploy_drivers/ant_commands.h"
 #include "antenna_deploy_drivers/ant_internal_drivers.h"
+#include "antenna_deploy_drivers/ant_commands.h"
 #include "stm32l4xx_hal_i2c.h"
 #include "debug_tools/debug_uart.h"
 

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
@@ -3,17 +3,17 @@
 #include "antenna_deploy_drivers/ant_internal_drivers.h"
 #include "antenna_deploy_drivers/ant_commands.h"
 #include "stm32l4xx_hal_i2c.h"
-#include "debug_tools/debug_uart.h"
+#include "log/log.h"
 
 #include <stdint.h>
 #include <stdio.h>
 
 /*-----------------------------COMMAND VARIABLES-----------------------------*/
-// All commands in this section refer to the "ISIS.ANTS.UM.001" datasheet by ISISpace
+// All commands in this section come from the "ISIS.ANTS.UM.001" datasheet by ISISpace
 static const uint8_t ANT_CMD_RESET = 0xAA;
-static const uint8_t ANT_CMD_ARM_ANTENNA_SYSTEM = 0xAD; // Arm the antenna deploy system
+static const uint8_t ANT_CMD_ARM_ANTENNA_SYSTEM = 0xAD; 
 static const uint8_t ANT_CMD_DISARM_ANTENNA_SYSTEM = 0xAC;
-static const uint8_t ANT_CMD_DEPLOY_ANTENNA1 = 0xA1; // Deploy antenna 1
+static const uint8_t ANT_CMD_DEPLOY_ANTENNA1 = 0xA1; 
 static const uint8_t ANT_CMD_DEPLOY_ANTENNA2 = 0xA2;
 static const uint8_t ANT_CMD_DEPLOY_ANTENNA3 = 0xA3;
 static const uint8_t ANT_CMD_DEPLOY_ANTENNA4 = 0xA4;
@@ -36,8 +36,8 @@ static const uint8_t ANT_CMD_REPORT_ANT4_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB7;
 /*-----------------------------COMMAND VARIABLES-----------------------------*/
 
 
-/// @brief Performs a reset of the antenna deployment systems microcontroller 
-/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
+/// @brief Performs a reset of the antenna deployment systems microcontroller which is specified 
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to reset, and which i2c bus to use
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_reset(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
     const uint8_t CMD_BUF_LEN = 1;
@@ -51,8 +51,9 @@ uint8_t ANT_CMD_reset(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
 
 
 /// @brief  Arm the antenna deploy system
-/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to arm, and which i2c bus to use
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
+/// @note arming one mcu does not arm the other. Each mcu must be armed before it can be used to deploy
 uint8_t ANT_CMD_arm_antenna_system(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
     uint8_t cmd_len = 1;
     uint8_t cmd_buf[cmd_len];
@@ -64,7 +65,7 @@ uint8_t ANT_CMD_arm_antenna_system(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
 }
 
 /// @brief Disarms the antenna deploy system
-/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to disarm, and which i2c bus to use
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_disarm_antenna_system(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
     const uint8_t CMD_BUF_LEN = 1;
@@ -77,9 +78,9 @@ uint8_t ANT_CMD_disarm_antenna_system(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
 }
 
 /// @brief activates the deployment system for the selected antenna for the specified amount of time
-/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to use, and which i2c bus to use
 /// @param antenna The antenna number of the antenna to deploy, this is a number between 1-4.
-/// @param[in] activation_time_seconds the amount of time the deployment system should be active for in seconds.
+/// @param activation_time_seconds the amount of time the deployment system should be active for in seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise.
 uint8_t ANT_CMD_deploy_antenna(enum Ant_i2c_bus_mcu i2c_bus_mcu ,uint8_t antenna, uint8_t activation_time_seconds) {
     const uint8_t cmd_len = 2;
@@ -99,7 +100,12 @@ uint8_t ANT_CMD_deploy_antenna(enum Ant_i2c_bus_mcu i2c_bus_mcu ,uint8_t antenna
             cmd_buf[0] = ANT_CMD_DEPLOY_ANTENNA4;
             break;
         default:
-            DEBUG_uart_print_str("Invalid choice for antenna: antenna must be between 1-4 inclusive.");
+            LOG_message(
+                LOG_SYSTEM_ANTENNA_DEPLOY,
+                LOG_SEVERITY_WARNING,
+                LOG_SINK_ALL, 
+                "Invalid choice for antenna: antenna must be between 1-4 inclusive."
+            );
             return 1;
     }
     cmd_buf[1] = activation_time_seconds;
@@ -109,8 +115,8 @@ uint8_t ANT_CMD_deploy_antenna(enum Ant_i2c_bus_mcu i2c_bus_mcu ,uint8_t antenna
 }
 
 /// @brief deploys all antennas one by one sequentially.
-/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
-/// @param activation_time_seconds the amount of time the deployment system for each antenna should be active for in seconds.
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to use, and which i2c bus to use
+/// @param activation_time_seconds the amount of time the deployment system for each antenna should be active for in seconds
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_start_automated_sequential_deployment(enum Ant_i2c_bus_mcu i2c_bus_mcu,uint8_t activation_time_seconds) {
     const uint8_t CMD_BUF_LEN = 2;
@@ -124,7 +130,7 @@ uint8_t ANT_CMD_start_automated_sequential_deployment(enum Ant_i2c_bus_mcu i2c_b
 }
 
 /// @brief initiates deployment of the selected antenna, ignoring whether the current status of that antenna is deployed
-/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to use, and which i2c bus to use
 /// @param antenna the antenna to deploy 
 /// @param activation_time_seconds the amount of time the deployment system should be active for in seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise.
@@ -146,7 +152,12 @@ uint8_t ANT_CMD_deploy_antenna_with_override(enum Ant_i2c_bus_mcu i2c_bus_mcu,ui
             cmd_buf[0] = ANT_CMD_DEPLOY_ANTENNA4_OVERRIDE;
             break;
         default:
-            DEBUG_uart_print_str("Invalid choice for antenna: antenna must be between 1-4 inclusive.");
+            LOG_message(
+                LOG_SYSTEM_ANTENNA_DEPLOY,
+                LOG_SEVERITY_WARNING,
+                LOG_SINK_ALL, 
+                "Invalid choice for antenna: antenna must be between 1-4 inclusive."
+            );
             return 1;
     }
     cmd_buf[1] = activation_time_seconds;
@@ -156,7 +167,7 @@ uint8_t ANT_CMD_deploy_antenna_with_override(enum Ant_i2c_bus_mcu i2c_bus_mcu,ui
 }
 
 /// @brief cancels any active attempts to deploy an antenna
-/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 uint8_t ANT_CMD_cancel_deployment_system_activation(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
     const uint8_t CMD_BUF_LEN = 1;
@@ -169,7 +180,7 @@ uint8_t ANT_CMD_cancel_deployment_system_activation(enum Ant_i2c_bus_mcu i2c_bus
 }
 
 /// @brief Measures the temperature at the antenna controller system.
-/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use
 /// @param result a pointer to a 16 bit unsigned integer where the temperature measurement is written. Refer to the 
 /// "ISIS.ANTS.UM.001" datasheet by ISISpace for information on interpreting this measurement
 /// @return 0 when the antenna deployment system has received the command, > 0 otherwise.
@@ -202,10 +213,11 @@ static uint8_t extract_bit(uint8_t byte, uint8_t position) {return byte >> posit
 
 /// @brief writes 2 bytes of information representing the deployment status of the antennas to the passed buffer,
 ///         information on interpreting the response may be found in the ISIS Antenna System user manual. Doc ID: ISIS.ANTS.UM.001 pg. 42
-/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use
 /// @param response a two byte buffer where the status information is written to.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
-/// @note data written to the response struct is only valid if 0 was returned. One should check this before using the response.
+/// @note - Data written to the response struct is only valid if 0 was returned. One should check this before using the response.
+/// @note - This command probes the micro controller specified. data from each mcu may differ.
 uint8_t ANT_CMD_report_deployment_status(enum Ant_i2c_bus_mcu i2c_bus_mcu, struct Antenna_deployment_status *response) {
     const uint8_t CMD_LEN  = 1;
     uint8_t cmd_buf[CMD_LEN];
@@ -241,8 +253,8 @@ uint8_t ANT_CMD_report_deployment_status(enum Ant_i2c_bus_mcu i2c_bus_mcu, struc
     }
     return status;
 }
-/// @brief writes the number of times deployment has been attempted (for a specified antenna) in a response buffer.
-/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
+/// @brief writes the number of times deployment has been attempted (for a specified antenna and mcu) in a response buffer.
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to check, and which i2c bus to use
 /// @param antenna the antenna to check
 /// @param response a 1 byte buffer where the count of attempted deployments will be written
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
@@ -265,7 +277,12 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum Ant_i2c_bus_mcu 
             cmd_buf[0] = ANT_CMD_REPORT_ANT4_DEPLOYMENT_COUNT;
             break;
         default:
-            DEBUG_uart_print_str("Invalid choice for antenna: antenna must be between 1-4 inclusive.");
+            LOG_message(
+                LOG_SYSTEM_ANTENNA_DEPLOY,
+                LOG_SEVERITY_WARNING,
+                LOG_SINK_ALL, 
+                "Invalid choice for antenna: antenna must be between 1-4 inclusive."
+            );
             return 1;
     }
 
@@ -277,8 +294,8 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum Ant_i2c_bus_mcu 
     return status;
 }
 
-/// @brief writes the cumulative time (in 50ms increments) that the deployment system has been active (for a specified antenna) in a response buffer.
-/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
+/// @brief writes the cumulative time (in 50ms increments) that the deployment system has been active (for a specified antenna and mcu) in a response buffer.
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use
 /// @param antenna the antenna to check. A number between 1-4
 /// @param response a 2 byte buffer where the cumulative deployment time (in 50ms increments) will be written. divide the response by 20 to get seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
@@ -301,7 +318,12 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum Ant_i2c_bus_mcu i
             cmd_buf[0] = ANT_CMD_REPORT_ANT4_DEPLOYMENT_SYS_ACTIVATION_TIME;
             break;
         default:
-            DEBUG_uart_print_str("Invalid choice for antenna: antenna must be between 1-4 inclusive.");
+            LOG_message(
+                LOG_SYSTEM_ANTENNA_DEPLOY,
+                LOG_SEVERITY_WARNING,
+                LOG_SINK_ALL, 
+                "Invalid choice for antenna: antenna must be between 1-4 inclusive."
+            );
             return 1;
     }
 

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
@@ -37,47 +37,51 @@ static const uint8_t ANT_CMD_REPORT_ANT4_DEPLOYMENT_SYS_ACTIVATION_TIME= 0xB7;
 
 
 /// @brief Performs a reset of the antenna deployment systems microcontroller 
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
-uint8_t ANT_CMD_reset(enum Ant_i2c_bus i2c_bus) {
+uint8_t ANT_CMD_reset(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
     const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
     cmd_buf[0] = ANT_CMD_RESET;
 
-    const uint8_t send_status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_BUF_LEN); 
+    const uint8_t send_status = ANT_send_cmd(i2c_bus_mcu, cmd_buf, CMD_BUF_LEN); 
     return send_status;
 }
 
 
 /// @brief  Arm the antenna deploy system
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
-uint8_t ANT_CMD_arm_antenna_system(enum Ant_i2c_bus i2c_bus) {
+uint8_t ANT_CMD_arm_antenna_system(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
     uint8_t cmd_len = 1;
     uint8_t cmd_buf[cmd_len];
 
     cmd_buf[0] = ANT_CMD_ARM_ANTENNA_SYSTEM;
 
-    const uint8_t comms_err = ANT_send_cmd(i2c_bus, cmd_buf, cmd_len);
+    const uint8_t comms_err = ANT_send_cmd(i2c_bus_mcu, cmd_buf, cmd_len);
     return comms_err;
 }
 
 /// @brief Disarms the antenna deploy system
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
-uint8_t ANT_CMD_disarm_antenna_system(enum Ant_i2c_bus i2c_bus) {
+uint8_t ANT_CMD_disarm_antenna_system(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
     const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
     cmd_buf[0] = ANT_CMD_DISARM_ANTENNA_SYSTEM;
 
-    const uint8_t send_status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_BUF_LEN); 
+    const uint8_t send_status = ANT_send_cmd(i2c_bus_mcu, cmd_buf, CMD_BUF_LEN); 
     return send_status;
 }
 
 /// @brief activates the deployment system for the selected antenna for the specified amount of time
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
 /// @param antenna The antenna number of the antenna to deploy, this is a number between 1-4.
 /// @param[in] activation_time_seconds the amount of time the deployment system should be active for in seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise.
-uint8_t ANT_CMD_deploy_antenna(enum Ant_i2c_bus i2c_bus ,uint8_t antenna, uint8_t activation_time_seconds) {
+uint8_t ANT_CMD_deploy_antenna(enum Ant_i2c_bus_mcu i2c_bus_mcu ,uint8_t antenna, uint8_t activation_time_seconds) {
     const uint8_t cmd_len = 2;
     uint8_t cmd_buf[cmd_len];
 
@@ -100,29 +104,31 @@ uint8_t ANT_CMD_deploy_antenna(enum Ant_i2c_bus i2c_bus ,uint8_t antenna, uint8_
     }
     cmd_buf[1] = activation_time_seconds;
 
-    const uint8_t comms_err = ANT_send_cmd(i2c_bus, cmd_buf, cmd_len);
+    const uint8_t comms_err = ANT_send_cmd(i2c_bus_mcu, cmd_buf, cmd_len);
     return comms_err;
 }
 
 /// @brief deploys all antennas one by one sequentially.
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
 /// @param activation_time_seconds the amount of time the deployment system for each antenna should be active for in seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
-uint8_t ANT_CMD_start_automated_sequential_deployment(enum Ant_i2c_bus i2c_bus,uint8_t activation_time_seconds) {
+uint8_t ANT_CMD_start_automated_sequential_deployment(enum Ant_i2c_bus_mcu i2c_bus_mcu,uint8_t activation_time_seconds) {
     const uint8_t CMD_BUF_LEN = 2;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
     cmd_buf[0] = ANT_CMD_DEPLOY_ALL_ANTENNAS_SEQ;
     cmd_buf[1] = activation_time_seconds;
 
-    const uint8_t send_status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_BUF_LEN); 
+    const uint8_t send_status = ANT_send_cmd(i2c_bus_mcu, cmd_buf, CMD_BUF_LEN); 
     return send_status;
 }
 
 /// @brief initiates deployment of the selected antenna, ignoring whether the current status of that antenna is deployed
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
 /// @param antenna the antenna to deploy 
 /// @param activation_time_seconds the amount of time the deployment system should be active for in seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise.
-uint8_t ANT_CMD_deploy_antenna_with_override(enum Ant_i2c_bus i2c_bus,uint8_t antenna, uint8_t activation_time_seconds) {
+uint8_t ANT_CMD_deploy_antenna_with_override(enum Ant_i2c_bus_mcu i2c_bus_mcu,uint8_t antenna, uint8_t activation_time_seconds) {
     const uint8_t CMD_BUF_LEN = 2;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
@@ -145,27 +151,29 @@ uint8_t ANT_CMD_deploy_antenna_with_override(enum Ant_i2c_bus i2c_bus,uint8_t an
     }
     cmd_buf[1] = activation_time_seconds;
 
-    const uint8_t send_status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_BUF_LEN); 
+    const uint8_t send_status = ANT_send_cmd(i2c_bus_mcu, cmd_buf, CMD_BUF_LEN); 
     return send_status;
 }
 
 /// @brief cancels any active attempts to deploy an antenna
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
-uint8_t ANT_CMD_cancel_deployment_system_activation(enum Ant_i2c_bus i2c_bus) {
+uint8_t ANT_CMD_cancel_deployment_system_activation(enum Ant_i2c_bus_mcu i2c_bus_mcu) {
     const uint8_t CMD_BUF_LEN = 1;
     uint8_t cmd_buf[CMD_BUF_LEN];
 
     cmd_buf[0] = ANT_CMD_CANCEL_DEPLOYMENT;
 
-    const uint8_t send_status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_BUF_LEN); 
+    const uint8_t send_status = ANT_send_cmd(i2c_bus_mcu, cmd_buf, CMD_BUF_LEN); 
     return send_status;
 }
 
 /// @brief Measures the temperature at the antenna controller system.
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
 /// @param result a pointer to a 16 bit unsigned integer where the temperature measurement is written. Refer to the 
 /// "ISIS.ANTS.UM.001" datasheet by ISISpace for information on interpreting this measurement
 /// @return 0 when the antenna deployment system has received the command, > 0 otherwise.
-uint8_t ANT_CMD_measure_temp(enum Ant_i2c_bus i2c_bus, uint16_t *result) {
+uint8_t ANT_CMD_measure_temp(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint16_t *result) {
     const uint8_t cmd_len = 1;
     uint8_t cmd_buf[cmd_len];
 
@@ -174,9 +182,9 @@ uint8_t ANT_CMD_measure_temp(enum Ant_i2c_bus i2c_bus, uint16_t *result) {
     uint8_t rx_len = 2;
     uint8_t rx_buf[rx_len];
 
-    uint8_t comms_err = ANT_send_cmd(i2c_bus, cmd_buf, cmd_len);
+    uint8_t comms_err = ANT_send_cmd(i2c_bus_mcu, cmd_buf, cmd_len);
     if (comms_err == 0) {
-        comms_err = ANT_get_response(i2c_bus, rx_buf, rx_len);
+        comms_err = ANT_get_response(i2c_bus_mcu, rx_buf, rx_len);
         *result = (rx_buf[1] << 8) | rx_buf[0];
     }
     return comms_err;
@@ -194,21 +202,22 @@ static uint8_t extract_bit(uint8_t byte, uint8_t position) {return byte >> posit
 
 /// @brief writes 2 bytes of information representing the deployment status of the antennas to the passed buffer,
 ///         information on interpreting the response may be found in the ISIS Antenna System user manual. Doc ID: ISIS.ANTS.UM.001 pg. 42
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
 /// @param response a two byte buffer where the status information is written to.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 /// @note data written to the response struct is only valid if 0 was returned. One should check this before using the response.
-uint8_t ANT_CMD_report_deployment_status(enum Ant_i2c_bus i2c_bus, struct Antenna_deployment_status *response) {
+uint8_t ANT_CMD_report_deployment_status(enum Ant_i2c_bus_mcu i2c_bus_mcu, struct Antenna_deployment_status *response) {
     const uint8_t CMD_LEN  = 1;
     uint8_t cmd_buf[CMD_LEN];
 
     cmd_buf[0] = ANT_CMD_REPORT_DEPLOYMENT_STATUS;
 
-    uint8_t status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_LEN); 
+    uint8_t status = ANT_send_cmd(i2c_bus_mcu, cmd_buf, CMD_LEN); 
     
     if (status == 0) {
         const uint8_t response_size = 2;
         uint8_t raw_bytes[response_size];
-        status = ANT_get_response(i2c_bus, raw_bytes, response_size);
+        status = ANT_get_response(i2c_bus_mcu, raw_bytes, response_size);
 
         response->antenna_1_deployed= !extract_bit(raw_bytes[1], 7);       
         response->antenna_1_deployment_time_limit_reached= extract_bit(raw_bytes[1], 6);       
@@ -233,11 +242,12 @@ uint8_t ANT_CMD_report_deployment_status(enum Ant_i2c_bus i2c_bus, struct Antenn
     return status;
 }
 /// @brief writes the number of times deployment has been attempted (for a specified antenna) in a response buffer.
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
 /// @param antenna the antenna to check
 /// @param response a 1 byte buffer where the count of attempted deployments will be written
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 /// @note data written to the response buffer is only valid if 0 was returned. One should check this before using the response.
-uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum Ant_i2c_bus i2c_bus, uint8_t antenna, uint8_t *response) {
+uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint8_t *response) {
     const uint8_t CMD_BUFF_SIZE = 1;
     uint8_t cmd_buf[CMD_BUFF_SIZE];
 
@@ -259,20 +269,21 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum Ant_i2c_bus i2c_
             return 1;
     }
 
-    uint8_t status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_BUFF_SIZE); 
+    uint8_t status = ANT_send_cmd(i2c_bus_mcu, cmd_buf, CMD_BUFF_SIZE); 
     if(status == 0) {
         const uint8_t response_len = 1;
-        status = ANT_get_response(i2c_bus, response, response_len);
+        status = ANT_get_response(i2c_bus_mcu, response, response_len);
     }
     return status;
 }
 
 /// @brief writes the cumulative time (in 50ms increments) that the deployment system has been active (for a specified antenna) in a response buffer.
+/// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use
 /// @param antenna the antenna to check. A number between 1-4
 /// @param response a 2 byte buffer where the cumulative deployment time (in 50ms increments) will be written. divide the response by 20 to get seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 /// @note data written to the result buffer is only valid if 0 was returned. One should check this before using the result.
-uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum Ant_i2c_bus i2c_bus, uint8_t antenna, uint16_t *result) {
+uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint16_t *result) {
     const uint8_t CMD_BUFF_SIZE = 1;
     uint8_t cmd_buf[CMD_BUFF_SIZE];
 
@@ -294,11 +305,11 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum Ant_i2c_bus i2c_b
             return 1;
     }
 
-    uint8_t status = ANT_send_cmd(i2c_bus, cmd_buf, CMD_BUFF_SIZE); 
+    uint8_t status = ANT_send_cmd(i2c_bus_mcu, cmd_buf, CMD_BUFF_SIZE); 
     if(status == 0) {
         const uint8_t response_len = 2; 
         uint8_t response[2];
-        status = ANT_get_response(i2c_bus, response, response_len);
+        status = ANT_get_response(i2c_bus_mcu, response, response_len);
 
         *result = (response[1] << 8) | response[0];
     }

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_internal_drivers.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_internal_drivers.c
@@ -56,7 +56,7 @@ uint8_t ANT_send_cmd(enum Ant_i2c_bus i2c_bus, uint8_t cmd_buf[], uint8_t cmd_le
  * @return 0 upon success, 4 if read_status received HAL_ERROR
  */
 uint8_t ANT_get_response(enum Ant_i2c_bus i2c_bus, uint8_t rx_buf[], uint16_t rx_len) {
-    HAL_StatusTypeDef read_status;
+    HAL_StatusTypeDef read_status = HAL_ERROR;
     
     switch (i2c_bus) {
     case ANT_I2C_BUS_A:

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_internal_drivers.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_internal_drivers.c
@@ -6,8 +6,9 @@
 #include "debug_uart.h"
 #include <stdint.h>
 #include <string.h>
-
-const uint16_t ANT_ADDR = 0x31 << 1;
+//TODO: so much to do, mainly changing any calls to ANT_ADDR to use new names
+const uint16_t ANT_ADDR_A = 0x31 << 1;
+const uint16_t ANT_ADDR_B = 0x32 << 1;
 const uint8_t timeout = 50;
 
 extern I2C_HandleTypeDef hi2c2;
@@ -27,7 +28,7 @@ uint8_t ANT_send_cmd(enum Ant_i2c_bus i2c_bus, uint8_t cmd_buf[], uint8_t cmd_le
             transmit_status = HAL_I2C_Master_Transmit(&hi2c2, ANT_ADDR, cmd_buf, cmd_len, timeout);
             break;
         case ANT_I2C_BUS_B:
-            transmit_status = HAL_I2C_Master_Transmit(&hi2c3, ANT_ADDR, cmd_buf, cmd_len, timeout);
+            transmit_status = HAL_I2C_Master_Transmit(&hi2c3, ANT_ADDR_B, cmd_buf, cmd_len, timeout);
             break;
         default:
             DEBUG_uart_print_str("invalid i2c bus passed");

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_internal_drivers.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_internal_drivers.c
@@ -3,7 +3,7 @@
 #include "stm32l4xx_hal_i2c.h"
 #include "antenna_deploy_drivers/ant_internal_drivers.h"
 #include "debug_tools/debug_i2c.h"
-
+#include "debug_uart.h"
 #include <stdint.h>
 #include <string.h>
 
@@ -11,41 +11,70 @@ const uint16_t ANT_ADDR = 0x31 << 1;
 const uint8_t timeout = 50;
 
 extern I2C_HandleTypeDef hi2c2;
+extern I2C_HandleTypeDef hi2c3;
 
 /**
  * @brief Sends a command to the antenna controller.
- * 
+ * @param i2c_bus  
  * @param cmd_buf Array of bytes to send to the antenna controller
  * @param cmd_len Length of the command buffer
- * @return 0 upon success, 1 if tx_status received HAL_ERROR, 2 if tx_status received HAL_BUSY, 3 if tx_status received HAL_TIMEOUT
+ * @return 0 upon success, 1 if tx_status received HAL_ERROR, 2 if tx_status received HAL_BUSY, 3 if tx_status received HAL_TIMEOUT, 4 if invalid i2c bus is passed
  */
-uint8_t ANT_send_cmd(uint8_t cmd_buf[], uint8_t cmd_len) {
-    const HAL_StatusTypeDef tx_status = HAL_I2C_Master_Transmit(&hi2c2, ANT_ADDR, cmd_buf, cmd_len, timeout);
-    if (tx_status == HAL_ERROR) {
-        // TODO: Add print statement for debugging
-        return 1;
-    } else if(tx_status == HAL_BUSY) {
-        return 2;
-    } else if(tx_status == HAL_TIMEOUT) {
-        return 3;
+uint8_t ANT_send_cmd(enum Ant_i2c_bus i2c_bus, uint8_t cmd_buf[], uint8_t cmd_len) {
+    HAL_StatusTypeDef transmit_status;
+    switch(i2c_bus) {
+        case ANT_I2C_BUS_A:
+            transmit_status = HAL_I2C_Master_Transmit(&hi2c2, ANT_ADDR, cmd_buf, cmd_len, timeout);
+            break;
+        case ANT_I2C_BUS_B:
+            transmit_status = HAL_I2C_Master_Transmit(&hi2c3, ANT_ADDR, cmd_buf, cmd_len, timeout);
+            break;
+        default:
+            DEBUG_uart_print_str("invalid i2c bus passed");
+            return 4;
     }
 
+    if (transmit_status == HAL_ERROR) {
+        // TODO: Add print statement for debugging
+        DEBUG_uart_print_str("i2c transmit failed: HAL_ERROR");
+        return 1;
+    } else if(transmit_status == HAL_BUSY) {
+        DEBUG_uart_print_str("i2c transmit failed: HAL_BUSY");
+        return 2;
+    } else if(transmit_status == HAL_TIMEOUT) {
+        DEBUG_uart_print_str("i2c transmit failed: HAL_TIMEOUT");
+        return 3;
+    }
     return 0;
 }
 
 /**
  * @brief Receives a response from the antenna controller.
- * 
+ * @param i2c_bus the i2c_bus to read from. Either ANT_I2C_BUS_A or ANT_I2C_BUS_B  
  * @param rx_buf Array to store the response from the antenna controller
  * @param rx_len Length of the response buffer
- * @return 0 upon success, 4 if rx_status received HAL_ERROR
+ * @return 0 upon success, 4 if read_status received HAL_ERROR
  */
-uint8_t ANT_get_response(uint8_t rx_buf[], uint16_t rx_len) {
-    const HAL_StatusTypeDef rx_status = HAL_I2C_Master_Receive(&hi2c2, ANT_ADDR, rx_buf, rx_len, timeout);
-        if(rx_status != HAL_OK) {
-            // TODO: Add print statement for debugging
-            return 4;
-        }
+uint8_t ANT_get_response(enum Ant_i2c_bus i2c_bus, uint8_t rx_buf[], uint16_t rx_len) {
+    HAL_StatusTypeDef read_status;
     
+    switch (i2c_bus) {
+    case ANT_I2C_BUS_A:
+        read_status = HAL_I2C_Master_Receive(&hi2c2, ANT_ADDR, rx_buf, rx_len, timeout);
+        break;
+    
+    case ANT_I2C_BUS_B:
+        read_status = HAL_I2C_Master_Receive(&hi2c3, ANT_ADDR, rx_buf, rx_len, timeout);
+        break;
+
+    default:
+        DEBUG_uart_print_str("invalid choice of i2c bus");
+        break;
+    }
+
+    if(read_status != HAL_OK) {
+        DEBUG_uart_print_str("i2c read failed: HAL_ERROR");
+        return 4;
+    }
     return 0;
 }

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_internal_drivers.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_internal_drivers.c
@@ -3,7 +3,7 @@
 #include "stm32l4xx_hal_i2c.h"
 #include "antenna_deploy_drivers/ant_internal_drivers.h"
 #include "debug_tools/debug_i2c.h"
-#include "debug_uart.h"
+#include "debug_tools/debug_uart.h"
 #include <stdint.h>
 #include <string.h>
 //TODO: so much to do, mainly changing any calls to ANT_ADDR to use new names

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_internal_drivers.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_internal_drivers.c
@@ -16,18 +16,18 @@ extern I2C_HandleTypeDef hi2c3;
 
 /**
  * @brief Sends a command to the antenna controller.
- * @param i2c_bus  
+ * @param i2c_bus_mcu  
  * @param cmd_buf Array of bytes to send to the antenna controller
  * @param cmd_len Length of the command buffer
  * @return 0 upon success, 1 if tx_status received HAL_ERROR, 2 if tx_status received HAL_BUSY, 3 if tx_status received HAL_TIMEOUT, 4 if invalid i2c bus is passed
  */
-uint8_t ANT_send_cmd(enum Ant_i2c_bus i2c_bus, uint8_t cmd_buf[], uint8_t cmd_len) {
+uint8_t ANT_send_cmd(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t cmd_buf[], uint8_t cmd_len) {
     HAL_StatusTypeDef transmit_status;
-    switch(i2c_bus) {
-        case ANT_I2C_BUS_A:
+    switch(i2c_bus_mcu) {
+        case ANT_I2C_BUS_A_MCU_A:
             transmit_status = HAL_I2C_Master_Transmit(&hi2c2, ANT_ADDR_A, cmd_buf, cmd_len, timeout);
             break;
-        case ANT_I2C_BUS_B:
+        case ANT_I2C_BUS_A_MCU_B:
             transmit_status = HAL_I2C_Master_Transmit(&hi2c3, ANT_ADDR_B, cmd_buf, cmd_len, timeout);
             break;
         default:
@@ -51,20 +51,20 @@ uint8_t ANT_send_cmd(enum Ant_i2c_bus i2c_bus, uint8_t cmd_buf[], uint8_t cmd_le
 
 /**
  * @brief Receives a response from the antenna controller.
- * @param i2c_bus the i2c_bus to read from. Either ANT_I2C_BUS_A or ANT_I2C_BUS_B  
+ * @param i2c_bus_mcu the i2c_bus_mcu to read from. Either ANT_I2C_BUS_A_MCU_A or ANT_I2C_BUS_A_MCU_B  
  * @param rx_buf Array to store the response from the antenna controller
  * @param rx_len Length of the response buffer
  * @return 0 upon success, 4 if read_status received HAL_ERROR
  */
-uint8_t ANT_get_response(enum Ant_i2c_bus i2c_bus, uint8_t rx_buf[], uint16_t rx_len) {
+uint8_t ANT_get_response(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t rx_buf[], uint16_t rx_len) {
     HAL_StatusTypeDef read_status = HAL_ERROR;
     
-    switch (i2c_bus) {
-    case ANT_I2C_BUS_A:
+    switch (i2c_bus_mcu) {
+    case ANT_I2C_BUS_A_MCU_A:
         read_status = HAL_I2C_Master_Receive(&hi2c2, ANT_ADDR_A, rx_buf, rx_len, timeout);
         break;
     
-    case ANT_I2C_BUS_B:
+    case ANT_I2C_BUS_A_MCU_B:
         read_status = HAL_I2C_Master_Receive(&hi2c3, ANT_ADDR_B, rx_buf, rx_len, timeout);
         break;
 

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_internal_drivers.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_internal_drivers.c
@@ -25,7 +25,7 @@ uint8_t ANT_send_cmd(enum Ant_i2c_bus i2c_bus, uint8_t cmd_buf[], uint8_t cmd_le
     HAL_StatusTypeDef transmit_status;
     switch(i2c_bus) {
         case ANT_I2C_BUS_A:
-            transmit_status = HAL_I2C_Master_Transmit(&hi2c2, ANT_ADDR, cmd_buf, cmd_len, timeout);
+            transmit_status = HAL_I2C_Master_Transmit(&hi2c2, ANT_ADDR_A, cmd_buf, cmd_len, timeout);
             break;
         case ANT_I2C_BUS_B:
             transmit_status = HAL_I2C_Master_Transmit(&hi2c3, ANT_ADDR_B, cmd_buf, cmd_len, timeout);
@@ -61,11 +61,11 @@ uint8_t ANT_get_response(enum Ant_i2c_bus i2c_bus, uint8_t rx_buf[], uint16_t rx
     
     switch (i2c_bus) {
     case ANT_I2C_BUS_A:
-        read_status = HAL_I2C_Master_Receive(&hi2c2, ANT_ADDR, rx_buf, rx_len, timeout);
+        read_status = HAL_I2C_Master_Receive(&hi2c2, ANT_ADDR_A, rx_buf, rx_len, timeout);
         break;
     
     case ANT_I2C_BUS_B:
-        read_status = HAL_I2C_Master_Receive(&hi2c3, ANT_ADDR, rx_buf, rx_len, timeout);
+        read_status = HAL_I2C_Master_Receive(&hi2c3, ANT_ADDR_B, rx_buf, rx_len, timeout);
         break;
 
     default:

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_internal_drivers.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_internal_drivers.c
@@ -1,25 +1,36 @@
 #include "main.h"
 
 #include "stm32l4xx_hal_i2c.h"
+#include "stm32l4xx_hal_def.h"
 #include "antenna_deploy_drivers/ant_internal_drivers.h"
 #include "debug_tools/debug_i2c.h"
 #include "debug_tools/debug_uart.h"
+#include "log/log.h"
 #include <stdint.h>
 #include <string.h>
-//TODO: so much to do, mainly changing any calls to ANT_ADDR to use new names
-const uint16_t ANT_ADDR_A = 0x31 << 1;
-const uint16_t ANT_ADDR_B = 0x32 << 1;
+
+/**
+ * @brief This file contains commands for communicating with the antenna deploy system(ADS). The ADS has two microcontrollers which control
+ * the deployment of the antennas. It also has two seperate i2c buses which can be used to communicate with the ADS. The combination of 
+ * microcontroller (mcu) to communicate to and i2c line to use is specified using a value from the Ant_i2c_bus_mcu enum. 
+ * 
+ */
+ 
+
+const uint16_t ANT_ADDR_A = 0x31 << 1; // i2c address of mcu A on ant deploy system
+const uint16_t ANT_ADDR_B = 0x32 << 1; // i2c address of mcu B on ant deploy system
+
 const uint8_t timeout = 50;
 
-extern I2C_HandleTypeDef hi2c2;
-extern I2C_HandleTypeDef hi2c3;
+extern I2C_HandleTypeDef hi2c2; //i2c bus A
+extern I2C_HandleTypeDef hi2c3; //i2c bus B
 
 /**
  * @brief Sends a command to the antenna controller.
- * @param i2c_bus_mcu  
+ * @param i2c_bus_mcu  the i2c_bus and mcu combination to use/transmit to. Either ANT_I2C_BUS_A_MCU_A or ANT_I2C_BUS_B_MCU_B
  * @param cmd_buf Array of bytes to send to the antenna controller
  * @param cmd_len Length of the command buffer
- * @return 0 upon success, 1 if tx_status received HAL_ERROR, 2 if tx_status received HAL_BUSY, 3 if tx_status received HAL_TIMEOUT, 4 if invalid i2c bus is passed
+ * @return 0 upon success, 1 if tx_status received HAL_ERROR, 2 if tx_status received HAL_BUSY, 3 if tx_status received HAL_TIMEOUT, 4 if invalid i2c bus/mcu is passed
  */
 uint8_t ANT_send_cmd(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t cmd_buf[], uint8_t cmd_len) {
     HAL_StatusTypeDef transmit_status;
@@ -27,23 +38,23 @@ uint8_t ANT_send_cmd(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t cmd_buf[], uint8_
         case ANT_I2C_BUS_A_MCU_A:
             transmit_status = HAL_I2C_Master_Transmit(&hi2c2, ANT_ADDR_A, cmd_buf, cmd_len, timeout);
             break;
-        case ANT_I2C_BUS_A_MCU_B:
+        case ANT_I2C_BUS_B_MCU_B:
             transmit_status = HAL_I2C_Master_Transmit(&hi2c3, ANT_ADDR_B, cmd_buf, cmd_len, timeout);
             break;
         default:
             DEBUG_uart_print_str("invalid i2c bus passed");
+            LOG_message(LOG_SYSTEM_ANTENNA_DEPLOY, LOG_SEVERITY_WARNING, LOG_SINK_ALL, "Invalid choice for i2c bus/mcu");
             return 4;
     }
 
     if (transmit_status == HAL_ERROR) {
-        // TODO: Add print statement for debugging
-        DEBUG_uart_print_str("i2c transmit failed: HAL_ERROR");
+        LOG_message(LOG_SYSTEM_ANTENNA_DEPLOY, LOG_SEVERITY_WARNING, LOG_SINK_ALL, "I2C transmit failed: HAL_ERROR");
         return 1;
     } else if(transmit_status == HAL_BUSY) {
-        DEBUG_uart_print_str("i2c transmit failed: HAL_BUSY");
+        LOG_message(LOG_SYSTEM_ANTENNA_DEPLOY, LOG_SEVERITY_WARNING, LOG_SINK_ALL, "I2C transmit failed: HAL_BUSY");
         return 2;
     } else if(transmit_status == HAL_TIMEOUT) {
-        DEBUG_uart_print_str("i2c transmit failed: HAL_TIMEOUT");
+        LOG_message(LOG_SYSTEM_ANTENNA_DEPLOY, LOG_SEVERITY_WARNING, LOG_SINK_ALL, "I2C transmit failed: HAL_TIMEOUT");
         return 3;
     }
     return 0;
@@ -51,10 +62,10 @@ uint8_t ANT_send_cmd(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t cmd_buf[], uint8_
 
 /**
  * @brief Receives a response from the antenna controller.
- * @param i2c_bus_mcu the i2c_bus_mcu to read from. Either ANT_I2C_BUS_A_MCU_A or ANT_I2C_BUS_A_MCU_B  
+ * @param i2c_bus_mcu the i2c_bus_mcu to read from. Either ANT_I2C_BUS_A_MCU_A or ANT_I2C_BUS_B_MCU_B  
  * @param rx_buf Array to store the response from the antenna controller
  * @param rx_len Length of the response buffer
- * @return 0 upon success, 4 if read_status received HAL_ERROR
+ * @return 0 upon success, 1 if read_status received HAL_ERROR
  */
 uint8_t ANT_get_response(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t rx_buf[], uint16_t rx_len) {
     HAL_StatusTypeDef read_status = HAL_ERROR;
@@ -64,18 +75,18 @@ uint8_t ANT_get_response(enum Ant_i2c_bus_mcu i2c_bus_mcu, uint8_t rx_buf[], uin
         read_status = HAL_I2C_Master_Receive(&hi2c2, ANT_ADDR_A, rx_buf, rx_len, timeout);
         break;
     
-    case ANT_I2C_BUS_A_MCU_B:
+    case ANT_I2C_BUS_B_MCU_B:
         read_status = HAL_I2C_Master_Receive(&hi2c3, ANT_ADDR_B, rx_buf, rx_len, timeout);
         break;
 
     default:
-        DEBUG_uart_print_str("invalid choice of i2c bus");
+        LOG_message(LOG_SYSTEM_ANTENNA_DEPLOY, LOG_SEVERITY_WARNING, LOG_SINK_ALL, "Invalid choice of i2c bus/mcu");
         break;
     }
 
     if(read_status != HAL_OK) {
-        DEBUG_uart_print_str("i2c read failed: HAL_ERROR");
-        return 4;
+        LOG_message(LOG_SYSTEM_ANTENNA_DEPLOY, LOG_SEVERITY_WARNING, LOG_SINK_ALL, "I2C read failed: HAL_ERROR");
+        return 1;
     }
     return 0;
 }

--- a/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
@@ -11,16 +11,16 @@
 #include <string.h>
 #include "inttypes.h"
 
-/// @brief Resets the antenna deployment system's microcontroller
+/// @brief Resets the specified antenna deployment system's microcontroller
 /// @param args_str
-/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// @return 0 on success, > 0 otherwise
 uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) 
 {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus/mcu");
         return 1;
     }
 
@@ -31,7 +31,7 @@ uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t 
         i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
+        i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -50,7 +50,7 @@ uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t 
 
 /// @brief Telecommand: Arm the antenna deploy system
 /// @param args_str 
-/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -67,7 +67,7 @@ uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandCh
         i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
+        i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -85,9 +85,9 @@ uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandCh
     return 0;
 }
 
-/// @brief Disarms the antenna system
+/// @brief Disarms the specified antenna deploy system's mcu 
 /// @param args_str 
-/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 0: specifies which mcu on the antenna deployment system to disarm, and which i2c bus to use 
 /// @return 0 on success, 0 > otherwise
 uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -104,7 +104,7 @@ uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_Telecomman
         i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
+        i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -124,13 +124,12 @@ uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_Telecomman
 
 /// @brief  Telecommand: Initiates deployment of the selected antenna
 /// @param args_str 
-/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Either "A" or "B"
 /// - Arg 1: antenna number. between 1-4
 /// - Arg 2: Activation time in seconds
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
-    //TODO: error checking for bad i2c bus arguments
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
@@ -144,7 +143,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChanne
         i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
+        i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -201,7 +200,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChanne
 
 /// @brief begins deployment of all antennas, one by one.
 /// @param args_str 
-/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// - Arg 1: Activation time in seconds
 /// @return returns 0 on success, > 0 otherwise
 uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
@@ -220,7 +219,7 @@ uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TC
         i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
+        i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -250,7 +249,7 @@ uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TC
 
 /// @brief  Telecommand: Initiates deployment of the selected antenna, ignoring whether the antennas current status is deployed. 
 /// @param args_str 
-/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// - Arg 1: antenna number. between 1-4
 /// - Arg 2: Activation time in seconds
 /// @return 0 on successful communication, >0 on communications error 
@@ -269,7 +268,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_Tel
         i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
+        i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -327,7 +326,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_Tel
 
 /// @brief Cancels any active attempts to deploy an antenna
 /// @param args_str 
-/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -344,7 +343,7 @@ uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, T
         i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
+        i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -365,7 +364,7 @@ uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, T
 
 /// @brief Prints the deployment status of all antennas
 /// @param args_str 
-/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -382,7 +381,7 @@ uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_Telecom
         i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
+        i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -446,7 +445,7 @@ uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_Telecom
 
 /// @brief Prints the number of times deployment was attempted on the selected antenna
 /// @param args_str 
-/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// - Arg 1: the antenna to check, between 1-4 
 /// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
@@ -464,7 +463,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args
         i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
+        i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -510,7 +509,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args
 
 /// @brief Prints amount of time the deployment system has been active for for the selected antenna
 /// @param args_str 
-/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// - Arg 1: the antenna to check, between 1-4 
 /// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
@@ -528,7 +527,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
         i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
+        i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -573,7 +572,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
 
 /// @brief Telecommand: Measures the temperature of the antenna controller in centi-degrees celsius
 /// @param args_str
-/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_ant_measure_temp(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -590,7 +589,7 @@ uint8_t TCMDEXEC_ant_measure_temp(const char *args_str, TCMD_TelecommandChannel_
         i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
+        i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");

--- a/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
@@ -1,8 +1,8 @@
 #include "main.h"
 
 #include "telecommands/antenna_telecommand_defs.h"
-#include "antenna_deploy_drivers/ant_commands.h"
 #include "antenna_deploy_drivers/ant_internal_drivers.h"
+#include "antenna_deploy_drivers/ant_commands.h"
 #include "telecommands/telecommand_args_helpers.h"
 
 #include <stdio.h>
@@ -16,7 +16,7 @@
 uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) 
 {
-    const int status = ANT_CMD_reset();
+    const int status = ANT_CMD_reset(ANT_I2C_BUS_A);
     if (status != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", status);
         return status;
@@ -30,7 +30,7 @@ uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t 
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
-    const uint8_t comms_err = ANT_CMD_arm_antenna_system();
+    const uint8_t comms_err = ANT_CMD_arm_antenna_system(ANT_I2C_BUS_A);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", comms_err);
         return comms_err;
@@ -45,7 +45,7 @@ uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandCh
 /// @return 0 on success, 0 > otherwise
 uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
-    const uint8_t status = ANT_CMD_disarm_antenna_system();
+    const uint8_t status = ANT_CMD_disarm_antenna_system(ANT_I2C_BUS_A);
     if (status != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error disarming antenna system: %d", status);
         return status;
@@ -62,9 +62,15 @@ uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_Telecomman
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
+    //TODO: error checking for bad i2c bus arguments
+    char i2c_bus_str[2];
+    const uint8_t parse_i2c_bus_result = TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2);
+    enum Ant_i2c_bus i2c_bus;
+    if (i2c_bus_str[0] == 'A') i2c_bus = ANT_I2C_BUS_A; 
+    if (i2c_bus_str[0] == 'B') i2c_bus = ANT_I2C_BUS_B; 
 
     uint64_t antenna;
-    const uint8_t parse_antenna_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  0, &antenna);
+    const uint8_t parse_antenna_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  1, &antenna);
     if (parse_antenna_result != 0) {
         // error parsing
         snprintf(
@@ -83,7 +89,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChanne
     }
 
     uint64_t arg_activation_time;
-    const uint8_t parse_activation_time_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  1, &arg_activation_time);
+    const uint8_t parse_activation_time_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  2, &arg_activation_time);
     if (parse_activation_time_result != 0) {
         // error parsing
         snprintf(
@@ -101,7 +107,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChanne
         return 4;
     }
 
-    const uint8_t comms_err = ANT_CMD_deploy_antenna((uint8_t)antenna, (uint8_t)arg_activation_time);
+    const uint8_t comms_err = ANT_CMD_deploy_antenna(i2c_bus, (uint8_t)antenna, (uint8_t)arg_activation_time);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", comms_err);
         return comms_err;
@@ -129,7 +135,7 @@ uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TC
         return 4;
     }
 
-    const uint8_t status = ANT_CMD_start_automated_sequential_deployment((uint8_t)activation_time);
+    const uint8_t status = ANT_CMD_start_automated_sequential_deployment(ANT_I2C_BUS_A,(uint8_t)activation_time);
     if (status != 0) {
         snprintf( response_output_buf, response_output_buf_len, "Error: %d", status);
         return status;
@@ -184,7 +190,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_Tel
         return 4;
     }
 
-    const uint8_t comms_err = ANT_CMD_deploy_antenna_with_override((uint8_t)antenna, (uint8_t)arg_activation_time);
+    const uint8_t comms_err = ANT_CMD_deploy_antenna_with_override(ANT_I2C_BUS_A,(uint8_t)antenna, (uint8_t)arg_activation_time);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", comms_err);
         return comms_err;
@@ -200,7 +206,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_Tel
 uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     
-    const uint8_t comms_err = ANT_CMD_cancel_deployment_system_activation();
+    const uint8_t comms_err = ANT_CMD_cancel_deployment_system_activation(ANT_I2C_BUS_A);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: failed to cancel deployment");
         return comms_err;
@@ -218,7 +224,7 @@ uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_Telecom
                         char *response_output_buf, uint16_t response_output_buf_len) {
     
     struct Antenna_deployment_status response;
-    const uint8_t comms_err = ANT_CMD_report_deployment_status(&response);
+    const uint8_t comms_err = ANT_CMD_report_deployment_status(ANT_I2C_BUS_A, &response);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: failed to report status.");
         return comms_err;
@@ -297,7 +303,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args
     }
 
     uint8_t response[1];
-    const uint8_t comms_status = ANT_CMD_report_antenna_deployment_activation_count((uint8_t)antenna, response);
+    const uint8_t comms_status = ANT_CMD_report_antenna_deployment_activation_count(ANT_I2C_BUS_A, (uint8_t)antenna, response);
     if (comms_status != 0) {
         snprintf(
             response_output_buf,
@@ -339,7 +345,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
     }
 
     uint16_t response;
-    const uint8_t comms_status = ANT_CMD_report_antenna_deployment_activation_time((uint8_t)antenna, &response);
+    const uint8_t comms_status = ANT_CMD_report_antenna_deployment_activation_time(ANT_I2C_BUS_A,(uint8_t)antenna, &response);
     if (comms_status != 0) {
         snprintf(
             response_output_buf,
@@ -360,7 +366,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
 uint8_t TCMDEXEC_ant_measure_temp(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint16_t measurement;
-    const uint8_t comms_err = ANT_CMD_measure_temp(&measurement);
+    const uint8_t comms_err = ANT_CMD_measure_temp(ANT_I2C_BUS_A,&measurement);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", comms_err);
         return comms_err;

--- a/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
@@ -5,6 +5,7 @@
 #include "antenna_deploy_drivers/ant_commands.h"
 #include "telecommands/telecommand_args_helpers.h"
 #include "debug_uart.h"
+#include "log/log.h"
 
 #include <stdio.h>
 #include <stdint.h>
@@ -17,7 +18,28 @@
 uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) 
 {
-    const int status = ANT_CMD_reset(ANT_I2C_BUS_A);
+    char i2c_bus_str [2];
+    if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        return 1;
+    }
+
+    enum Ant_i2c_bus i2c_bus;
+    switch (i2c_bus_str[0])
+    {
+    case 'A':
+        i2c_bus = ANT_I2C_BUS_A;
+        break;
+    case 'B':
+        i2c_bus = ANT_I2C_BUS_B;
+        break; 
+    default:
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        return 1;
+        break;
+    }
+
+    const int status = ANT_CMD_reset(i2c_bus);
     if (status != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", status);
         return status;
@@ -32,12 +54,25 @@ uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t 
 uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
-    const uint8_t parse_i2c_bus_result = TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2);
+    if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        return 1;
+    }
 
     enum Ant_i2c_bus i2c_bus;
-    if (i2c_bus_str[0] == 'A') i2c_bus = ANT_I2C_BUS_A;
-    if (i2c_bus_str[0] == 'B') i2c_bus = ANT_I2C_BUS_B;
-    
+    switch (i2c_bus_str[0])
+    {
+    case 'A':
+        i2c_bus = ANT_I2C_BUS_A;
+        break;
+    case 'B':
+        i2c_bus = ANT_I2C_BUS_B;
+        break; 
+    default:
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        return 1;
+        break;
+    }
     
     const uint8_t comms_err = ANT_CMD_arm_antenna_system(i2c_bus);
     if (comms_err != 0) {
@@ -54,7 +89,28 @@ uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandCh
 /// @return 0 on success, 0 > otherwise
 uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
-    const uint8_t status = ANT_CMD_disarm_antenna_system(ANT_I2C_BUS_A);
+    char i2c_bus_str [2];
+    if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        return 1;
+    }
+
+    enum Ant_i2c_bus i2c_bus;
+    switch (i2c_bus_str[0])
+    {
+    case 'A':
+        i2c_bus = ANT_I2C_BUS_A;
+        break;
+    case 'B':
+        i2c_bus = ANT_I2C_BUS_B;
+        break; 
+    default:
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        return 1;
+        break;
+    }
+
+    const uint8_t status = ANT_CMD_disarm_antenna_system(i2c_bus);
     if (status != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error disarming antenna system: %d", status);
         return status;
@@ -72,11 +128,13 @@ uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_Telecomman
 uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     //TODO: error checking for bad i2c bus arguments
-    char i2c_bus_str[2];
-    const uint8_t parse_i2c_bus_result = TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2);
+    char i2c_bus_str [2];
+    if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        return 1;
+    }
+
     enum Ant_i2c_bus i2c_bus;
-    //if (i2c_bus_str[0] == 'A') i2c_bus = ANT_I2C_BUS_A; 
-    //if (i2c_bus_str[0] == 'B') i2c_bus = ANT_I2C_BUS_B; 
     switch (i2c_bus_str[0])
     {
     case 'A':
@@ -86,8 +144,8 @@ uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChanne
         i2c_bus = ANT_I2C_BUS_B;
         break; 
     default:
-        DEBUG_uart_print_str("WRONG i2C BUS!!!!");
-        break;
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        return 1;
     }
 
     uint64_t antenna;
@@ -145,6 +203,27 @@ uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChanne
 uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) 
 {
+    char i2c_bus_str [2];
+    if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        return 1;
+    }
+
+    enum Ant_i2c_bus i2c_bus;
+    switch (i2c_bus_str[0])
+    {
+    case 'A':
+        i2c_bus = ANT_I2C_BUS_A;
+        break;
+    case 'B':
+        i2c_bus = ANT_I2C_BUS_B;
+        break; 
+    default:
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        return 1;
+        break;
+    }
+
     uint64_t activation_time;
     const uint8_t parse_activation_time_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &activation_time);
     if (parse_activation_time_result != 0) {
@@ -156,7 +235,7 @@ uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TC
         return 4;
     }
 
-    const uint8_t status = ANT_CMD_start_automated_sequential_deployment(ANT_I2C_BUS_A,(uint8_t)activation_time);
+    const uint8_t status = ANT_CMD_start_automated_sequential_deployment(i2c_bus,(uint8_t)activation_time);
     if (status != 0) {
         snprintf( response_output_buf, response_output_buf_len, "Error: %d", status);
         return status;
@@ -172,6 +251,26 @@ uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TC
 /// @return 0 on successful communication, >0 on communications error 
 uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
+    char i2c_bus_str [2];
+    if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        return 1;
+    }
+
+    enum Ant_i2c_bus i2c_bus;
+    switch (i2c_bus_str[0])
+    {
+    case 'A':
+        i2c_bus = ANT_I2C_BUS_A;
+        break;
+    case 'B':
+        i2c_bus = ANT_I2C_BUS_B;
+        break; 
+    default:
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        return 1;
+        break;
+    }
 
     uint64_t antenna;
     const uint8_t parse_antenna_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  0, &antenna);
@@ -211,7 +310,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_Tel
         return 4;
     }
 
-    const uint8_t comms_err = ANT_CMD_deploy_antenna_with_override(ANT_I2C_BUS_A,(uint8_t)antenna, (uint8_t)arg_activation_time);
+    const uint8_t comms_err = ANT_CMD_deploy_antenna_with_override(i2c_bus,(uint8_t)antenna, (uint8_t)arg_activation_time);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", comms_err);
         return comms_err;
@@ -226,8 +325,28 @@ uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_Tel
 /// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
+    char i2c_bus_str [2];
+    if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        return 1;
+    }
+
+    enum Ant_i2c_bus i2c_bus;
+    switch (i2c_bus_str[0])
+    {
+    case 'A':
+        i2c_bus = ANT_I2C_BUS_A;
+        break;
+    case 'B':
+        i2c_bus = ANT_I2C_BUS_B;
+        break; 
+    default:
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        return 1;
+        break;
+    }
     
-    const uint8_t comms_err = ANT_CMD_cancel_deployment_system_activation(ANT_I2C_BUS_A);
+    const uint8_t comms_err = ANT_CMD_cancel_deployment_system_activation(i2c_bus);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: failed to cancel deployment");
         return comms_err;
@@ -243,9 +362,29 @@ uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, T
 /// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
+    char i2c_bus_str [2];
+    if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        return 1;
+    }
+
+    enum Ant_i2c_bus i2c_bus;
+    switch (i2c_bus_str[0])
+    {
+    case 'A':
+        i2c_bus = ANT_I2C_BUS_A;
+        break;
+    case 'B':
+        i2c_bus = ANT_I2C_BUS_B;
+        break; 
+    default:
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        return 1;
+        break;
+    }
     
     struct Antenna_deployment_status response;
-    const uint8_t comms_err = ANT_CMD_report_deployment_status(ANT_I2C_BUS_A, &response);
+    const uint8_t comms_err = ANT_CMD_report_deployment_status(i2c_bus, &response);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: failed to report status.");
         return comms_err;
@@ -304,6 +443,27 @@ uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_Telecom
 /// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
+    char i2c_bus_str [2];
+    if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        return 1;
+    }
+
+    enum Ant_i2c_bus i2c_bus;
+    switch (i2c_bus_str[0])
+    {
+    case 'A':
+        i2c_bus = ANT_I2C_BUS_A;
+        break;
+    case 'B':
+        i2c_bus = ANT_I2C_BUS_B;
+        break; 
+    default:
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        return 1;
+        break;
+    }
+
     uint64_t antenna;
     const uint8_t parse_antenna_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  0, &antenna);
     if (parse_antenna_result != 0) {
@@ -324,7 +484,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args
     }
 
     uint8_t response[1];
-    const uint8_t comms_status = ANT_CMD_report_antenna_deployment_activation_count(ANT_I2C_BUS_A, (uint8_t)antenna, response);
+    const uint8_t comms_status = ANT_CMD_report_antenna_deployment_activation_count(i2c_bus, (uint8_t)antenna, response);
     if (comms_status != 0) {
         snprintf(
             response_output_buf,
@@ -346,6 +506,27 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args
 /// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
+    char i2c_bus_str [2];
+    if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        return 1;
+    }
+
+    enum Ant_i2c_bus i2c_bus;
+    switch (i2c_bus_str[0])
+    {
+    case 'A':
+        i2c_bus = ANT_I2C_BUS_A;
+        break;
+    case 'B':
+        i2c_bus = ANT_I2C_BUS_B;
+        break; 
+    default:
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        return 1;
+        break;
+    }
+
     uint64_t antenna;
     const uint8_t parse_antenna_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  0, &antenna);
     if (parse_antenna_result != 0) {
@@ -366,7 +547,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
     }
 
     uint16_t response;
-    const uint8_t comms_status = ANT_CMD_report_antenna_deployment_activation_time(ANT_I2C_BUS_A,(uint8_t)antenna, &response);
+    const uint8_t comms_status = ANT_CMD_report_antenna_deployment_activation_time(i2c_bus,(uint8_t)antenna, &response);
     if (comms_status != 0) {
         snprintf(
             response_output_buf,
@@ -386,8 +567,29 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_ant_measure_temp(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
+    char i2c_bus_str [2];
+    if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        return 1;
+    }
+
+    enum Ant_i2c_bus i2c_bus;
+    switch (i2c_bus_str[0])
+    {
+    case 'A':
+        i2c_bus = ANT_I2C_BUS_A;
+        break;
+    case 'B':
+        i2c_bus = ANT_I2C_BUS_B;
+        break; 
+    default:
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        return 1;
+        break;
+    }
+
     uint16_t measurement;
-    const uint8_t comms_err = ANT_CMD_measure_temp(ANT_I2C_BUS_A,&measurement);
+    const uint8_t comms_err = ANT_CMD_measure_temp(i2c_bus,&measurement);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", comms_err);
         return comms_err;

--- a/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
@@ -13,7 +13,8 @@
 #include "inttypes.h"
 
 /// @brief Resets the antenna deployment system's microcontroller
-/// @param args_str no arguments
+/// @param args_str
+/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
 /// @return 0 on success, > 0 otherwise
 uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) 
@@ -24,14 +25,14 @@ uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t 
         return 1;
     }
 
-    enum Ant_i2c_bus i2c_bus;
+    enum Ant_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
-        i2c_bus = ANT_I2C_BUS_A;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus = ANT_I2C_BUS_B;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -39,7 +40,7 @@ uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t 
         break;
     }
 
-    const int status = ANT_CMD_reset(i2c_bus);
+    const int status = ANT_CMD_reset(i2c_bus_mcu);
     if (status != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", status);
         return status;
@@ -49,7 +50,8 @@ uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t 
 }
 
 /// @brief Telecommand: Arm the antenna deploy system
-/// @param args_str No args
+/// @param args_str 
+/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -59,14 +61,14 @@ uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandCh
         return 1;
     }
 
-    enum Ant_i2c_bus i2c_bus;
+    enum Ant_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
-        i2c_bus = ANT_I2C_BUS_A;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus = ANT_I2C_BUS_B;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -74,7 +76,7 @@ uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandCh
         break;
     }
     
-    const uint8_t comms_err = ANT_CMD_arm_antenna_system(i2c_bus);
+    const uint8_t comms_err = ANT_CMD_arm_antenna_system(i2c_bus_mcu);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", comms_err);
         return comms_err;
@@ -85,7 +87,8 @@ uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandCh
 }
 
 /// @brief Disarms the antenna system
-/// @param args_str No arguments
+/// @param args_str 
+/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
 /// @return 0 on success, 0 > otherwise
 uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -95,14 +98,14 @@ uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_Telecomman
         return 1;
     }
 
-    enum Ant_i2c_bus i2c_bus;
+    enum Ant_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
-        i2c_bus = ANT_I2C_BUS_A;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus = ANT_I2C_BUS_B;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -110,7 +113,7 @@ uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_Telecomman
         break;
     }
 
-    const uint8_t status = ANT_CMD_disarm_antenna_system(i2c_bus);
+    const uint8_t status = ANT_CMD_disarm_antenna_system(i2c_bus_mcu);
     if (status != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error disarming antenna system: %d", status);
         return status;
@@ -122,8 +125,9 @@ uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_Telecomman
 
 /// @brief  Telecommand: Initiates deployment of the selected antenna
 /// @param args_str 
-/// - Arg 0: antenna number. between 1-4
-/// - Arg 1: Activation time in seconds
+/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 1: antenna number. between 1-4
+/// - Arg 2: Activation time in seconds
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -134,14 +138,14 @@ uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChanne
         return 1;
     }
 
-    enum Ant_i2c_bus i2c_bus;
+    enum Ant_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
-        i2c_bus = ANT_I2C_BUS_A;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus = ANT_I2C_BUS_B;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -186,7 +190,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChanne
         return 4;
     }
 
-    const uint8_t comms_err = ANT_CMD_deploy_antenna(i2c_bus, (uint8_t)antenna, (uint8_t)arg_activation_time);
+    const uint8_t comms_err = ANT_CMD_deploy_antenna(i2c_bus_mcu, (uint8_t)antenna, (uint8_t)arg_activation_time);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", comms_err);
         return comms_err;
@@ -198,7 +202,8 @@ uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChanne
 
 /// @brief begins deployment of all antennas, one by one.
 /// @param args_str 
-/// - Arg 0: Activation time in seconds
+/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 1: Activation time in seconds
 /// @return returns 0 on success, > 0 otherwise
 uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) 
@@ -209,14 +214,14 @@ uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TC
         return 1;
     }
 
-    enum Ant_i2c_bus i2c_bus;
+    enum Ant_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
-        i2c_bus = ANT_I2C_BUS_A;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus = ANT_I2C_BUS_B;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -225,7 +230,7 @@ uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TC
     }
 
     uint64_t activation_time;
-    const uint8_t parse_activation_time_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &activation_time);
+    const uint8_t parse_activation_time_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 1, &activation_time);
     if (parse_activation_time_result != 0) {
         snprintf( response_output_buf, response_output_buf_len, "Error parsing argument: %d", parse_activation_time_result);
         return 3;
@@ -235,7 +240,7 @@ uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TC
         return 4;
     }
 
-    const uint8_t status = ANT_CMD_start_automated_sequential_deployment(i2c_bus,(uint8_t)activation_time);
+    const uint8_t status = ANT_CMD_start_automated_sequential_deployment(i2c_bus_mcu,(uint8_t)activation_time);
     if (status != 0) {
         snprintf( response_output_buf, response_output_buf_len, "Error: %d", status);
         return status;
@@ -246,8 +251,9 @@ uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TC
 
 /// @brief  Telecommand: Initiates deployment of the selected antenna, ignoring whether the antennas current status is deployed. 
 /// @param args_str 
-/// - Arg 0: antenna number. between 1-4
-/// - Arg 1: Activation time in seconds
+/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 1: antenna number. between 1-4
+/// - Arg 2: Activation time in seconds
 /// @return 0 on successful communication, >0 on communications error 
 uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -257,14 +263,14 @@ uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_Tel
         return 1;
     }
 
-    enum Ant_i2c_bus i2c_bus;
+    enum Ant_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
-        i2c_bus = ANT_I2C_BUS_A;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus = ANT_I2C_BUS_B;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -273,7 +279,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_Tel
     }
 
     uint64_t antenna;
-    const uint8_t parse_antenna_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  0, &antenna);
+    const uint8_t parse_antenna_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  1, &antenna);
     if (parse_antenna_result != 0) {
         // error parsing
         snprintf(
@@ -292,7 +298,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_Tel
     }
 
     uint64_t arg_activation_time;
-    const uint8_t parse_activation_time_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  1, &arg_activation_time);
+    const uint8_t parse_activation_time_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  2, &arg_activation_time);
     if (parse_activation_time_result != 0) {
         // error parsing
         snprintf(
@@ -310,7 +316,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_Tel
         return 4;
     }
 
-    const uint8_t comms_err = ANT_CMD_deploy_antenna_with_override(i2c_bus,(uint8_t)antenna, (uint8_t)arg_activation_time);
+    const uint8_t comms_err = ANT_CMD_deploy_antenna_with_override(i2c_bus_mcu,(uint8_t)antenna, (uint8_t)arg_activation_time);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", comms_err);
         return comms_err;
@@ -321,7 +327,8 @@ uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_Tel
 }
 
 /// @brief Cancels any active attempts to deploy an antenna
-/// @param args_str No arguments 
+/// @param args_str 
+/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
 /// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -331,14 +338,14 @@ uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, T
         return 1;
     }
 
-    enum Ant_i2c_bus i2c_bus;
+    enum Ant_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
-        i2c_bus = ANT_I2C_BUS_A;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus = ANT_I2C_BUS_B;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -346,7 +353,7 @@ uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, T
         break;
     }
     
-    const uint8_t comms_err = ANT_CMD_cancel_deployment_system_activation(i2c_bus);
+    const uint8_t comms_err = ANT_CMD_cancel_deployment_system_activation(i2c_bus_mcu);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: failed to cancel deployment");
         return comms_err;
@@ -358,7 +365,8 @@ uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, T
 
 
 /// @brief Prints the deployment status of all antennas
-/// @param args_str No arguments 
+/// @param args_str 
+/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
 /// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -368,14 +376,14 @@ uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_Telecom
         return 1;
     }
 
-    enum Ant_i2c_bus i2c_bus;
+    enum Ant_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
-        i2c_bus = ANT_I2C_BUS_A;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus = ANT_I2C_BUS_B;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -384,7 +392,7 @@ uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_Telecom
     }
     
     struct Antenna_deployment_status response;
-    const uint8_t comms_err = ANT_CMD_report_deployment_status(i2c_bus, &response);
+    const uint8_t comms_err = ANT_CMD_report_deployment_status(i2c_bus_mcu, &response);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: failed to report status.");
         return comms_err;
@@ -439,7 +447,8 @@ uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_Telecom
 
 /// @brief Prints the number of times deployment was attempted on the selected antenna
 /// @param args_str 
-/// - Arg 0: the antenna to check, between 1-4 
+/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 1: the antenna to check, between 1-4 
 /// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -449,14 +458,14 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args
         return 1;
     }
 
-    enum Ant_i2c_bus i2c_bus;
+    enum Ant_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
-        i2c_bus = ANT_I2C_BUS_A;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus = ANT_I2C_BUS_B;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -465,7 +474,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args
     }
 
     uint64_t antenna;
-    const uint8_t parse_antenna_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  0, &antenna);
+    const uint8_t parse_antenna_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  1, &antenna);
     if (parse_antenna_result != 0) {
         // error parsing
         snprintf(
@@ -484,7 +493,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args
     }
 
     uint8_t response[1];
-    const uint8_t comms_status = ANT_CMD_report_antenna_deployment_activation_count(i2c_bus, (uint8_t)antenna, response);
+    const uint8_t comms_status = ANT_CMD_report_antenna_deployment_activation_count(i2c_bus_mcu, (uint8_t)antenna, response);
     if (comms_status != 0) {
         snprintf(
             response_output_buf,
@@ -502,7 +511,8 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args
 
 /// @brief Prints amount of time the deployment system has been active for for the selected antenna
 /// @param args_str 
-/// - Arg 0: the antenna to check, between 1-4 
+/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
+/// - Arg 1: the antenna to check, between 1-4 
 /// @return 0 on successful communication, > 0 on communications error
 uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -512,14 +522,14 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
         return 1;
     }
 
-    enum Ant_i2c_bus i2c_bus;
+    enum Ant_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
-        i2c_bus = ANT_I2C_BUS_A;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus = ANT_I2C_BUS_B;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -528,7 +538,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
     }
 
     uint64_t antenna;
-    const uint8_t parse_antenna_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  0, &antenna);
+    const uint8_t parse_antenna_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  1, &antenna);
     if (parse_antenna_result != 0) {
         // error parsing
         snprintf(
@@ -547,7 +557,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
     }
 
     uint16_t response;
-    const uint8_t comms_status = ANT_CMD_report_antenna_deployment_activation_time(i2c_bus,(uint8_t)antenna, &response);
+    const uint8_t comms_status = ANT_CMD_report_antenna_deployment_activation_time(i2c_bus_mcu,(uint8_t)antenna, &response);
     if (comms_status != 0) {
         snprintf(
             response_output_buf,
@@ -563,7 +573,8 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
 }
 
 /// @brief Telecommand: Measures the temperature of the antenna controller in centi-degrees celsius
-/// @param args_str No args
+/// @param args_str
+/// - Arg 0: specifies which mcu on the antenna deployment system to trasmit to, and which i2c bus to use 
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_ant_measure_temp(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
@@ -573,14 +584,14 @@ uint8_t TCMDEXEC_ant_measure_temp(const char *args_str, TCMD_TelecommandChannel_
         return 1;
     }
 
-    enum Ant_i2c_bus i2c_bus;
+    enum Ant_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
-        i2c_bus = ANT_I2C_BUS_A;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus = ANT_I2C_BUS_B;
+        i2c_bus_mcu = ANT_I2C_BUS_A_MCU_B;
         break; 
     default:
         LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
@@ -589,7 +600,7 @@ uint8_t TCMDEXEC_ant_measure_temp(const char *args_str, TCMD_TelecommandChannel_
     }
 
     uint16_t measurement;
-    const uint8_t comms_err = ANT_CMD_measure_temp(i2c_bus,&measurement);
+    const uint8_t comms_err = ANT_CMD_measure_temp(i2c_bus_mcu,&measurement);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", comms_err);
         return comms_err;

--- a/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
@@ -4,6 +4,7 @@
 #include "antenna_deploy_drivers/ant_internal_drivers.h"
 #include "antenna_deploy_drivers/ant_commands.h"
 #include "telecommands/telecommand_args_helpers.h"
+#include "debug_uart.h"
 
 #include <stdio.h>
 #include <stdint.h>
@@ -30,7 +31,15 @@ uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t 
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
-    const uint8_t comms_err = ANT_CMD_arm_antenna_system(ANT_I2C_BUS_A);
+    char i2c_bus_str [2];
+    const uint8_t parse_i2c_bus_result = TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2);
+
+    enum Ant_i2c_bus i2c_bus;
+    if (i2c_bus_str[0] == 'A') i2c_bus = ANT_I2C_BUS_A;
+    if (i2c_bus_str[0] == 'B') i2c_bus = ANT_I2C_BUS_B;
+    
+    
+    const uint8_t comms_err = ANT_CMD_arm_antenna_system(i2c_bus);
     if (comms_err != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", comms_err);
         return comms_err;
@@ -66,8 +75,20 @@ uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChanne
     char i2c_bus_str[2];
     const uint8_t parse_i2c_bus_result = TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2);
     enum Ant_i2c_bus i2c_bus;
-    if (i2c_bus_str[0] == 'A') i2c_bus = ANT_I2C_BUS_A; 
-    if (i2c_bus_str[0] == 'B') i2c_bus = ANT_I2C_BUS_B; 
+    //if (i2c_bus_str[0] == 'A') i2c_bus = ANT_I2C_BUS_A; 
+    //if (i2c_bus_str[0] == 'B') i2c_bus = ANT_I2C_BUS_B; 
+    switch (i2c_bus_str[0])
+    {
+    case 'A':
+        i2c_bus = ANT_I2C_BUS_A;
+        break;
+    case 'B':
+        i2c_bus = ANT_I2C_BUS_B;
+        break; 
+    default:
+        DEBUG_uart_print_str("WRONG i2C BUS!!!!");
+        break;
+    }
 
     uint64_t antenna;
     const uint8_t parse_antenna_result = TCMD_extract_uint64_arg(args_str, strlen(args_str),  1, &antenna);

--- a/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
@@ -4,7 +4,6 @@
 #include "antenna_deploy_drivers/ant_internal_drivers.h"
 #include "antenna_deploy_drivers/ant_commands.h"
 #include "telecommands/telecommand_args_helpers.h"
-#include "debug_uart.h"
 #include "log/log.h"
 
 #include <stdio.h>

--- a/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
@@ -20,26 +20,26 @@ uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t 
 {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus/mcu");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Failed reading i2c bus/mcu");
         return 1;
     }
 
-    enum Ant_i2c_bus_mcu i2c_bus_mcu;
+    enum ANT_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
         i2c_bus_mcu = ANT_I2C_BUS_A_MCU_A;
         break;
     case 'B':
-        i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
+    i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Invalid choice for i2c bus");
         return 1;
         break;
     }
 
-    const int status = ANT_CMD_reset(i2c_bus_mcu);
+    const uint8_t status = ANT_CMD_reset(i2c_bus_mcu);
     if (status != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: %d", status);
         return status;
@@ -56,11 +56,11 @@ uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandCh
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Failed reading i2c bus");
         return 1;
     }
 
-    enum Ant_i2c_bus_mcu i2c_bus_mcu;
+    enum ANT_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
@@ -70,7 +70,7 @@ uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandCh
         i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Invalid choice for i2c bus");
         return 1;
         break;
     }
@@ -93,11 +93,11 @@ uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_Telecomman
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Failed reading i2c bus");
         return 1;
     }
 
-    enum Ant_i2c_bus_mcu i2c_bus_mcu;
+    enum ANT_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
@@ -107,7 +107,7 @@ uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_Telecomman
         i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Invalid choice for i2c bus");
         return 1;
         break;
     }
@@ -132,11 +132,11 @@ uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChanne
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Failed reading i2c bus");
         return 1;
     }
 
-    enum Ant_i2c_bus_mcu i2c_bus_mcu;
+    enum ANT_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
@@ -146,7 +146,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChanne
         i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Invalid choice for i2c bus");
         return 1;
     }
 
@@ -208,11 +208,11 @@ uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TC
 {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Failed reading i2c bus");
         return 1;
     }
 
-    enum Ant_i2c_bus_mcu i2c_bus_mcu;
+    enum ANT_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
@@ -222,7 +222,7 @@ uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TC
         i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Invalid choice for i2c bus");
         return 1;
         break;
     }
@@ -257,11 +257,11 @@ uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_Tel
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Failed reading i2c bus");
         return 1;
     }
 
-    enum Ant_i2c_bus_mcu i2c_bus_mcu;
+    enum ANT_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
@@ -271,7 +271,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_Tel
         i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Invalid choice for i2c bus");
         return 1;
         break;
     }
@@ -332,11 +332,11 @@ uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, T
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Failed reading i2c bus");
         return 1;
     }
 
-    enum Ant_i2c_bus_mcu i2c_bus_mcu;
+    enum ANT_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
@@ -346,7 +346,7 @@ uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, T
         i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Invalid choice for i2c bus");
         return 1;
         break;
     }
@@ -370,11 +370,11 @@ uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_Telecom
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Failed reading i2c bus");
         return 1;
     }
 
-    enum Ant_i2c_bus_mcu i2c_bus_mcu;
+    enum ANT_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
@@ -384,7 +384,7 @@ uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_Telecom
         i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Invalid choice for i2c bus");
         return 1;
         break;
     }
@@ -452,11 +452,11 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Failed reading i2c bus");
         return 1;
     }
 
-    enum Ant_i2c_bus_mcu i2c_bus_mcu;
+    enum ANT_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
@@ -466,7 +466,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args
         i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Invalid choice for i2c bus");
         return 1;
         break;
     }
@@ -516,11 +516,11 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Failed reading i2c bus");
         return 1;
     }
 
-    enum Ant_i2c_bus_mcu i2c_bus_mcu;
+    enum ANT_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
@@ -530,7 +530,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
         i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Invalid choice for i2c bus");
         return 1;
         break;
     }
@@ -578,11 +578,11 @@ uint8_t TCMDEXEC_ant_measure_temp(const char *args_str, TCMD_TelecommandChannel_
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Failed reading i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Failed reading i2c bus");
         return 1;
     }
 
-    enum Ant_i2c_bus_mcu i2c_bus_mcu;
+    enum ANT_i2c_bus_mcu i2c_bus_mcu;
     switch (i2c_bus_str[0])
     {
     case 'A':
@@ -592,7 +592,7 @@ uint8_t TCMDEXEC_ant_measure_temp(const char *args_str, TCMD_TelecommandChannel_
         i2c_bus_mcu = ANT_I2C_BUS_B_MCU_B;
         break; 
     default:
-        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_WARNING,LOG_SINK_ALL, "Invalid choice for i2c bus");
+        LOG_message(LOG_SYSTEM_TELECOMMAND,LOG_SEVERITY_ERROR,LOG_SINK_ALL, "Invalid choice for i2c bus");
         return 1;
         break;
     }

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -902,7 +902,7 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
     {
         .tcmd_name = "ant_arm_antenna_system",
         .tcmd_func = TCMDEXEC_ant_arm_antenna_system,
-        .number_of_args = 0,
+        .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -914,7 +914,7 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
     {
         .tcmd_name = "ant_deploy_antenna",
         .tcmd_func = TCMDEXEC_ant_deploy_antenna,
-        .number_of_args = 2,
+        .number_of_args = 3,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -896,7 +896,7 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
     {
         .tcmd_name = "ant_reset",
         .tcmd_func = TCMDEXEC_ant_reset,
-        .number_of_args = 0,
+        .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {
@@ -908,7 +908,7 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
     {
         .tcmd_name = "ant_disarm_antenna_system",
         .tcmd_func = TCMDEXEC_ant_disarm_antenna_system,
-        .number_of_args = 0,
+        .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {
@@ -920,43 +920,43 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
     {
         .tcmd_name = "ant_start_automated_antenna_deployment",
         .tcmd_func = TCMDEXEC_ant_start_automated_antenna_deployment,
-        .number_of_args = 1,
+        .number_of_args = 2,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {
         .tcmd_name = "ant_deploy_antenna_with_override",
         .tcmd_func = TCMDEXEC_ant_deploy_antenna_with_override,
-        .number_of_args = 2,
+        .number_of_args = 3,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {
         .tcmd_name = "ant_cancel_deployment_system_activation",
         .tcmd_func = TCMDEXEC_ant_cancel_deployment_system_activation,
-        .number_of_args = 0,
+        .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {
         .tcmd_name = "ant_measure_temp",
         .tcmd_func = TCMDEXEC_ant_measure_temp,
-        .number_of_args = 0,
+        .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {
         .tcmd_name = "ant_report_deployment_status",
         .tcmd_func = TCMDEXEC_ant_report_deployment_status,
-        .number_of_args = 0,
+        .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {
         .tcmd_name = "ant_report_antenna_deployment_activation_count",
         .tcmd_func = TCMDEXEC_ant_report_antenna_deployment_activation_count,
-        .number_of_args = 1,
+        .number_of_args = 2,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {
         .tcmd_name = "ant_report_antenna_deployment_activation_time",
         .tcmd_func = TCMDEXEC_ant_report_antenna_deployment_activation_time,
-        .number_of_args = 1,
+        .number_of_args = 2,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     // ****************** END SECTION: antenna_telecommand_defs ******************


### PR DESCRIPTION
implements #144 

For testing, each command was run on both buses and I verified that the correct led was lit on the electrical model.
