### PR TITLE
Start up antenna deployment sequence

### DIFF
--- a/firmware/Core/Inc/rtos_tasks/rtos_tasks.h
+++ b/firmware/Core/Inc/rtos_tasks/rtos_tasks.h
@@ -14,5 +14,6 @@ void TASK_handle_uart_telecommands(void *argument);
 void TASK_execute_telecommands(void *argument);
 
 void TASK_monitor_freertos_memory(void *argument);
+void TASK_bootup(void *argument);
 
 #endif // __INCLUDE_GUARD__RTOS_TASKS_H__

--- a/firmware/Core/Inc/startup_sequence/antenna_deploy_startup.h
+++ b/firmware/Core/Inc/startup_sequence/antenna_deploy_startup.h
@@ -1,0 +1,7 @@
+#ifndef __INCLUDE_GUARD__ANTENNA_DEPLOY_STARTUP_H__
+#define __INCLUDE_GUARD__ANTENNA_DEPLOY_STARTUP_H__
+#include <stdint.h>
+uint8_t START_antenna_deploy();
+
+
+#endif  // __INCLUDE_GUARD__ANTENNA_DEPLOY_STARTUP_H__

--- a/firmware/Core/Inc/startup_sequence/antenna_deploy_startup.h
+++ b/firmware/Core/Inc/startup_sequence/antenna_deploy_startup.h
@@ -1,7 +1,8 @@
 #ifndef __INCLUDE_GUARD__ANTENNA_DEPLOY_STARTUP_H__
 #define __INCLUDE_GUARD__ANTENNA_DEPLOY_STARTUP_H__
 #include <stdint.h>
-int16_t START_antenna_deploy();
 
-
+int16_t START_deploy_antenna();
+int16_t START_deploy_antenna_if_sufficiently_charged();
+int16_t START_read_config_and_deploy_antenna_accordingly();
 #endif  // __INCLUDE_GUARD__ANTENNA_DEPLOY_STARTUP_H__

--- a/firmware/Core/Inc/startup_sequence/antenna_deploy_startup.h
+++ b/firmware/Core/Inc/startup_sequence/antenna_deploy_startup.h
@@ -1,7 +1,7 @@
 #ifndef __INCLUDE_GUARD__ANTENNA_DEPLOY_STARTUP_H__
 #define __INCLUDE_GUARD__ANTENNA_DEPLOY_STARTUP_H__
 #include <stdint.h>
-uint8_t START_antenna_deploy();
+int16_t START_antenna_deploy();
 
 
 #endif  // __INCLUDE_GUARD__ANTENNA_DEPLOY_STARTUP_H__

--- a/firmware/Core/Src/main.c
+++ b/firmware/Core/Src/main.c
@@ -32,6 +32,8 @@
 #include "adcs_drivers/adcs_internal_drivers.h"
 #include "littlefs/flash_driver.h"
 
+#include "startup_sequence/antenna_deploy_startup.h"
+
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -257,6 +259,7 @@ int main(void)
   // Initialise the ADCS CRC8 checksum (required for ADCS operation).
   ADCS_initialise_crc8_checksum();
 
+  START_antenna_deploy();
   /* USER CODE END 2 */
 
   /* Init scheduler */

--- a/firmware/Core/Src/main.c
+++ b/firmware/Core/Src/main.c
@@ -170,6 +170,13 @@ FREERTOS_task_info_struct_t FREERTOS_task_handles_array [] = {
 
 const uint32_t FREERTOS_task_handles_array_size = sizeof(FREERTOS_task_handles_array) / sizeof(FREERTOS_task_info_struct_t);
 
+osThreadId_t TASK_bootup_Handle;
+const osThreadAttr_t TASK_bootup_Attributes = {
+  .name = "TASK_bootup",
+  .stack_size = 1024, //in bytes. 512 is tool small and will cause crashes when lfs_close() is called!
+  .priority = (osPriority_t) osPriorityNormal, //TODO: Figure out which priority makes sense for this task
+};
+
 
 /* USER CODE END PV */
 
@@ -259,7 +266,6 @@ int main(void)
   // Initialise the ADCS CRC8 checksum (required for ADCS operation).
   ADCS_initialise_crc8_checksum();
 
-  START_antenna_deploy();
   /* USER CODE END 2 */
 
   /* Init scheduler */
@@ -297,6 +303,8 @@ int main(void)
   TASK_service_eps_watchdog_Handle = osThreadNew(TASK_service_eps_watchdog, NULL, &TASK_service_eps_watchdog_Attributes);
 
   TASK_time_sync_Handle = osThreadNew(TASK_time_sync, NULL, &TASK_time_sync_Attributes);
+
+  TASK_bootup_Handle = osThreadNew(TASK_bootup, NULL, &TASK_bootup_Attributes);
   /* USER CODE END RTOS_THREADS */
 
   /* USER CODE BEGIN RTOS_EVENTS */

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -229,14 +229,13 @@ void TASK_bootup(void *argument) {
 	TASK_HELP_start_of_task();
 
 	uint8_t ant_deploy_complete = 0;
-	//TODO: Unsure of how to properly terminate this task. Should it be a forever loop?
+	uint32_t delay_ms = 100;
 	while (1) {
-		//TODO: What should the delay be here? I suspect it should be smaller.
-		osDelay(2000);
+		//TODO: What should the delay be here? 
+		osDelay(delay_ms);
+		delay_ms = 60000;
 		if (!ant_deploy_complete) {
-			START_antenna_deploy();
-			//TODO: This should be changed to the commeted out code
-			if (/*START_antenna_deploy() == 0*/ 1) {
+			if (START_antenna_deploy() == 0) {
 				ant_deploy_complete = 1;	
 			}
 		}

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -12,6 +12,7 @@
 #include "log/log.h"
 #include "config/configuration.h"
 #include "eps_drivers/eps_commands.h"
+#include "startup_sequence/antenna_deploy_startup.h"
 
 #include "cmsis_os.h"
 
@@ -220,5 +221,24 @@ void TASK_monitor_freertos_memory(void *argument) {
 			}
 		}
 
+	} /* End Task's Main Loop */
+}
+/// @brief Completes all tasks which are nesssary after the obc is powered on(or rebooted)
+/// @param argument 
+void TASK_bootup(void *argument) {
+	TASK_HELP_start_of_task();
+
+	uint8_t ant_deploy_complete = 0;
+	//TODO: Unsure of how to properly terminate this task. Should it be a forever loop?
+	while (1) {
+		//TODO: What should the delay be here? I suspect it should be smaller.
+		osDelay(2000);
+		if (!ant_deploy_complete) {
+			START_antenna_deploy();
+			//TODO: This should be changed to the commeted out code
+			if (/*START_antenna_deploy() == 0*/ 1) {
+				ant_deploy_complete = 1;	
+			}
+		}
 	} /* End Task's Main Loop */
 }

--- a/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
+++ b/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
@@ -2,6 +2,8 @@
 #include "littlefs/littlefs_helper.h"
 #include "littlefs/lfs.h"
 #include "log/log.h"
+#include "antenna_deploy_drivers/ant_commands.h"
+#include "antenna_deploy_drivers/ant_internal_drivers.h"
 uint8_t START_antenna_deploy() {
     LOG_message(
         LOG_SYSTEM_LFS, 
@@ -47,20 +49,55 @@ uint8_t START_antenna_deploy() {
     }
     // At this point the lifecycle directory exists or has been created
 
+
     // Create deploy_antenna_on_boot_enabled.bool file if it doesn't exist
     //
     lfs_file_t file;
     int32_t open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_RDONLY, &LFS_file_cfg);
+    uint8_t file_did_exist = 1;
     if ( open_result == LFS_ERR_NOENT) {
-        // Create file if it doesn't exist
-        open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_RDONLY | LFS_O_CREAT, &LFS_file_cfg);
+        // file doesn't exist, create it and open for writing 
+        file_did_exist = 0;
+        open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_WRONLY | LFS_O_CREAT, &LFS_file_cfg);
         LOG_message(
             LOG_SYSTEM_LFS, 
             LOG_SEVERITY_NORMAL, 
             LOG_SINK_ALL, 
             "file did not exist, created deploy_antenna_on_boot_enabled.bool file."
         );
+        if (open_result == 0)
+        {
+            uint8_t buff = 1;
+            int32_t write_result = lfs_file_write(&LFS_filesystem, &file, &buff, sizeof(buff));
+            if(write_result < 0) {
+                LOG_message(
+                    LOG_SYSTEM_LFS, 
+                    LOG_SEVERITY_WARNING, 
+                    LOG_SINK_ALL, 
+                    "Error %d writing to newly created deploy_antenna_on_boot_enabled.bool file.",
+                    write_result
+                );
+                //TODO: what happens if write fails? 
+            }
+            
+            int32_t close_result = lfs_file_close(&LFS_filesystem, &file);
+            if(close_result < 0) {
+            LOG_message(
+                    LOG_SYSTEM_LFS, 
+                    LOG_SEVERITY_WARNING, 
+                    LOG_SINK_ALL, 
+                    "Error %d closing newly created deploy_antenna_on_boot_enabled.bool file.",
+                    close_result
+                );
+                //TODO: what happens if close fails?
+            }
+
+            // the fil has been created and 1 (assuming no errors occured) has been written to it, open for reading
+            open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_RDONLY, &LFS_file_cfg);
+        }
+        
     } 
+    //TODO: should this be else if?
     else if(open_result != 0) {
         LOG_message(
             LOG_SYSTEM_LFS, 
@@ -80,9 +117,8 @@ uint8_t START_antenna_deploy() {
     }
     // At this point the depoy_antenna_on_boot_enabled.bool file is open 
 
-    uint8_t deploy_antenna_on_boot_enabled[10];
-    size_t num_bytes_read = lfs_file_read(&LFS_filesystem, &file, &deploy_antenna_on_boot_enabled, sizeof(deploy_antenna_on_boot_enabled));
-
+    uint8_t deploy_antenna_on_boot_enabled;
+    int32_t num_bytes_read = lfs_file_read(&LFS_filesystem, &file, &deploy_antenna_on_boot_enabled, sizeof(deploy_antenna_on_boot_enabled));
     if(num_bytes_read < 0) { 
         LOG_message(
             LOG_SYSTEM_LFS, 
@@ -105,20 +141,23 @@ uint8_t START_antenna_deploy() {
             LOG_SYSTEM_LFS, 
             LOG_SEVERITY_NORMAL, 
             LOG_SINK_ALL, 
-            "read %d bytes from deploy_antenna_on_boot_enabled.bool. Result: %s",
+            "read %d bytes from deploy_antenna_on_boot_enabled.bool. Result: %d",
             num_bytes_read,
-            deploy_antenna_on_boot_enabled
+            deploy_antenna_on_boot_enabled[0]
         );
     }
-
-    //uint8_t deploy_antenna_on_boot_enabled;
-
-    //lfs_file_read(&LFS_filesystem, &file, &deploy_antenna_on_boot_enabled, sizeof(deploy_antenna_on_boot_enabled));
-
-    // lfs_file_close(&LFS_filesystem, &file);
-
+    //reading the file is done now, unmount fs and close the file
+    lfs_file_close(&LFS_filesystem, &file);
     if(LFS_unmount_on_completion) {
         lfs_unmount(&LFS_filesystem);
     }
+
+    if(deploy_antenna_on_boot_enabled == 1) {
+        //TODO: which mcu should be armed on the antenna deploy system? Error handling
+     ANT_CMD_arm_antenna_system(ANT_i2c_bus_mcu1);
+     ANT_CMD_start_automated_sequential_deployment(ANT_i2c_bus_mcu1, 7);
+    }
+
+
     return 0;
 }

--- a/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
+++ b/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
@@ -4,7 +4,7 @@
 #include "log/log.h"
 #include "antenna_deploy_drivers/ant_commands.h"
 #include "antenna_deploy_drivers/ant_internal_drivers.h"
-#include "eps_commands.h"
+#include "eps_drivers/eps_commands.h"
 
 /// @brief reads the value from the file "lifecycle/deploy_antenna_on_boot_enabled.bool"
 /// @param read_value where the read value will be stored upon success 

--- a/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
+++ b/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
@@ -4,32 +4,29 @@
 #include "log/log.h"
 #include "antenna_deploy_drivers/ant_commands.h"
 #include "antenna_deploy_drivers/ant_internal_drivers.h"
-uint8_t START_antenna_deploy() {
+/// @brief Attempts to read to the file "lifecycle/deploy_antenna_on_boot_enabled.bool".
+/// If 1 is stored in the file then it attempts to deploy the antenna. If the file did not
+/// exist: then it creates the file, stores a 1 in it, and attempts to deploy.
+/// @return 0 on success, <0 on failure
+int16_t START_antenna_deploy() {
+    //TODO: remove after validation
     LOG_message(
         LOG_SYSTEM_LFS, 
         LOG_SEVERITY_NORMAL, 
         LOG_SINK_ALL, 
         "Starting Antenna Deploy"
     );
+
     uint8_t LFS_unmount_on_completion = 0;
     if (!LFS_is_lfs_mounted) {
-        lfs_mount(&LFS_filesystem, &LFS_cfg);
+        if (lfs_mount(&LFS_filesystem, &LFS_cfg) != 0) {
+            return -1;
+        }
         LFS_unmount_on_completion = 1;
     }
 
     // Create lifecycle directory if it doesn't exist
     const int32_t mkdir_result = lfs_mkdir(&LFS_filesystem, "lifecycle");
-    if(mkdir_result != LFS_ERR_EXIST && mkdir_result != 0) {
-        LOG_message(
-            LOG_SYSTEM_LFS, 
-            LOG_SEVERITY_NORMAL, 
-            LOG_SINK_ALL, 
-            "Error %d creating lifecycle directory.",
-            mkdir_result
-        );
-        //TODO: what happens if directory creation fails?
-    }
-
     if(mkdir_result == LFS_ERR_EXIST) {
         LOG_message(
             LOG_SYSTEM_LFS, 
@@ -39,6 +36,18 @@ uint8_t START_antenna_deploy() {
         );
     }
 
+    if(mkdir_result != LFS_ERR_EXIST && mkdir_result != 0) {
+        LOG_message(
+            LOG_SYSTEM_LFS, 
+            LOG_SEVERITY_NORMAL, 
+            LOG_SINK_ALL, 
+            "Error %d creating lifecycle directory.",
+            mkdir_result
+        );
+        return -2;
+    }
+
+    //TODO: remove after validation
     if(mkdir_result == 0) {
         LOG_message(
             LOG_SYSTEM_LFS, 
@@ -51,54 +60,13 @@ uint8_t START_antenna_deploy() {
 
 
     // Create deploy_antenna_on_boot_enabled.bool file if it doesn't exist
-    //
     lfs_file_t file;
     int32_t open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_RDONLY, &LFS_file_cfg);
-    uint8_t file_did_exist = 1;
     if ( open_result == LFS_ERR_NOENT) {
-        // file doesn't exist, create it and open for writing 
-        file_did_exist = 0;
-        open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_WRONLY | LFS_O_CREAT, &LFS_file_cfg);
-        LOG_message(
-            LOG_SYSTEM_LFS, 
-            LOG_SEVERITY_NORMAL, 
-            LOG_SINK_ALL, 
-            "file did not exist, created deploy_antenna_on_boot_enabled.bool file."
-        );
-        if (open_result == 0)
-        {
-            uint8_t buff = 1;
-            int32_t write_result = lfs_file_write(&LFS_filesystem, &file, &buff, sizeof(buff));
-            if(write_result < 0) {
-                LOG_message(
-                    LOG_SYSTEM_LFS, 
-                    LOG_SEVERITY_WARNING, 
-                    LOG_SINK_ALL, 
-                    "Error %d writing to newly created deploy_antenna_on_boot_enabled.bool file.",
-                    write_result
-                );
-                //TODO: what happens if write fails? 
-            }
-            
-            int32_t close_result = lfs_file_close(&LFS_filesystem, &file);
-            if(close_result < 0) {
-            LOG_message(
-                    LOG_SYSTEM_LFS, 
-                    LOG_SEVERITY_WARNING, 
-                    LOG_SINK_ALL, 
-                    "Error %d closing newly created deploy_antenna_on_boot_enabled.bool file.",
-                    close_result
-                );
-                //TODO: what happens if close fails?
-            }
 
-            // the fil has been created and 1 (assuming no errors occured) has been written to it, open for reading
-            open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_RDONLY, &LFS_file_cfg);
-        }
-        
-    } 
-    //TODO: should this be else if?
-    else if(open_result != 0) {
+        // if file doesn't exist, create it and open for writing and write 1 
+        open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_WRONLY | LFS_O_CREAT, &LFS_file_cfg);
+        if(open_result != 0) {
         LOG_message(
             LOG_SYSTEM_LFS, 
             LOG_SEVERITY_WARNING, 
@@ -106,7 +74,64 @@ uint8_t START_antenna_deploy() {
             "Error %d opening/creating deploy_antenna_on_boot_enabled.bool file.",
             open_result
         );
+        return open_result;
+        }
+          
+        uint8_t buff = 1;
+        int32_t write_result = lfs_file_write(&LFS_filesystem, &file, &buff, sizeof(buff));
+        if(write_result < 0) {
+            LOG_message(
+                LOG_SYSTEM_LFS, 
+                LOG_SEVERITY_WARNING, 
+                LOG_SINK_ALL, 
+                "Error %d writing to newly created deploy_antenna_on_boot_enabled.bool file.",
+                write_result
+            );
+            return write_result;
+        }
+
+        //TODO: remove after validation
+        LOG_message(
+            LOG_SYSTEM_LFS, 
+            LOG_SEVERITY_NORMAL, 
+            LOG_SINK_ALL, 
+            "file did not exist, created deploy_antenna_on_boot_enabled.bool file."
+        );
+        
+        int32_t close_result = lfs_file_close(&LFS_filesystem, &file);
+        if(close_result != 0) {
+            LOG_message(
+                LOG_SYSTEM_LFS, 
+                LOG_SEVERITY_WARNING, 
+                LOG_SINK_ALL, 
+                "Error %d closing newly created deploy_antenna_on_boot_enabled.bool file.",
+                close_result
+            );
+            return close_result;
+        }
+
+        // the file has been created and 1 has been written to it, open for reading
+        open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_RDONLY, &LFS_file_cfg);
+        if (open_result != 0) {
+            LOG_message(
+                LOG_SYSTEM_LFS, 
+                LOG_SEVERITY_WARNING, 
+                LOG_SINK_ALL, 
+                "Error %d opening/creating deploy_antenna_on_boot_enabled.bool file.",
+                open_result
+            );
+            return -5 ;
+        }
+        LOG_message(
+            LOG_SYSTEM_LFS, 
+            LOG_SEVERITY_NORMAL, 
+            LOG_SINK_ALL, 
+            "new file created, 1 written, opend for reading."
+        );
     }
+        
+
+    //TODO: remove after validation
     else if (open_result == 0) {
         LOG_message(
             LOG_SYSTEM_LFS, 
@@ -115,8 +140,8 @@ uint8_t START_antenna_deploy() {
             "deploy_antenna_on_boot_enabled.bool file opened."
         );
     }
+    
     // At this point the depoy_antenna_on_boot_enabled.bool file is open 
-
     uint8_t deploy_antenna_on_boot_enabled;
     int32_t num_bytes_read = lfs_file_read(&LFS_filesystem, &file, &deploy_antenna_on_boot_enabled, sizeof(deploy_antenna_on_boot_enabled));
     if(num_bytes_read < 0) { 
@@ -127,7 +152,9 @@ uint8_t START_antenna_deploy() {
             "Error %d reading deploy_antenna_on_boot_enabled.bool file.",
             num_bytes_read
         );
+        return num_bytes_read;
     }
+    //TODO: remove after validation
     if(num_bytes_read == 0) {
         LOG_message(
             LOG_SYSTEM_LFS, 
@@ -136,6 +163,7 @@ uint8_t START_antenna_deploy() {
             "deploy_antenna_on_boot_enabled.bool file is empty."
         );
     }
+    //TODO: remove after validation
     if(num_bytes_read > 0) {
         LOG_message(
             LOG_SYSTEM_LFS, 
@@ -146,18 +174,59 @@ uint8_t START_antenna_deploy() {
             deploy_antenna_on_boot_enabled
         );
     }
-    //reading the file is done now, unmount fs and close the file
-    lfs_file_close(&LFS_filesystem, &file);
+    //reading the file is done now,  close the file and unmount lfs if needed
+    int close_status = lfs_file_close(&LFS_filesystem, &file);
+    if( close_status != 0) {
+        LOG_message(
+            LOG_SYSTEM_LFS, 
+            LOG_SEVERITY_ERROR, 
+            LOG_SINK_ALL, 
+            "Error %d closing deploy_antenna_on_boot_enabled.bool file.",
+            close_status
+        );
+        return close_status;
+    }
+
     if(LFS_unmount_on_completion) {
-        lfs_unmount(&LFS_filesystem);
+        int32_t unmount_status = lfs_unmount(&LFS_filesystem);
+        if (unmount_status != 0) {
+            LOG_message(
+                LOG_SYSTEM_LFS, 
+                LOG_SEVERITY_ERROR, 
+                LOG_SINK_ALL, 
+                "Error %d unmounting lfs.",
+                unmount_status
+            );
+            return unmount_status;
+        }
     }
 
     if(deploy_antenna_on_boot_enabled == 1) {
-        //TODO: which mcu should be armed on the antenna deploy system? Error handling
-     ANT_CMD_arm_antenna_system(ANT_I2C_BUS_A_MCU_A);
-     ANT_CMD_start_automated_sequential_deployment(ANT_I2C_BUS_A_MCU_A, 7);
-    }
+        //TODO: which mcu should be armed on the antenna deploy system? Error handling. How long to activate?
+        int8_t arm_result = ANT_CMD_arm_antenna_system(ANT_I2C_BUS_A_MCU_A);
+        if (arm_result != 0) {
+            LOG_message(
+                LOG_SYSTEM_ANTENNA_DEPLOY, 
+                LOG_SEVERITY_ERROR, 
+                LOG_SINK_ALL, 
+                "Error %d arming antenna deploy system.",
+                arm_result
+            );
+            return arm_result;
+        }
 
+        int8_t deploy_result = ANT_CMD_start_automated_sequential_deployment(ANT_I2C_BUS_A_MCU_A, 7);
+        if (deploy_result != 0) {
+            LOG_message(
+                LOG_SYSTEM_ANTENNA_DEPLOY, 
+                LOG_SEVERITY_ERROR, 
+                LOG_SINK_ALL, 
+                "Error %d deploying antennas.",
+                deploy_result
+            );
+            return deploy_result;
+        }
+    }
 
     return 0;
 }

--- a/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
+++ b/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
@@ -56,7 +56,7 @@ static int16_t read_bool_from_deploy_antenna_on_boot_enabled_file (uint8_t* read
     }
 
     int16_t read_result = lfs_file_read(&LFS_filesystem, &file, read_value, sizeof(uint8_t));
-    if (read_result != 0) {
+    if (read_result < 0) {
         LOG_message(
             LOG_SYSTEM_LFS, 
             LOG_SEVERITY_NORMAL, 
@@ -154,7 +154,7 @@ static int16_t create_deploy_antenna_on_boot_enabled_file_and_write_one() {
     
 //TODO: Implement this
 static uint8_t eps_is_sufficiently_charged() {
-    return 1;
+    return 0;
 }
 
 

--- a/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
+++ b/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
@@ -55,7 +55,7 @@ static int16_t read_bool_from_deploy_antenna_on_boot_enabled_file (uint8_t* read
         return open_result;
     }
 
-    int32_t read_result = lfs_file_read(&LFS_filesystem, &file, read_value, sizeof(uint8_t));
+    int16_t read_result = lfs_file_read(&LFS_filesystem, &file, read_value, sizeof(uint8_t));
     if (read_result != 0) {
         LOG_message(
             LOG_SYSTEM_LFS, 
@@ -67,7 +67,7 @@ static int16_t read_bool_from_deploy_antenna_on_boot_enabled_file (uint8_t* read
         return read_result;
     }
 
-    int32_t close_result = lfs_file_close(&LFS_filesystem, &file);
+    int16_t close_result = lfs_file_close(&LFS_filesystem, &file);
     if (close_result != 0) {
         LOG_message(
             LOG_SYSTEM_LFS, 
@@ -127,7 +127,7 @@ static int16_t create_deploy_antenna_on_boot_enabled_file_and_write_one() {
 
     uint8_t write_value = 1;
     int32_t write_result = lfs_file_write(&LFS_filesystem, &file, &write_value, sizeof(uint8_t));
-    if (write_result != 0) {
+    if (write_result < 0) {
         LOG_message(
             LOG_SYSTEM_LFS,
             LOG_SEVERITY_ERROR,
@@ -154,7 +154,7 @@ static int16_t create_deploy_antenna_on_boot_enabled_file_and_write_one() {
     
 //TODO: Implement this
 static uint8_t eps_is_sufficiently_charged() {
-    return 0;
+    return 1;
 }
 
 
@@ -205,7 +205,7 @@ int16_t START_deploy_antenna_if_sufficiently_charged() {
 }
 
 /// @brief Reads the file "lifecycle/deploy_antenna_on_boot_enabled.bool". If the file contains 1 or does not exist then it attempts to deploy the antennas.
-/// If the file contains 0 then it does not attempt to deploy the antennas.
+/// If the file contains 0 or eps is not sufficiently then it does not attempt to deploy the antennas.
 /// @return 0 on success, <0 on failure
 int16_t START_read_config_and_deploy_antenna_accordingly() {
 
@@ -242,20 +242,9 @@ int16_t START_read_config_and_deploy_antenna_accordingly() {
             );
             return create_result;
         }
-        read_result = read_bool_from_deploy_antenna_on_boot_enabled_file(&deploy_antenna_on_boot_enabled);
-        if (read_result != 0) {
-            LOG_message(
-                LOG_SYSTEM_LFS, 
-                LOG_SEVERITY_ERROR, 
-                LOG_SINK_ALL, 
-                "Error %d reading from file <lifecycle/deploy_antenna_on_boot_enabled.bool>.",
-                read_result
-            );
-            return read_result;
-        }
+        deploy_antenna_on_boot_enabled = 1;
     }
 
-    // at this point, file contents have been written into deploy_antenna_on_boot_enabled
     if (deploy_antenna_on_boot_enabled == 0) {
         return 0;
     }

--- a/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
+++ b/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
@@ -28,11 +28,32 @@ uint8_t START_antenna_deploy() {
         //TODO: what happens if directory creation fails?
     }
 
+    if(mkdir_result == LFS_ERR_EXIST) {
+        LOG_message(
+            LOG_SYSTEM_LFS, 
+            LOG_SEVERITY_NORMAL, 
+            LOG_SINK_ALL, 
+            "lifecycle directory already exists. Skipping creation."
+        );
+    }
+
+    if(mkdir_result == 0) {
+        LOG_message(
+            LOG_SYSTEM_LFS, 
+            LOG_SEVERITY_NORMAL, 
+            LOG_SINK_ALL, 
+            "lifecycle directory created."
+        );
+    }
+    // At this point the lifecycle directory exists or has been created
+
+    // Create deploy_antenna_on_boot_enabled.bool file if it doesn't exist
+    //
     lfs_file_t file;
     int32_t open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_RDONLY, &LFS_file_cfg);
     if ( open_result == LFS_ERR_NOENT) {
         // Create file if it doesn't exist
-        open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_RDONLY, &LFS_file_cfg);
+        open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_RDONLY | LFS_O_CREAT, &LFS_file_cfg);
         LOG_message(
             LOG_SYSTEM_LFS, 
             LOG_SEVERITY_NORMAL, 
@@ -45,18 +66,56 @@ uint8_t START_antenna_deploy() {
             LOG_SYSTEM_LFS, 
             LOG_SEVERITY_WARNING, 
             LOG_SINK_ALL, 
-            "Error %d opening deploy_antenna_on_boot_enabled.bool file.",
+            "Error %d opening/creating deploy_antenna_on_boot_enabled.bool file.",
             open_result
         );
     }
+    else if (open_result == 0) {
+        LOG_message(
+            LOG_SYSTEM_LFS, 
+            LOG_SEVERITY_NORMAL, 
+            LOG_SINK_ALL, 
+            "deploy_antenna_on_boot_enabled.bool file opened."
+        );
+    }
+    // At this point the depoy_antenna_on_boot_enabled.bool file is open 
 
-    lfs_file_rewind(&LFS_filesystem, &file);
+    uint8_t deploy_antenna_on_boot_enabled[10];
+    size_t num_bytes_read = lfs_file_read(&LFS_filesystem, &file, &deploy_antenna_on_boot_enabled, sizeof(deploy_antenna_on_boot_enabled));
 
-    uint8_t deploy_antenna_on_boot_enabled;
+    if(num_bytes_read < 0) { 
+        LOG_message(
+            LOG_SYSTEM_LFS, 
+            LOG_SEVERITY_WARNING, 
+            LOG_SINK_ALL, 
+            "Error %d reading deploy_antenna_on_boot_enabled.bool file.",
+            num_bytes_read
+        );
+    }
+    if(num_bytes_read == 0) {
+        LOG_message(
+            LOG_SYSTEM_LFS, 
+            LOG_SEVERITY_NORMAL, 
+            LOG_SINK_ALL, 
+            "deploy_antenna_on_boot_enabled.bool file is empty."
+        );
+    }
+    if(num_bytes_read > 0) {
+        LOG_message(
+            LOG_SYSTEM_LFS, 
+            LOG_SEVERITY_NORMAL, 
+            LOG_SINK_ALL, 
+            "read %d bytes from deploy_antenna_on_boot_enabled.bool. Result: %s",
+            num_bytes_read,
+            deploy_antenna_on_boot_enabled
+        );
+    }
 
-    lfs_file_read(&LFS_filesystem, &file, &deploy_antenna_on_boot_enabled, sizeof(deploy_antenna_on_boot_enabled));
+    //uint8_t deploy_antenna_on_boot_enabled;
 
-    lfs_file_close(&LFS_filesystem, &file);
+    //lfs_file_read(&LFS_filesystem, &file, &deploy_antenna_on_boot_enabled, sizeof(deploy_antenna_on_boot_enabled));
+
+    // lfs_file_close(&LFS_filesystem, &file);
 
     if(LFS_unmount_on_completion) {
         lfs_unmount(&LFS_filesystem);

--- a/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
+++ b/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
@@ -143,7 +143,7 @@ uint8_t START_antenna_deploy() {
             LOG_SINK_ALL, 
             "read %d bytes from deploy_antenna_on_boot_enabled.bool. Result: %d",
             num_bytes_read,
-            deploy_antenna_on_boot_enabled[0]
+            deploy_antenna_on_boot_enabled
         );
     }
     //reading the file is done now, unmount fs and close the file
@@ -154,8 +154,8 @@ uint8_t START_antenna_deploy() {
 
     if(deploy_antenna_on_boot_enabled == 1) {
         //TODO: which mcu should be armed on the antenna deploy system? Error handling
-     ANT_CMD_arm_antenna_system(ANT_i2c_bus_mcu1);
-     ANT_CMD_start_automated_sequential_deployment(ANT_i2c_bus_mcu1, 7);
+     ANT_CMD_arm_antenna_system(ANT_I2C_BUS_A_MCU_A);
+     ANT_CMD_start_automated_sequential_deployment(ANT_I2C_BUS_A_MCU_A, 7);
     }
 
 

--- a/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
+++ b/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
@@ -1,0 +1,65 @@
+#include "startup_sequence/antenna_deploy_startup.h"
+#include "littlefs/littlefs_helper.h"
+#include "littlefs/lfs.h"
+#include "log/log.h"
+uint8_t START_antenna_deploy() {
+    LOG_message(
+        LOG_SYSTEM_LFS, 
+        LOG_SEVERITY_NORMAL, 
+        LOG_SINK_ALL, 
+        "Starting Antenna Deploy"
+    );
+    uint8_t LFS_unmount_on_completion = 0;
+    if (!LFS_is_lfs_mounted) {
+        lfs_mount(&LFS_filesystem, &LFS_cfg);
+        LFS_unmount_on_completion = 1;
+    }
+
+    // Create lifecycle directory if it doesn't exist
+    const int32_t mkdir_result = lfs_mkdir(&LFS_filesystem, "lifecycle");
+    if(mkdir_result != LFS_ERR_EXIST && mkdir_result != 0) {
+        LOG_message(
+            LOG_SYSTEM_LFS, 
+            LOG_SEVERITY_NORMAL, 
+            LOG_SINK_ALL, 
+            "Error %d creating lifecycle directory.",
+            mkdir_result
+        );
+        //TODO: what happens if directory creation fails?
+    }
+
+    lfs_file_t file;
+    int32_t open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_RDONLY, &LFS_file_cfg);
+    if ( open_result == LFS_ERR_NOENT) {
+        // Create file if it doesn't exist
+        open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_RDONLY, &LFS_file_cfg);
+        LOG_message(
+            LOG_SYSTEM_LFS, 
+            LOG_SEVERITY_NORMAL, 
+            LOG_SINK_ALL, 
+            "file did not exist, created deploy_antenna_on_boot_enabled.bool file."
+        );
+    } 
+    else if(open_result != 0) {
+        LOG_message(
+            LOG_SYSTEM_LFS, 
+            LOG_SEVERITY_WARNING, 
+            LOG_SINK_ALL, 
+            "Error %d opening deploy_antenna_on_boot_enabled.bool file.",
+            open_result
+        );
+    }
+
+    lfs_file_rewind(&LFS_filesystem, &file);
+
+    uint8_t deploy_antenna_on_boot_enabled;
+
+    lfs_file_read(&LFS_filesystem, &file, &deploy_antenna_on_boot_enabled, sizeof(deploy_antenna_on_boot_enabled));
+
+    lfs_file_close(&LFS_filesystem, &file);
+
+    if(LFS_unmount_on_completion) {
+        lfs_unmount(&LFS_filesystem);
+    }
+    return 0;
+}

--- a/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
+++ b/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
@@ -10,6 +10,7 @@
 /// @return 0 on success, <0 on failure
 
 //TODO: unmount filesystem if error occurs
+//TODO: create initialization/destruction functions to handle file mounting/unmounting
 
 /// @brief reads the value from the file "lifecycle/deploy_antenna_on_boot_enabled.bool"
 /// @param read_value where the read value will be stored upon success 
@@ -207,6 +208,7 @@ int16_t START_deploy_antenna_if_sufficiently_charged() {
 /// @brief Reads the file "lifecycle/deploy_antenna_on_boot_enabled.bool". If the file contains 1 or does not exist then it attempts to deploy the antennas.
 /// If the file contains 0 or eps is not sufficiently then it does not attempt to deploy the antennas.
 /// @return 0 on success, <0 on failure
+/// @note this is the function which should be primarily used to deploy
 int16_t START_read_config_and_deploy_antenna_accordingly() {
 
     //TODO: remove after validation
@@ -245,6 +247,7 @@ int16_t START_read_config_and_deploy_antenna_accordingly() {
         deploy_antenna_on_boot_enabled = 1;
     }
 
+    // config file states that antenna should not be deployed, return 0
     if (deploy_antenna_on_boot_enabled == 0) {
         return 0;
     }

--- a/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
+++ b/firmware/Core/Src/startup_sequence/antenna_deploy_startup.c
@@ -5,96 +5,30 @@
 #include "antenna_deploy_drivers/ant_commands.h"
 #include "antenna_deploy_drivers/ant_internal_drivers.h"
 #include "eps_commands.h"
-/// @brief Attempts to read to the file "lifecycle/deploy_antenna_on_boot_enabled.bool".
-/// If 1 is stored in the file then it attempts to deploy the antenna. If the file did not
-/// exist: then it creates the file, stores a 1 in it, and attempts to deploy.
-/// @return 0 on success, <0 on failure
-
-//TODO: unmount filesystem if error occurs
-//TODO: create initialization/destruction functions to handle file mounting/unmounting
 
 /// @brief reads the value from the file "lifecycle/deploy_antenna_on_boot_enabled.bool"
 /// @param read_value where the read value will be stored upon success 
 /// @return 0 on success, LFS_ERR_NOENT if the file does not exist, <0 on failure 
 static int16_t read_bool_from_deploy_antenna_on_boot_enabled_file (uint8_t* read_value) {
-    uint8_t unmount_on_completion = 0;
-    if ( !LFS_is_lfs_mounted ) {
-        unmount_on_completion = 1;
-        int32_t mount_result = lfs_mount(&LFS_filesystem, &LFS_cfg); 
-        if (mount_result != 0) {
-            LOG_message(
-                LOG_SYSTEM_LFS, 
-                LOG_SEVERITY_ERROR, 
-                LOG_SINK_ALL, 
-                "Error %d mounting LittleFS.",
-                mount_result
-            );
-            return mount_result;
-        }
-    }
-    // lfs is mounted at this point 
-    
     lfs_file_t file;
     int16_t open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_RDONLY, &LFS_file_cfg);
     if (open_result == LFS_ERR_NOENT) {
-        LOG_message(
-            LOG_SYSTEM_LFS, 
-            LOG_SEVERITY_NORMAL, 
-            LOG_SINK_ALL, 
-            "File <lifecycle/deploy_antenna_on_boot_enabled.bool> does not exist."
-        );
         return LFS_ERR_NOENT;
     }
-    
     if (open_result != 0) {
-        LOG_message(
-            LOG_SYSTEM_LFS, 
-            LOG_SEVERITY_NORMAL, 
-            LOG_SINK_ALL, 
-            "Error %d opening file <lifecycle/deploy_antenna_on_boot_enabled.bool>.",
-            open_result
-        );
         return open_result;
     }
-
     // file exists and is opened for reading  
 
     int16_t read_result = lfs_file_read(&LFS_filesystem, &file, read_value, sizeof(uint8_t));
     if (read_result < 0) {
-        LOG_message(
-            LOG_SYSTEM_LFS, 
-            LOG_SEVERITY_NORMAL, 
-            LOG_SINK_ALL, 
-            "Error %d reading from file <lifecycle/deploy_antenna_on_boot_enabled.bool>.",
-            read_result
-        );
         return read_result;
     }
+    // value has been read and is stored in read_value
 
     int16_t close_result = lfs_file_close(&LFS_filesystem, &file);
     if (close_result != 0) {
-        LOG_message(
-            LOG_SYSTEM_LFS, 
-            LOG_SEVERITY_NORMAL, 
-            LOG_SINK_ALL, 
-            "Error %d closing file <lifecycle/deploy_antenna_on_boot_enabled.bool>.",
-            close_result
-        );
         return close_result;
-    }
-
-    if (unmount_on_completion) {
-        int16_t unmount_result = lfs_unmount(&LFS_filesystem);
-        if (unmount_result != 0) {  
-            LOG_message(
-                LOG_SYSTEM_LFS, 
-                LOG_SEVERITY_ERROR, 
-                LOG_SINK_ALL, 
-                "Error %d unmounting LittleFS.",
-                unmount_result
-            );
-            return unmount_result;
-        }
     }
     return 0;
 }
@@ -106,74 +40,65 @@ static int16_t read_bool_from_deploy_antenna_on_boot_enabled_file (uint8_t* read
 static int16_t create_deploy_antenna_on_boot_enabled_file_and_write_one() {
     int16_t mkdir_result = lfs_mkdir(&LFS_filesystem, "lifecycle");
     if(mkdir_result != LFS_ERR_EXIST && mkdir_result != 0) {
-        LOG_message(
-            LOG_SYSTEM_LFS,
-            LOG_SEVERITY_ERROR,
-            LOG_SINK_ALL,
-            "Error %d creating lifecycle directory.",
-            mkdir_result
-        );
         return mkdir_result;
     }
+    // either the directory already exists or it was successfully created
 
-    //at this point the directory exists
     lfs_file_t file;
     int16_t open_result = lfs_file_opencfg(&LFS_filesystem, &file, "lifecycle/deploy_antenna_on_boot_enabled.bool", LFS_O_WRONLY | LFS_O_CREAT, &LFS_file_cfg);
     if (open_result != 0) {
-        LOG_message(
-            LOG_SYSTEM_LFS,
-            LOG_SEVERITY_ERROR,
-            LOG_SINK_ALL,
-            "Error %d opening file lifecycle/deploy_antenna_on_boot_enabled.bool.",
-            open_result
-        );
         return open_result;
     }
+    // file exists and is opened for writing
 
     uint8_t write_value = 1;
-    int32_t write_result = lfs_file_write(&LFS_filesystem, &file, &write_value, sizeof(uint8_t));
+    int32_t write_result = lfs_file_write(&LFS_filesystem, &file, &write_value, sizeof(write_value));
     if (write_result < 0) {
-        LOG_message(
-            LOG_SYSTEM_LFS,
-            LOG_SEVERITY_ERROR,
-            LOG_SINK_ALL,
-            "Error %d writing to file lifecycle/deploy_antenna_on_boot_enabled.bool.",
-            write_result
-        );
         return write_result;
     }
+    // 1 has been written
 
     int32_t close_result = lfs_file_close(&LFS_filesystem, &file);
     if (close_result != 0) {
-        LOG_message(
-            LOG_SYSTEM_LFS,
-            LOG_SEVERITY_ERROR,
-            LOG_SINK_ALL,
-            "Error %d closing file lifecycle/deploy_antenna_on_boot_enabled.bool.",
-            close_result
-        );
         return close_result;
     }
     return 0;    
 }    
     
-//TODO: Implement this
+/// @brief Roughly computes a percentage of battery charge. If the battery is >50% charged, returns 1, else returns 0.
+/// @return 1 if the battery is >50% charged, 0 otherwise.
 static uint8_t eps_is_sufficiently_charged() {
-    // Not sure exactly which housekeeping data to use, here we are using the pbu engineering data
+    //TODO: Not sure exactly which housekeeping data to use, assuming PBU?
     EPS_struct_pbu_housekeeping_data_eng_t pbu_data;
     if (EPS_CMD_get_pbu_housekeeping_data_eng(&pbu_data) != 0) {
         return 0;
     };
-    //TODO: implement this
+    /* 
+    TODO: I have zero clue if this is correctly computing the battery pack voltage! please check Parker :)
+    my logic is as follows: each of the four battery cells has a max voltage of 4V, so the total max 
+    voltage of the battery pack is 16V. Sum up the voltages of each cell and divide by total max voltage to get a percentage.
+    */
+    int32_t total_mV = 0;
+    for (int i = 0; i < 4; i++) {
+        total_mV += pbu_data.battery_pack_info_each_pack[0].cell_voltage_each_cell_mV[i];
+    }
+
+    int32_t total_max_mV = 16000;
+    if (total_mV > total_max_mV/2) {
+        return 1;
+    }
+    
     return 0;
 }
 
 
 /// @brief Attempts to arm and deploy the antennas 
 /// @return 0 if mcu successfully transmitted the arm and deploy commands, <0 otherwise
-/// @note WARNING: Care must be taken with using this function as it does not check if the eps is sufficiently charged!
+/// @note WARNING: Care must be taken with using this function as it does not check if the eps is sufficiently charged! 
+///Prefer using another function for deployment!
 int16_t START_deploy_antenna() {
     //TODO: which mcu should be armed on the antenna deploy system? Error handling. How long to activate?
+    // TODO: perhaps a parameter should be pased to this function to specify which mcu to arm
     int8_t arm_result = ANT_CMD_arm_antenna_system(ANT_I2C_BUS_A_MCU_A);
     if (arm_result != 0) {
         LOG_message(
@@ -216,7 +141,7 @@ int16_t START_deploy_antenna_if_sufficiently_charged() {
 }
 
 /// @brief Reads the file "lifecycle/deploy_antenna_on_boot_enabled.bool". If the file contains 1 or does not exist then it attempts to deploy the antennas.
-/// If the file contains 0 or eps is not sufficiently then it does not attempt to deploy the antennas.
+/// If the file contains 0 or eps is not sufficiently charged then it does not attempt to deploy the antennas.
 /// @return 0 on success, <0 on failure
 /// @note this is the function which should be primarily used to deploy
 int16_t START_read_config_and_deploy_antenna_accordingly() {
@@ -226,6 +151,23 @@ int16_t START_read_config_and_deploy_antenna_accordingly() {
         LOG_SINK_ALL, 
         "Starting Antenna Deploy"
     );
+
+    uint8_t unmount_on_completion = 0;
+    if (!LFS_is_lfs_mounted) {
+        unmount_on_completion = 1;
+        
+        int16_t mount_result = LFS_mount();
+        if (mount_result != 0) {
+            LOG_message(
+                LOG_SYSTEM_LFS, 
+                LOG_SEVERITY_ERROR, 
+                LOG_SINK_ALL, 
+                "Error %d mounting LittleFS.",
+                mount_result
+            );
+            return mount_result;
+        }
+    }
 
     uint8_t deploy_antenna_on_boot_enabled;
     int16_t read_result = read_bool_from_deploy_antenna_on_boot_enabled_file(&deploy_antenna_on_boot_enabled);
@@ -237,6 +179,8 @@ int16_t START_read_config_and_deploy_antenna_accordingly() {
             "Error %d reading from file <lifecycle/deploy_antenna_on_boot_enabled.bool>.",
             read_result
         );
+        //unmount if error occurs
+        if (unmount_on_completion) lfs_unmount(&LFS_filesystem);
         return read_result;
     }
 
@@ -250,12 +194,29 @@ int16_t START_read_config_and_deploy_antenna_accordingly() {
                 "Error %d creating file <lifecycle/deploy_antenna_on_boot_enabled.bool>.",
                 create_result
             );
+            if (unmount_on_completion) lfs_unmount(&LFS_filesystem);
             return create_result;
         }
         deploy_antenna_on_boot_enabled = 1;
     }
 
-    // if true, config file states that antenna should not be deployed, return 0
+    //unmount if necessary
+    if (unmount_on_completion) {
+        int16_t unmount_result = lfs_unmount(&LFS_filesystem);
+        if (unmount_result != 0) {
+            LOG_message(
+                LOG_SYSTEM_LFS, 
+                LOG_SEVERITY_ERROR, 
+                LOG_SINK_ALL, 
+                "Error %d unmounting LittleFS.",
+                unmount_result
+            );
+            return unmount_result;
+        }
+    }
+
+
+    // if file states not to deploy, return 0
     if (deploy_antenna_on_boot_enabled == 0) {
         return 0;
     }


### PR DESCRIPTION
Test plan is in the works. I will give a brief description of the antenna deployment procedure here:

1. check if deploy_antenna_on_boot_enabled.bool exists:
    * if yes check the value stored:
        * if 1 deploy antenna if eps is charged.
        * if 0 return
    * if no create file and write 1 into it, deploy antenna if eps is charged
2. If this fails 3 times (ie. 0 is not returned):
    * deploy antenna if eps is charged
3. if this fails another 2 times (5 failures in total):
    *deploy antenna

The thread sleeps for a given amount of time before retrying. The idea here is that if the file system fails or the eps is not correctly communicating its voltage, the antennas can still be deployed, since the program becomes less strict with its checks. Some tweaking is probably needed with the timeouts to ensure we are not ignoring our checks prematurely. 

Hopefully one of these weeks I'll get a chance to test it out with all of the actual hardware!

resolves #148 

(Work in progress) Test Plan: https://docs.google.com/document/d/1oRtDT4qSS5IVf1GBiwmX7NjGOQkH9OvaxN826IcmcE0/edit?tab=t.0
   
 