### PR TITLE
Fixes the temporary issue of tmstmp == 0. Allows for running Telecommands w/o specifiying one beforehand.

### DIFF
--- a/firmware/Core/Src/telecommands/telecommand_executor.c
+++ b/firmware/Core/Src/telecommands/telecommand_executor.c
@@ -57,7 +57,7 @@ uint8_t TCMD_add_tcmd_to_agenda(const TCMD_parsed_tcmd_to_execute_t *parsed_tcmd
         }
 
         // check to see if timestamp is in the circular buffer
-        for (uint32_t i = 0; i <= TCMD_timestamp_sent_head; i++) {
+        for (uint32_t i = 0; i < TCMD_timestamp_sent_head; i++) {
             
             // TODO; Get rid of this when telecommands do not automatically default to 0.
             if(parsed_tcmd->timestamp_sent == 0){
@@ -73,13 +73,11 @@ uint8_t TCMD_add_tcmd_to_agenda(const TCMD_parsed_tcmd_to_execute_t *parsed_tcmd
                 );
                 return 1; 
             }
-            else{
-                // Add the timestamp to the circular buffer
-                TCMD_timestamp_sent_store[TCMD_timestamp_sent_head] = parsed_tcmd->timestamp_sent;
-                TCMD_timestamp_sent_head = (TCMD_timestamp_sent_head + 1) % TCMD_TIMESTAMP_RECORD_SIZE;
-                break;
-            }
         }
+
+        // Add the timestamp to the circular buffer
+        TCMD_timestamp_sent_store[TCMD_timestamp_sent_head] = parsed_tcmd->timestamp_sent;
+        TCMD_timestamp_sent_head = (TCMD_timestamp_sent_head + 1) % TCMD_TIMESTAMP_RECORD_SIZE;
 
         // Copy the parsed telecommand into the agenda.
         TCMD_agenda[slot_num].tcmd_idx = parsed_tcmd->tcmd_idx;


### PR DESCRIPTION
### ----------------------------------------------------------------------------------------------
### This fix is meant to be temporary until we get the timestamp function working. This should make debugging and running telecommands as easy as it was before issue #53 was pushed.
### ----------------------------------------------------------------------------------------------

### To Test:

1. Run any Telecommand.
2. Check the Timestamp (it should be 0).
3. Rerun any telecommand. Check telecommand works as requested. 
       - If you receive an error "Telecommand skipped due to timestamp collision" try Flashing/Building again.
5.  Check the timestamp again (it should be 0); Check if the telecommand works as requested.
6. Run any Telecommand with the '@tssent=x' function. (Ex: CTS1+hello_world()@tssent=1!)
7. Rerun the same telecommand with the same number.
      - The expected output should be "Telecommand skipped due to timestamp collision" This time, if the telecommand runs to completion, flash/build and try again.
8. run another telecommand with the same 'tssent' value. 
     - The expected output should be "Telecommand skipped due to timestamp collision" This time, if the telecommand runs to completion, flash/build and try again. 
10. rerun the same telecommand with another 'tssent' value that hasn't been used yet (ex. if you used '1' last time, use '4' now).
     - This time Telecommand should run to completion. 