### PR TITLE
GPS: Send log command and receive log response from gps receiver

### DIFF
--- a/firmware/Core/Inc/gps/gps_internal_drivers.h
+++ b/firmware/Core/Inc/gps/gps_internal_drivers.h
@@ -1,0 +1,11 @@
+
+#ifndef INCLUDE_GUARD__GPS_INTERNAL_DRIVERS_H__
+#define INCLUDE_GUARD__GPS_INTERNAL_DRIVERS_H__
+
+#include <stdint.h>
+
+uint8_t GPS_send_cmd_get_response(const char *cmd_buf, uint8_t cmd_buf_len, uint8_t rx_buf[],
+                                  uint16_t rx_buf_len, const uint16_t rx_buf_max_size);
+
+
+#endif /* INCLUDE_GUARD__GPS_INTERNAL_DRIVERS_H__ */

--- a/firmware/Core/Inc/telecommands/gps_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/gps_telecommand_defs.h
@@ -1,0 +1,11 @@
+#ifndef __INCLUDE_GUARD__GPS_TELECOMMAND_DEFS_H
+#define __INCLUDE_GUARD__GPS_TELECOMMAND_DEFS_H
+
+#include "telecommands/telecommand_types.h"
+
+#include <stdint.h>
+
+uint8_t TCMDEXEC_gps_send_log_cmd(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                                 char *response_output_buf, uint16_t response_output_buf_len);
+
+#endif // __INCLUDE_GUARD__GPS_TELECOMMAND_DEFS_H

--- a/firmware/Core/Inc/telecommands/gps_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/gps_telecommand_defs.h
@@ -5,7 +5,7 @@
 
 #include <stdint.h>
 
-uint8_t TCMDEXEC_gps_send_log_cmd(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_gps_send_cmd_ascii(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                                  char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif // __INCLUDE_GUARD__GPS_TELECOMMAND_DEFS_H

--- a/firmware/Core/Inc/uart_handler/uart_handler.h
+++ b/firmware/Core/Inc/uart_handler/uart_handler.h
@@ -21,7 +21,15 @@ extern volatile uint8_t UART_mpi_rx_last_byte; // Last received byte from the MP
 extern volatile uint32_t UART_mpi_rx_last_byte_write_time_ms; // Last write time in milliseconds for MPI response
 extern volatile uint16_t UART_mpi_rx_buffer_write_idx; // Write index for MPI response buffer
 
+extern const uint16_t UART_gps_buffer_len; 
+extern volatile uint8_t UART_gps_buffer[];          
+extern volatile uint16_t UART_gps_buffer_write_idx; 
+extern volatile uint32_t UART_gps_last_write_time_ms; 
+extern volatile uint8_t UART_gps_buffer_last_rx_byte;  
+extern volatile uint8_t UART_gps_uart_interrupt_enabled; // Flag to enable or disable the UART GPS ISR
+
 void UART_init_uart_handlers(void);
+void GPS_set_uart_interrupt_state(uint8_t new_enabled) ;
 
 
 #endif // __INCLUDE_GUARD__UART_HANDLER_H__

--- a/firmware/Core/Src/gps/gps_internal_drivers.c
+++ b/firmware/Core/Src/gps/gps_internal_drivers.c
@@ -124,17 +124,15 @@ uint8_t GPS_send_cmd_get_response(const char *cmd_buf, uint8_t cmd_buf_len, uint
 	}
 
 	// Copy the log response from the UART gps buffer to the rx_buf[] and clear the buffer
-    for (uint16_t i = 0; i < rx_buf_len; i++) {
+    for (uint16_t i = 0; i < UART_gps_buffer_write_idx; i++) {
 		rx_buf[i] = UART_gps_buffer[i];
 	}
 
-    // Reset the GPS UART interrupt variables
-    // TODO: Needs to be tested
-	for (uint16_t i = 0; i < UART_gps_buffer_len; i++)
-	{
-		UART_gps_buffer[i] = 0;
-	}
-	UART_gps_buffer_write_idx = 0;
+	LOG_message(
+		LOG_SYSTEM_GPS, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+        "rx_buf: %s",
+        rx_buf
+	);
 
 	return 0;
 }

--- a/firmware/Core/Src/gps/gps_internal_drivers.c
+++ b/firmware/Core/Src/gps/gps_internal_drivers.c
@@ -102,8 +102,6 @@ uint8_t GPS_send_cmd_get_response(const char *cmd_buf, uint8_t cmd_buf_len, uint
 	}
 
 	// End Receiving
-    // TODO: Determine where to call this. Further testing required
-    // If nothing is being populated in the UART_gps_buffer during testing, consider commenting out the line below
 	GPS_set_uart_interrupt_state(0); // We are no longer expecting a response
 
 	// Logging the received response

--- a/firmware/Core/Src/gps/gps_internal_drivers.c
+++ b/firmware/Core/Src/gps/gps_internal_drivers.c
@@ -1,0 +1,144 @@
+#include "main.h"
+
+#include "debug_tools/debug_uart.h"
+#include "debug_tools/debug_i2c.h"
+#include "gps/gps_internal_drivers.h"
+#include "uart_handler/uart_handler.h"
+#include "stm_drivers/timing_helpers.h"
+#include "uart_handler/uart_handler.h"
+#include "log/log.h"
+
+#include <stdint.h>
+#include <string.h>
+
+extern UART_HandleTypeDef *UART_gps_port_handle;
+
+const uint32_t GPS_RX_TIMEOUT_MS = 800;
+
+/// @brief Sends a log command to the GPS, and receives the response.
+/// @param cmd_buf log command string to send to the GPS.
+/// @param cmd_buf_len Exact length of the log command string.
+/// @param rx_buf Buffer to store the response.
+/// @param rx_buf_len Length of the response buffer.
+/// @param rx_buf_max_size Maximum length of the response buffer.
+/// @return 0 on success, >0 if error.
+/// @note This function is intended for "once" log commands
+uint8_t GPS_send_cmd_get_response(const char *cmd_buf, uint8_t cmd_buf_len, uint8_t rx_buf[], uint16_t rx_buf_len, const uint16_t rx_buf_max_size)
+{
+	
+	// Reset the GPS UART interrupt variables
+	GPS_set_uart_interrupt_state(0); // Lock writing to the UART_gps_buffer while we memset it
+	for (uint16_t i = 0; i < UART_gps_buffer_len; i++)
+	{
+		// Clear the buffer
+		// Can't use memset because UART_gps_buffer is volatile
+		UART_gps_buffer[i] = 0;
+	}
+	UART_gps_buffer_write_idx = 0;		 // Make it start writing from the start
+	GPS_set_uart_interrupt_state(1); // We are now expecting a response
+
+	// TX TO GPS
+	const HAL_StatusTypeDef tx_status = HAL_UART_Transmit(
+		UART_gps_port_handle,
+		(uint8_t *)cmd_buf,
+		cmd_buf_len,
+		GPS_RX_TIMEOUT_MS); // FIXME: update the timeout
+
+	if (tx_status != HAL_OK)
+	{
+		LOG_message(
+			LOG_SYSTEM_GPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+			"GPS ERROR: tx_status != HAL_OK (%d)\n",
+			tx_status);
+
+		return 1;
+	}
+
+	// FIXME: Update the timeouts with the actual times, it currently works with 800 ms and 500ms does not work
+	// GPS takes time to respond, first section of log response ie <OK\n [COM1] is quick but the rest of the data response takes a while
+	
+
+	// RX FROM GPS, into UART_gps_buffer
+	const uint32_t start_rx_time = HAL_GetTick();
+	while (1) {
+		if ((UART_gps_buffer_write_idx == 0)) {
+			// Check if we've timed out (before the first byte)
+			if ((HAL_GetTick() - start_rx_time) > GPS_RX_TIMEOUT_MS) {
+
+				LOG_message(
+					LOG_SYSTEM_GPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+					"GPS ERROR: Timeout before receiving any data"
+				);
+			
+				// fatal error; return
+				return 2;
+			}
+		}
+		else { // thus, UART_eps_buffer_write_idx > 0
+			// Check if we've timed out (between bytes)
+			const uint32_t cur_time = HAL_GetTick();
+			// Note: Sometimes, because ISRs and C are fun, the UART_eps_last_write_time_ms is
+			// greater than `cur_time`. Thus, we must do a safety check that the time difference
+			// is positive.
+			if (
+				(cur_time > UART_gps_last_write_time_ms) // Important seemingly-obvious safety check.
+				&& ((cur_time - UART_gps_last_write_time_ms) >  GPS_RX_TIMEOUT_MS)
+			) {
+				LOG_message(
+					LOG_SYSTEM_GPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+					"GPS WARNING: Timeout during receiving of response. UART_gps_last_write_time_ms=%lu, cur_time=%lu",
+					UART_gps_last_write_time_ms,
+					cur_time
+				);
+				// Non-fatal error; try to parse what we received
+				break;
+			}
+		}
+	}
+
+	// End Receiving
+    // TODO: Determine where to call this. Further testing required
+    // If nothing is being populated in the UART_gps_buffer during testing, consider commenting out the line below
+	GPS_set_uart_interrupt_state(0); // We are no longer expecting a response
+
+	// Logging the received response
+	LOG_message(
+		LOG_SYSTEM_GPS, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+        "GPS Buffer Data: %s",
+        UART_gps_buffer
+	);
+
+	// Check that we've received what we're expecting
+	// TODO: if the following cases happen ever during testing, consider allowing them and treating them as WARNINGs
+	if (UART_gps_buffer_write_idx == 0)
+	{
+		LOG_message(
+			LOG_SYSTEM_GPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+			"GPS ERROR: UART_gps_buffer_write_idx == 0"
+		);
+
+		return 3;
+	}
+	else if (UART_gps_buffer_write_idx > rx_buf_max_size)
+	{
+		LOG_message(
+			LOG_SYSTEM_GPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+			"GPS ERROR: UART_gps_buffer overflow");
+		return 4;
+	}
+
+	// Copying the log response from the UART gps buffer to the rx_buf[] and clearing the buffer
+    for (uint16_t i = 0; i < rx_buf_len; i++) {
+		rx_buf[i] = UART_gps_buffer[i];
+	}
+
+    // Reset the GPS UART interrupt variables
+    // TODO: Needs to be tested
+	for (uint16_t i = 0; i < UART_gps_buffer_len; i++)
+	{
+		UART_gps_buffer[i] = 0;
+	}
+	UART_gps_buffer_write_idx = 0;
+
+	return 0;
+}

--- a/firmware/Core/Src/gps/gps_internal_drivers.c
+++ b/firmware/Core/Src/gps/gps_internal_drivers.c
@@ -26,111 +26,110 @@ const uint32_t GPS_RX_TIMEOUT_BETWEEN_BYTES_MS = 800;
 /// @note This function is intended for "once" log commands
 uint8_t GPS_send_cmd_get_response(const char *cmd_buf, uint8_t cmd_buf_len, uint8_t rx_buf[], uint16_t rx_buf_len, const uint16_t rx_buf_max_size)
 {
-	
-	// Reset the GPS UART interrupt variables
-	GPS_set_uart_interrupt_state(0); // Lock writing to the UART_gps_buffer while we memset it
-	for (uint16_t i = 0; i < UART_gps_buffer_len; i++)
-	{
-		// Clear the buffer
-		// Can't use memset because UART_gps_buffer is volatile
-		UART_gps_buffer[i] = 0;
-	}
-	UART_gps_buffer_write_idx = 0;		// Make it start writing from the start
+    
+    // Reset the GPS UART interrupt variables
+    GPS_set_uart_interrupt_state(0); // Lock writing to the UART_gps_buffer while we memset it
+    for (uint16_t i = 0; i < UART_gps_buffer_len; i++)
+    {
+        // Clear the buffer
+        // Can't use memset because UART_gps_buffer is volatile
+        UART_gps_buffer[i] = 0;
+    }
+    UART_gps_buffer_write_idx = 0;		// Make it start writing from the start
 
-	// TX TO GPS
-	const HAL_StatusTypeDef tx_status = HAL_UART_Transmit(
-		UART_gps_port_handle,
-		(uint8_t *)cmd_buf,
-		cmd_buf_len,
-		100);
+    // TX TO GPS
+    const HAL_StatusTypeDef tx_status = HAL_UART_Transmit(
+        UART_gps_port_handle,
+        (uint8_t *)cmd_buf,
+        cmd_buf_len,
+        100);
 
-	if (tx_status != HAL_OK)
-	{
-		LOG_message(
-			LOG_SYSTEM_GPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
-			"GPS ERROR: tx_status != HAL_OK (%d)\n",
-			tx_status);
+    if (tx_status != HAL_OK)
+    {
+        LOG_message(
+            LOG_SYSTEM_GPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+            "GPS ERROR: tx_status != HAL_OK (%d)\n",
+            tx_status);
 
-		return 1;
-	}
+        return 1;
+    }
 
-	GPS_set_uart_interrupt_state(1);	// We are now expecting a response
+    GPS_set_uart_interrupt_state(1);	// We are now expecting a response
 
-	// FIXME: Update the timeouts with the actual times, it currently works with 800 ms and 500ms does not work
-	// GPS takes time to respond, first section of log response ie <OK\n [COM1] is quick but the rest of the data response takes a while
-	
+    // FIXME: Update the timeouts with the actual times, it currently works with 800 ms and 500ms does not work
+    // GPS takes time to respond, first section of log response ie <OK\n [COM1] is quick but the rest of the data response takes a while
+    
 
-	// RX FROM GPS, into UART_gps_buffer
-	const uint32_t start_rx_time = HAL_GetTick();
-	while (1) {
-		if ((UART_gps_buffer_write_idx == 0)) {
-			// Check if we've timed out (before the first byte)
-			if ((HAL_GetTick() - start_rx_time) > GPS_RX_TIMEOUT_BEFORE_FIRST_BYTE_MS) {
+    // RX FROM GPS, into UART_gps_buffer
+    const uint32_t start_rx_time = HAL_GetTick();
+    while (1) {
+        if ((UART_gps_buffer_write_idx == 0)) {
+            // Check if we've timed out (before the first byte)
+            if ((HAL_GetTick() - start_rx_time) > GPS_RX_TIMEOUT_BEFORE_FIRST_BYTE_MS) {
+                LOG_message(
+                    LOG_SYSTEM_GPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+                    "GPS ERROR: Timeout before receiving any data"
+                );
 
-				LOG_message(
-					LOG_SYSTEM_GPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
-					"GPS ERROR: Timeout before receiving any data"
-				);
+                // Disable the UART gps channel
+                GPS_set_uart_interrupt_state(0);
+            
+                // fatal error; return
+                return 2;
+            }
+        }
+        else { // thus, UART_eps_buffer_write_idx > 0
+            // Check if we've timed out (between bytes)
+            const uint32_t cur_time = HAL_GetTick();
+            // Note: Sometimes, because ISRs and C are fun, the UART_eps_last_write_time_ms is
+            // greater than `cur_time`. Thus, we must do a safety check that the time difference
+            // is positive.
+            if (
+                (cur_time > UART_gps_last_write_time_ms) // Important seemingly-obvious safety check.
+                && ((cur_time - UART_gps_last_write_time_ms) > GPS_RX_TIMEOUT_BETWEEN_BYTES_MS)
+            ) {
+                LOG_message(
+                    LOG_SYSTEM_GPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+                    "GPS WARNING: Timeout during receiving of response. UART_gps_last_write_time_ms=%lu, cur_time=%lu",
+                    UART_gps_last_write_time_ms,
+                    cur_time
+                );
+                // Non-fatal error; try to parse what we received
+                break;
+            }
+        }
+    }
 
-				// Disable the UART gps channel
-				GPS_set_uart_interrupt_state(0);
-			
-				// fatal error; return
-				return 2;
-			}
-		}
-		else { // thus, UART_eps_buffer_write_idx > 0
-			// Check if we've timed out (between bytes)
-			const uint32_t cur_time = HAL_GetTick();
-			// Note: Sometimes, because ISRs and C are fun, the UART_eps_last_write_time_ms is
-			// greater than `cur_time`. Thus, we must do a safety check that the time difference
-			// is positive.
-			if (
-				(cur_time > UART_gps_last_write_time_ms) // Important seemingly-obvious safety check.
-				&& ((cur_time - UART_gps_last_write_time_ms) > GPS_RX_TIMEOUT_BETWEEN_BYTES_MS)
-			) {
-				LOG_message(
-					LOG_SYSTEM_GPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
-					"GPS WARNING: Timeout during receiving of response. UART_gps_last_write_time_ms=%lu, cur_time=%lu",
-					UART_gps_last_write_time_ms,
-					cur_time
-				);
-				// Non-fatal error; try to parse what we received
-				break;
-			}
-		}
-	}
+    // End Receiving
+    GPS_set_uart_interrupt_state(0); // We are no longer expecting a response
 
-	// End Receiving
-	GPS_set_uart_interrupt_state(0); // We are no longer expecting a response
-
-	// Logging the received response
-	LOG_message(
-		LOG_SYSTEM_GPS, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+    // Logging the received response
+    LOG_message(
+        LOG_SYSTEM_GPS, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
         "GPS Buffer Data: %s",
         UART_gps_buffer
-	);
+    );
 
-	// Check that we've received what we're expecting
-	// TODO: If the following cases happen ever during testing, consider allowing them and treating them as WARNINGs
-	if (UART_gps_buffer_write_idx > rx_buf_max_size)
-	{
-		LOG_message(
-			LOG_SYSTEM_GPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
-			"GPS ERROR: UART_gps_buffer overflow");
-		return 3;
-	}
+    // Check that we've received what we're expecting
+    // TODO: If the following cases happen ever during testing, consider allowing them and treating them as WARNINGs
+    if (UART_gps_buffer_write_idx > rx_buf_max_size)
+    {
+        LOG_message(
+            LOG_SYSTEM_GPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+            "GPS ERROR: UART_gps_buffer overflow");
+        return 3;
+    }
 
-	// Copy the log response from the UART gps buffer to the rx_buf[] and clear the buffer
+    // Copy the log response from the UART gps buffer to the rx_buf[] and clear the buffer
     for (uint16_t i = 0; i < UART_gps_buffer_write_idx; i++) {
-		rx_buf[i] = UART_gps_buffer[i];
-	}
+        rx_buf[i] = UART_gps_buffer[i];
+    }
 
-	LOG_message(
-		LOG_SYSTEM_GPS, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+    LOG_message(
+        LOG_SYSTEM_GPS, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
         "rx_buf: %s",
         rx_buf
-	);
+    );
 
-	return 0;
+    return 0;
 }

--- a/firmware/Core/Src/log/log.c
+++ b/firmware/Core/Src/log/log.c
@@ -17,8 +17,8 @@
 #define LOG_TIMESTAMP_MAX_LENGTH 30
 #define LOG_SINK_NAME_MAX_LENGTH 20
 #define LOG_SYSTEM_NAME_MAX_LENGTH 20
-// Messages up to 256 characters
-#define LOG_FORMATTED_MESSAGE_MAX_LENGTH 256
+// Messages up to 512 characters
+#define LOG_FORMATTED_MESSAGE_MAX_LENGTH 512
 // Includes prefix, with cushion for delimiters, newline, and null terminator
 #define LOG_FULL_MESSAGE_MAX_LENGTH ( LOG_FORMATTED_MESSAGE_MAX_LENGTH + LOG_TIMESTAMP_MAX_LENGTH + LOG_SINK_NAME_MAX_LENGTH + LOG_SYSTEM_NAME_MAX_LENGTH + 1 )
 

--- a/firmware/Core/Src/telecommands/gps_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/gps_telecommand_defs.c
@@ -41,13 +41,14 @@ uint8_t TCMDEXEC_gps_send_cmd_ascii(const char *args_str, TCMD_TelecommandChanne
     memset(GPS_rx_buffer, 0, GPS_rx_buffer_max_size); // Initialize all elements to 0
 
     // Send log command to GPS and receive response
-    const uint8_t gps_cmd_response = GPS_send_cmd_get_response(gps_log_cmd, gps_log_cmd_len, GPS_rx_buffer, GPS_rx_buffer_len, GPS_rx_buffer_max_size);
+    const uint8_t gps_cmd_response = GPS_send_cmd_get_response(
+        gps_log_cmd, gps_log_cmd_len, GPS_rx_buffer, GPS_rx_buffer_len, GPS_rx_buffer_max_size
+    );
 
     // Handle the gps_cmd_response: Perform the error checks
     // TODO: Potentially add GPS_validate_log_response function in here to validate response from the gps receiver
 
-    if(gps_cmd_response!=0){
-        
+    if(gps_cmd_response != 0){
         LOG_message(
             LOG_SYSTEM_GPS,
             LOG_SEVERITY_NORMAL,

--- a/firmware/Core/Src/telecommands/gps_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/gps_telecommand_defs.c
@@ -1,0 +1,64 @@
+#include "telecommands/telecommand_definitions.h"
+#include "uart_handler/uart_handler.h"
+#include "telecommands/eps_telecommands.h"
+#include "gps/gps_internal_drivers.h"
+#include "log/log.h"
+#include "main.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+/// @brief Telecommand: Transmit a log command to the GPS receiver through UART
+/// @param args_str
+/// - Arg 0: Log command to be sent to GPS eg "log bestxyza once" (string)
+/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
+/// @param response_output_buf The buffer to write the response to
+/// @param response_output_buf_len The maximum length of the response_output_buf (its size)
+/// @return 0 on success, > 0 error
+uint8_t TCMDEXEC_gps_send_log_cmd(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                                  char *response_output_buf, uint16_t response_output_buf_len)
+{
+
+    if (args_str == NULL)
+    {
+        snprintf(response_output_buf, response_output_buf_len, "Error: Empty args_str");
+        return 1;
+    }
+
+    // TODO : Determine if we need to perform extra error checks on arg_str ie log command format etc
+
+    // Adding a new line character to the log command
+    char gps_log_cmd[128];
+    snprintf(gps_log_cmd, sizeof(gps_log_cmd), "%s\n", args_str);
+    const uint16_t gps_log_cmd_len = strlen(gps_log_cmd);
+
+    // Allocate space to receive incoming GPS response.
+    const uint16_t GPS_rx_buffer_max_size = 512;
+    uint16_t GPS_rx_buffer_len = 0;
+    uint8_t GPS_rx_buffer[GPS_rx_buffer_max_size];
+    memset(GPS_rx_buffer, 0, GPS_rx_buffer_max_size); // Initialize all elements to 0
+
+    // Send log command to GPS and receive response
+    const uint8_t gps_cmd_response = GPS_send_cmd_get_response(gps_log_cmd, gps_log_cmd_len, GPS_rx_buffer, GPS_rx_buffer_len, GPS_rx_buffer_max_size);
+
+    // Handle the gps_cmd_response: Perform the error checks
+    // TODO: Potentially add GPS_validate_log_response function in here to validate response from the gps receiver
+
+    if(gps_cmd_response!=0){
+        
+        LOG_message(
+            LOG_SYSTEM_GPS,
+            LOG_SEVERITY_NORMAL,
+            LOG_SINK_ALL,
+            "GPS Response Code: %d",
+            gps_cmd_response
+        );
+
+    }
+
+    snprintf(response_output_buf, response_output_buf_len, "GPS Command: %s successfully transmitted", args_str);
+
+    return 0;
+}

--- a/firmware/Core/Src/telecommands/gps_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/gps_telecommand_defs.c
@@ -58,7 +58,7 @@ uint8_t TCMDEXEC_gps_send_log_cmd(const char *args_str, TCMD_TelecommandChannel_
 
     }
 
-    snprintf(response_output_buf, response_output_buf_len, "GPS Command: %s successfully transmitted", args_str);
+    snprintf(response_output_buf, response_output_buf_len, "GPS Command: '%s' successfully transmitted", args_str);
 
     return 0;
 }

--- a/firmware/Core/Src/telecommands/gps_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/gps_telecommand_defs.c
@@ -17,7 +17,7 @@
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0 on success, > 0 error
-uint8_t TCMDEXEC_gps_send_log_cmd(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_gps_send_cmd_ascii(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                                   char *response_output_buf, uint16_t response_output_buf_len)
 {
 

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -24,6 +24,7 @@
 #include "telecommands/eps_telecommands.h"
 #include "telecommands/stm32_internal_flash_telecommand_defs.h"
 #include "telecommands/comms_telecommand_defs.h"
+#include "telecommands/gps_telecommand_defs.h"
 
 
 #include "timekeeping/timekeeping.h"
@@ -1016,6 +1017,14 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .readiness_level = TCMD_READINESS_LEVEL_FLIGHT_TESTING,
     },
     // ****************** END SECTION: comms_telecommand_defs ******************
+    // ****************** SECTION: gps_telecommand_defs ******************
+    {
+        .tcmd_name = "gps_send_log_cmd",
+        .tcmd_func = TCMDEXEC_gps_send_log_cmd,
+        .number_of_args = 1,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+    // ****************** END SECTION: gps_telecommand_defs ******************
 };
 
 // extern

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -1019,7 +1019,7 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
     // ****************** END SECTION: comms_telecommand_defs ******************
     // ****************** SECTION: gps_telecommand_defs ******************
     {
-        .tcmd_name = "gps_send_log_cmd",
+        .tcmd_name = "gps_send_cmd_ascii",
         .tcmd_func = TCMDEXEC_gps_send_cmd_ascii,
         .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -1020,7 +1020,7 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
     // ****************** SECTION: gps_telecommand_defs ******************
     {
         .tcmd_name = "gps_send_log_cmd",
-        .tcmd_func = TCMDEXEC_gps_send_log_cmd,
+        .tcmd_func = TCMDEXEC_gps_send_cmd_ascii,
         .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },

--- a/firmware/Core/Src/uart_handler/uart_handler.c
+++ b/firmware/Core/Src/uart_handler/uart_handler.c
@@ -7,6 +7,7 @@
 UART_HandleTypeDef *UART_telecommand_port_handle = &hlpuart1;
 UART_HandleTypeDef *UART_eps_port_handle = &huart5; // TODO: update this
 UART_HandleTypeDef *UART_mpi_port_handle = &huart1;
+UART_HandleTypeDef *UART_gps_port_handle = &huart3;
 
 // UART telecommand buffer
 const uint16_t UART_telecommand_buffer_len = 256; // extern
@@ -29,6 +30,14 @@ volatile uint8_t UART_mpi_rx_buffer[50]; // extern
 volatile uint8_t UART_mpi_rx_last_byte = 0; // extern
 volatile uint32_t UART_mpi_rx_last_byte_write_time_ms = 0; // extern
 volatile uint16_t UART_mpi_rx_buffer_write_idx = 0; // extern
+
+// UART GPS buffer
+const uint16_t UART_gps_buffer_len = 512; // extern
+volatile uint8_t UART_gps_buffer[512]; // extern
+volatile uint16_t UART_gps_buffer_write_idx = 0; // extern
+volatile uint32_t UART_gps_last_write_time_ms = 0; // extern
+volatile uint8_t UART_gps_buffer_last_rx_byte = 0; // extern
+volatile uint8_t UART_gps_uart_interrupt_enabled = 0; //extern
 
 // UART MPI science data buffer (WILL NEED IN THE FUTURE)
 // const uint16_t UART_mpi_data_rx_buffer_len = 8192; // extern 
@@ -104,6 +113,29 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
             DEBUG_uart_print_str("Unhandled MPI Mode\n"); // TODO: HANDLE other MPI MODES
         }
     }
+    
+    else if (huart->Instance == UART_gps_port_handle->Instance) {
+        if (UART_gps_uart_interrupt_enabled == 1) {
+
+            // Add the byte to the buffer
+            if (UART_gps_buffer_write_idx >= UART_gps_buffer_len) {
+                DEBUG_uart_print_str("HAL_UART_RxCpltCallback() -> UART gps buffer is full\n");
+                
+                // Shift all bytes left by 1
+                for (uint16_t i = 1; i < UART_gps_buffer_len; i++) {
+                    UART_gps_buffer[i - 1] = UART_gps_buffer[i];
+                }
+
+                // Reset to a valid index
+                UART_gps_buffer_write_idx = UART_gps_buffer_len - 1;
+            }
+            UART_gps_buffer[UART_gps_buffer_write_idx++] = UART_gps_buffer_last_rx_byte;
+            UART_gps_last_write_time_ms = HAL_GetTick();
+
+            HAL_UART_Receive_IT(UART_gps_port_handle, (uint8_t*) &UART_gps_buffer_last_rx_byte, 1);
+        }
+        
+    }
 
     else {
         // FIXME: add the rest (camera, MPI, maybe others)
@@ -117,4 +149,18 @@ void UART_init_uart_handlers(void) {
     HAL_UART_Receive_IT(UART_eps_port_handle, (uint8_t*) &UART_eps_buffer_last_rx_byte, 1);
 
     // TODO: add the rest
+}
+
+
+/// @brief Sets the UART interrupt state (enabled/disabled)
+/// @param new_enabled 1: enable interrupt; 0: disable interrupt
+void GPS_set_uart_interrupt_state(uint8_t new_enabled) {
+    if (new_enabled == 1)
+    {
+        UART_gps_uart_interrupt_enabled = 1;
+        HAL_UART_Receive_IT(UART_gps_port_handle, (uint8_t*) &UART_gps_buffer_last_rx_byte, 1);
+    }
+    else {
+        UART_gps_uart_interrupt_enabled = 0;
+    }
 }


### PR DESCRIPTION
## Related Issues

Closes #246  

## Summary

This PR implements UART communication between the GNSS Receiver and the OBC. This includes transmitting a log command as a string and receiving a log response from the GNSS receiver

## Changes Made

The changes made to realize this were as follows:
- Modified `uart_handler` to receive the GNSS response in interrupt mode. 
- Created a function `GPS_set_uart_interrupt_state` to initialize UART communication
- Created a file called `gps_internal_drivers` that contains the function, `GPS_send_cmd_get_response`, that handles the communication with the GNSS receiver.
- Added a telecommand `TCMDEXEC_gps_send_log_cmd` to call the function mentioned above.

## Testing Instructions
Tests were conducted on 28th November with @DeflateAwning and @NuclearTea present and we verified the functionality of the functions mentioned. Hence, the tests were successful. 

## Special Notes for Your Reviewer(s)

There are some `TODO` and `FIXME` tags within the code based on the current implementation that will need deeper looking into for proper functionality. 