### PR TITLE
Telecommand: LFS delete file (#227)

### DIFF
--- a/firmware/Core/Inc/telecommands/lfs_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/lfs_telecommand_defs.h
@@ -22,6 +22,9 @@ uint8_t TCMDEXEC_fs_make_directory(const char *args_str, TCMD_TelecommandChannel
 
 uint8_t TCMDEXEC_fs_write_file_str(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_delete_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
                         
 uint8_t TCMDEXEC_fs_read_file_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);

--- a/firmware/Core/Inc/telecommands/lfs_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/lfs_telecommand_defs.h
@@ -23,7 +23,7 @@ uint8_t TCMDEXEC_fs_make_directory(const char *args_str, TCMD_TelecommandChannel
 uint8_t TCMDEXEC_fs_write_file_str(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_delete_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_delete_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
                         
 uint8_t TCMDEXEC_fs_read_file_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -180,7 +180,7 @@ uint8_t TCMDEXEC_fs_write_file_str(const char *args_str, TCMD_TelecommandChannel
 /// @brief Telecommand: Deletes a specified file in LittleFS
 /// @param args_str
 /// - Arg 0: File name to be deleted
-uint8_t TCMDEXEC_delete_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_delete_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char arg_file_name[64] = {0};
     const uint8_t parse_file_name_result = TCMD_extract_string_arg(args_str, 0, arg_file_name, sizeof(arg_file_name));

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -183,7 +183,7 @@ uint8_t TCMDEXEC_fs_write_file_str(const char *args_str, TCMD_TelecommandChannel
 /// @note Do not add quotations around the argument, write as is.
 uint8_t TCMDEXEC_fs_delete_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
-    char arg_file_name[64] = {0};
+    char arg_file_name[LFS_MAX_PATH_LENGTH];
     const uint8_t parse_file_name_result = TCMD_extract_string_arg(args_str, 0, arg_file_name, sizeof(arg_file_name));
     if (parse_file_name_result != 0) {
         // error parsing

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -177,6 +177,31 @@ uint8_t TCMDEXEC_fs_write_file_str(const char *args_str, TCMD_TelecommandChannel
 
 // TODO: Add a `fs_write_file_hex` telecommand, which supports offsets within the file. (Issue #266)
 
+/// @brief Telecommand: Deletes a specified file in LittleFS
+/// @param args_str
+/// - Arg 0: File name to be deleted
+uint8_t TCMDEXEC_delete_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+    char arg_file_name[64] = {0};
+    const uint8_t parse_file_name_result = TCMD_extract_string_arg(args_str, 0, arg_file_name, sizeof(arg_file_name));
+    if (parse_file_name_result != 0) {
+        // error parsing
+        snprintf(
+            response_output_buf,
+            response_output_buf_len,
+            "Error parsing file name arg: Error %d", parse_file_name_result);
+        return 1;
+    }
+
+    int8_t result = LFS_delete_file(arg_file_name);
+    if (result < 0) {
+        snprintf(response_output_buf, response_output_buf_len, "LittleFS Deleting Error: %d\n", result);
+        return 1;
+    }
+
+    snprintf(response_output_buf, response_output_buf_len, "LittleFS Successfully Deleted File!");
+    return 0;
+}
 /// @brief Reads a file from LittleFS, and responds with its contents as 2-digit hex bytes.
 /// @param args_str
 /// - Arg 0: File path as string

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -180,6 +180,7 @@ uint8_t TCMDEXEC_fs_write_file_str(const char *args_str, TCMD_TelecommandChannel
 /// @brief Telecommand: Deletes a specified file in LittleFS
 /// @param args_str
 /// - Arg 0: File name to be deleted
+/// @note Do not add quotations around the argument, write as is.
 uint8_t TCMDEXEC_fs_delete_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char arg_file_name[64] = {0};
@@ -202,6 +203,7 @@ uint8_t TCMDEXEC_fs_delete_file(const char *args_str, TCMD_TelecommandChannel_en
     snprintf(response_output_buf, response_output_buf_len, "LittleFS Successfully Deleted File!");
     return 0;
 }
+
 /// @brief Reads a file from LittleFS, and responds with its contents as 2-digit hex bytes.
 /// @param args_str
 /// - Arg 0: File path as string

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -272,7 +272,7 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
     },
     {
         .tcmd_name = "fs_delete_file",
-        .tcmd_func = TCMDEXEC_delete_file,
+        .tcmd_func = TCMDEXEC_fs_delete_file,
         .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -271,6 +271,12 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {
+        .tcmd_name = "fs_delete_file",
+        .tcmd_func = TCMDEXEC_delete_file,
+        .number_of_args = 1,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+    {
         .tcmd_name = "fs_read_file_hex",
         .tcmd_func = TCMDEXEC_fs_read_file_hex,
         .number_of_args = 1,


### PR DESCRIPTION
Resolves #227:

**Summary**
- Included telecommand that uses `LFS_delete_file` helper function to delete a file from LFS
- Accepts 1 argument: The name of the file to be deleted