### PR TITLE
Remove unnecessary `(char *)` casts in LFS/flash telecommands

### DIFF
--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -270,9 +270,9 @@ uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const char *args_str, TCMD_Tel
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t chip_num, test_data_address, test_data_length;
 
-    uint8_t arg0_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 0, &chip_num);
-    uint8_t arg1_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 1, &test_data_address);
-    uint8_t arg2_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 2, &test_data_length);
+    uint8_t arg0_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &chip_num);
+    uint8_t arg1_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 1, &test_data_address);
+    uint8_t arg2_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 2, &test_data_length);
     
     if (arg0_result != 0 || arg1_result != 0 || arg2_result != 0) {
         snprintf(

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -140,7 +140,7 @@ uint8_t TCMDEXEC_fs_read_text_file(const char *args_str, TCMD_TelecommandChannel
     uint8_t rx_buffer[512] = {0};
 
     char arg_file_name[64] = {0};
-    const uint8_t parse_file_name_result = TCMD_extract_string_arg((char*)args_str, 0, arg_file_name, sizeof(arg_file_name));
+    const uint8_t parse_file_name_result = TCMD_extract_string_arg(args_str, 0, arg_file_name, sizeof(arg_file_name));
     if (parse_file_name_result != 0) {
         // error parsing
         snprintf(
@@ -225,8 +225,8 @@ uint8_t TCMDEXEC_fs_benchmark_write_read(const char *args_str, TCMD_TelecommandC
     
     uint64_t arg_write_chunk_size, arg_write_chunk_count;
 
-    const uint8_t parse_write_chunk_size_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 0, &arg_write_chunk_size);
-    const uint8_t parse_write_chunk_count_result = TCMD_extract_uint64_arg((char*)args_str, strlen((char*)args_str), 1, &arg_write_chunk_count);
+    const uint8_t parse_write_chunk_size_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &arg_write_chunk_size);
+    const uint8_t parse_write_chunk_count_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 1, &arg_write_chunk_count);
     if (parse_write_chunk_size_result != 0 || parse_write_chunk_count_result != 0) {
         // error parsing
         snprintf(


### PR DESCRIPTION
I got rid of all unnecessary casts (char*)args_src in the flash and lfs telecommand definitions. 