### PR TITLE
Antenna deploy: report durations in ms

### DIFF
--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -33,7 +33,7 @@ uint8_t ANT_CMD_measure_temp(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint16_t *result)
 int16_t ANT_convert_raw_temp_to_cCelsius(uint16_t measurement);
 uint8_t ANT_CMD_report_deployment_status(enum ANT_i2c_bus_mcu i2c_bus_mcu, struct Antenna_deployment_status *response);
 uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint8_t *response);
-uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint16_t *result);
+uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint32_t *result);
 
 
 

--- a/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
+++ b/firmware/Core/Inc/antenna_deploy_drivers/ant_commands.h
@@ -33,7 +33,7 @@ uint8_t ANT_CMD_measure_temp(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint16_t *result)
 int16_t ANT_convert_raw_temp_to_cCelsius(uint16_t measurement);
 uint8_t ANT_CMD_report_deployment_status(enum ANT_i2c_bus_mcu i2c_bus_mcu, struct Antenna_deployment_status *response);
 uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint8_t *response);
-uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint32_t *result);
+uint8_t ANT_CMD_get_antenna_deployment_activation_time(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint32_t *result);
 
 
 

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
@@ -294,13 +294,14 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum ANT_i2c_bus_mcu 
     return status;
 }
 
-/// @brief writes the cumulative time (in 50ms increments) that the deployment system has been active (for a specified antenna and mcu) in a response buffer.
+/// @brief writes the cumulative time (in ms increments) that the deployment system has been active (for a specified antenna and mcu) in a response buffer.
 /// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use
 /// @param antenna the antenna to check. A number between 1-4
-/// @param response a 2 byte buffer where the cumulative deployment time (in 50ms increments) will be written. divide the response by 20 to get seconds.
+/// @param result a 2 byte buffer where the cumulative deployment time (in ms increments) will be written. divide the response by 20 to get seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 /// @note data written to the result buffer is only valid if 0 was returned. One should check this before using the result.
-uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint16_t *result) {
+//TODO in search, find all instances of this function and change result to uint32_t REMEMBER THIS!!!!!!
+uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint32_t *result) {
     const uint8_t CMD_BUFF_SIZE = 1;
     uint8_t cmd_buf[CMD_BUFF_SIZE];
 
@@ -326,14 +327,13 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum ANT_i2c_bus_mcu i
             );
             return 1;
     }
-
     uint8_t status = ANT_send_cmd(i2c_bus_mcu, cmd_buf, CMD_BUFF_SIZE); 
     if(status == 0) {
         const uint8_t response_len = 2; 
         uint8_t response[2];
         status = ANT_get_response(i2c_bus_mcu, response, response_len);
-
         *result = (response[1] << 8) | response[0];
+        *result *= 50;
     }
     return status;
 }

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
@@ -300,7 +300,7 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum ANT_i2c_bus_mcu 
 /// @param result_ms a 2 byte buffer where the cumulative deployment time (in ms increments) will be written. divide the response by 20 to get seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 /// @note data written to the result buffer is only valid if 0 was returned. One should check this before using the result.
-uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint32_t *result_ms) {
+uint8_t ANT_CMD_get_antenna_deployment_activation_time(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint32_t *result_ms) {
     const uint8_t CMD_BUFF_SIZE = 1;
     uint8_t cmd_buf[CMD_BUFF_SIZE];
 

--- a/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
+++ b/firmware/Core/Src/antenna_deploy_drivers/ant_commands.c
@@ -297,11 +297,10 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_count(enum ANT_i2c_bus_mcu 
 /// @brief writes the cumulative time (in ms increments) that the deployment system has been active (for a specified antenna and mcu) in a response buffer.
 /// @param i2c_bus_mcu specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use
 /// @param antenna the antenna to check. A number between 1-4
-/// @param result a 2 byte buffer where the cumulative deployment time (in ms increments) will be written. divide the response by 20 to get seconds.
+/// @param result_ms a 2 byte buffer where the cumulative deployment time (in ms increments) will be written. divide the response by 20 to get seconds.
 /// @return 0 when the antenna deployment system has received the command, >0 otherwise
 /// @note data written to the result buffer is only valid if 0 was returned. One should check this before using the result.
-//TODO in search, find all instances of this function and change result to uint32_t REMEMBER THIS!!!!!!
-uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint32_t *result) {
+uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum ANT_i2c_bus_mcu i2c_bus_mcu, uint8_t antenna, uint32_t *result_ms) {
     const uint8_t CMD_BUFF_SIZE = 1;
     uint8_t cmd_buf[CMD_BUFF_SIZE];
 
@@ -330,10 +329,10 @@ uint8_t ANT_CMD_report_antenna_deployment_activation_time(enum ANT_i2c_bus_mcu i
     uint8_t status = ANT_send_cmd(i2c_bus_mcu, cmd_buf, CMD_BUFF_SIZE); 
     if(status == 0) {
         const uint8_t response_len = 2; 
-        uint8_t response[2];
-        status = ANT_get_response(i2c_bus_mcu, response, response_len);
-        *result = (response[1] << 8) | response[0];
-        *result *= 50;
+        uint8_t response_ms[2];
+        status = ANT_get_response(i2c_bus_mcu, response_ms, response_len);
+        *result_ms = (response_ms[1] << 8) | response_ms[0];
+        *result_ms *= 50;
     }
     return status;
 }

--- a/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
@@ -555,7 +555,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
     }
 
     uint32_t response;
-    const uint8_t comms_status = ANT_CMD_report_antenna_deployment_activation_time(i2c_bus_mcu,(uint8_t)antenna, &response);
+    const uint8_t comms_status = ANT_CMD_get_antenna_deployment_activation_time(i2c_bus_mcu,(uint8_t)antenna, &response);
     if (comms_status != 0) {
         snprintf(
             response_output_buf,
@@ -566,7 +566,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
     snprintf(
         response_output_buf,
         response_output_buf_len,
-        "Success, antenna %u deployment time: %ld", (uint8_t)antenna, response);
+        "Success, antenna %u deployment time: %ld ms", (uint8_t)antenna, response);
     return 0;
 }
 

--- a/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
@@ -554,7 +554,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
         return 4;
     }
 
-    uint16_t response;
+    uint32_t response;
     const uint8_t comms_status = ANT_CMD_report_antenna_deployment_activation_time(i2c_bus_mcu,(uint8_t)antenna, &response);
     if (comms_status != 0) {
         snprintf(
@@ -566,7 +566,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
     snprintf(
         response_output_buf,
         response_output_buf_len,
-        "Success, antenna %u deployment time: %d", (uint8_t)antenna, response);
+        "Success, antenna %u deployment time: %ld", (uint8_t)antenna, response);
     return 0;
 }
 


### PR DESCRIPTION
I changed it so that Report durations are in milliseconds instead of multiples of milliseconds, and I fixed the typo in the antenna_deployment_activation_time parameter result to its actual name- response. Changed the result to unit32 to compensate for the larger number due to multiplying it by 50.