### PR TITLE
Send arbitrary bytes to UART peripheral, and read its response

### DIFF
--- a/docs/Non-Critical_Notes/UART_Ports.md
+++ b/docs/Non-Critical_Notes/UART_Ports.md
@@ -1,0 +1,38 @@
+# UART Ports
+
+Each UART port and associated subsystem behaves at least a little bit differently. This document captures these behaviours.
+
+## UART1 - MPI
+
+* High baud rate - 230400 baud
+* DMA access
+
+## UART2 - Spare, Disabled
+
+Disabled. Was going to be used for LoRa.
+
+## UART3 - GPS
+
+* Baud rate: 115200 baud
+* Interrupt-based.
+* Interrupt disabled by default. Very cautious about enabling it, as the GPS is known to spam null bytes if misconfigured.
+
+## UART4 - Camera
+
+* Variable baud rate. 115200 default, but decreased to 9600 by command right away to ease writing to LittleFS and avoid dropped data.
+* DMA access
+* Does not support receiving arbitrary data after transmitting arbitrary data (via the `CTS1+TCMDEXEC_uart_send_hex_get_response_hex` command).
+    * Justification: Unnecessary complexity. Not a mission requirement. The camera doesn't really have a "command-mode" like all other UART peripherals do.
+
+## UART5 - EPS
+
+* Baud rate: 115200 baud
+* Interrupt-based.
+* Interrupt enabled by default, and is trusted.
+* EPS only responds to commands, and does not send messages otherwise.
+
+## LPUART1 - Debug/Umbilical
+
+* Baud rate: 115200 baud
+* Interrupt-based.
+* Interrupt enabled by default, and is trusted. Always on.

--- a/firmware/Core/Inc/log/log.h
+++ b/firmware/Core/Inc/log/log.h
@@ -3,6 +3,9 @@
 
 #include <stdint.h>
 
+// Messages up to 256 characters
+#define LOG_FORMATTED_MESSAGE_MAX_LENGTH 256
+
 typedef enum {
     LOG_SEVERITY_DEBUG = 1 << 0,
     LOG_SEVERITY_NORMAL = 1 << 1,

--- a/firmware/Core/Inc/mpi/mpi_command_handling.h
+++ b/firmware/Core/Inc/mpi/mpi_command_handling.h
@@ -8,10 +8,10 @@
 
 extern MPI_rx_mode_t MPI_current_uart_rx_mode;  // Current mode under which the MPI is being operated
 
-uint8_t MPI_send_telecommand_get_response(
+uint8_t MPI_send_command_get_response(
     const uint8_t *bytes_to_send, const size_t bytes_to_send_len, uint8_t *MPI_rx_buffer,
     const size_t MPI_rx_buffer_max_size, uint16_t *MPI_rx_buffer_len
 );
-uint8_t MPI_validate_telecommand_response(const uint8_t *MPI_tx_buffer, uint8_t *MPI_rx_buffer, const uint16_t MPI_tx_buffer_size);
+uint8_t MPI_validate_command_response(const uint8_t *MPI_tx_buffer, uint8_t *MPI_rx_buffer, const uint16_t MPI_tx_buffer_size);
 
 #endif /* INC_MPI_COMMAND_HANDLING_H_ */

--- a/firmware/Core/Inc/telecommands/uart_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/uart_telecommand_defs.h
@@ -1,0 +1,9 @@
+#ifndef __INCLUDE_GUARD__UART_TELECOMMAND_DEFS_H__
+#define __INCLUDE_GUARD__UART_TELECOMMAND_DEFS_H__
+
+#include "telecommands/telecommand_definitions.h"
+
+uint8_t TCMDEXEC_uart_send_bytes_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+#endif /* __INCLUDE_GUARD__UART_TELECOMMAND_DEFS_H__*/

--- a/firmware/Core/Inc/telecommands/uart_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/uart_telecommand_defs.h
@@ -1,9 +1,11 @@
-#ifndef __INCLUDE_GUARD__UART_TELECOMMAND_DEFS_H__
-#define __INCLUDE_GUARD__UART_TELECOMMAND_DEFS_H__
+#ifndef INCLUDE_GUARD__UART_TELECOMMAND_DEFS_H__
+#define INCLUDE_GUARD__UART_TELECOMMAND_DEFS_H__
 
 #include "telecommands/telecommand_definitions.h"
 
-uint8_t TCMDEXEC_uart_send_bytes_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len);
+uint8_t TCMDEXEC_uart_send_bytes_hex(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len
+);
 
-#endif /* __INCLUDE_GUARD__UART_TELECOMMAND_DEFS_H__*/
+#endif /* INCLUDE_GUARD__UART_TELECOMMAND_DEFS_H__*/

--- a/firmware/Core/Inc/telecommands/uart_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/uart_telecommand_defs.h
@@ -3,7 +3,7 @@
 
 #include "telecommands/telecommand_definitions.h"
 
-uint8_t TCMDEXEC_uart_send_bytes_hex(
+uint8_t TCMDEXEC_uart_send_hex_get_response_hex(
     const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
     char *response_output_buf, uint16_t response_output_buf_len
 );

--- a/firmware/Core/Inc/uart_handler/uart_handler.h
+++ b/firmware/Core/Inc/uart_handler/uart_handler.h
@@ -29,6 +29,7 @@ extern volatile uint8_t UART_lora_buffer[];                     // Buffer for LO
 extern volatile uint16_t UART_lora_buffer_write_idx;            // Write index for LORA response buffer
 extern volatile uint32_t UART_lora_last_write_time_ms;          // Last write time in milliseconds for LORA response
 extern volatile uint8_t UART_lora_is_expecting_data;            // Set to 1 when a data is sent, and we're awaiting a response
+extern volatile uint8_t UART_lora_buffer_last_rx_byte;          // Last received byte for LORA response
 
 extern const uint16_t UART_gps_buffer_len;                      // Length of the GPS response buffer
 extern volatile uint8_t UART_gps_buffer[];                      // Buffer for GPS response

--- a/firmware/Core/Inc/uart_handler/uart_handler.h
+++ b/firmware/Core/Inc/uart_handler/uart_handler.h
@@ -2,24 +2,51 @@
 #ifndef INCLUDE_GUARD__UART_HANDLER_H__
 #define INCLUDE_GUARD__UART_HANDLER_H__
 
+#include "stm32l4xx_hal.h"
 #include <stdint.h>
 
-extern const uint16_t UART_telecommand_buffer_len; // Length of the UART telecommand buffer
-extern volatile uint8_t UART_telecommand_buffer[]; // Buffer for UART telecommands
-extern volatile uint16_t UART_telecommand_buffer_write_idx; // Write index for UART telecommand buffer
-extern volatile uint32_t UART_telecommand_last_write_time_ms; // Last write time in milliseconds for UART telecommand
+// Name the UART interfaces
+extern UART_HandleTypeDef *UART_telecommand_port_handle;  
+extern UART_HandleTypeDef *UART_mpi_port_handle;                
+extern UART_HandleTypeDef *UART_lora_port_handle;              
+extern UART_HandleTypeDef *UART_gps_port_handle;
+extern UART_HandleTypeDef *UART_camera_port_handle;
+extern UART_HandleTypeDef *UART_eps_port_handle;
 
-extern const uint16_t UART_eps_buffer_len;
-extern volatile uint8_t UART_eps_buffer[];
-extern volatile uint16_t UART_eps_buffer_write_idx;
-extern volatile uint32_t UART_eps_last_write_time_ms;
-extern volatile uint8_t UART_eps_is_expecting_data; // Set to 1 when a command is sent, and we're awaiting a response
+extern const uint16_t UART_telecommand_buffer_len;              // Length of the UART telecommand buffer
+extern volatile uint8_t UART_telecommand_buffer[];              // Buffer for UART telecommands
+extern volatile uint16_t UART_telecommand_buffer_write_idx;     // Write index for UART telecommand buffer
+extern volatile uint32_t UART_telecommand_last_write_time_ms;   // Last write time in milliseconds for UART telecommand
 
-extern const uint16_t UART_mpi_rx_buffer_len; // Length of the UART MPI response buffer (for telecommand responses only & NOT SCIENCE DATA)
-extern volatile uint8_t UART_mpi_rx_buffer[]; // Buffer for UART MPI response
-extern volatile uint8_t UART_mpi_rx_last_byte; // Last received byte from the MPI response
-extern volatile uint32_t UART_mpi_rx_last_byte_write_time_ms; // Last write time in milliseconds for MPI response
-extern volatile uint16_t UART_mpi_rx_buffer_write_idx; // Write index for MPI response buffer
+extern const uint16_t UART_mpi_buffer_len;                      // Length of the MPI response buffer (for telecommand responses only & NOT SCIENCE DATA)
+extern volatile uint8_t UART_mpi_buffer[];                      // Buffer for MPI response
+extern volatile uint16_t UART_mpi_buffer_write_idx;             // Write index for MPI response buffer
+extern volatile uint32_t UART_mpi_last_write_time_ms;           // Last write time in milliseconds for MPI response
+extern volatile uint8_t UART_mpi_last_rx_byte;                  // Last received byte from the MPI response
+
+extern const uint16_t UART_lora_buffer_len;                     // Length of the LORA response buffer
+extern volatile uint8_t UART_lora_buffer[];                     // Buffer for LORA response
+extern volatile uint16_t UART_lora_buffer_write_idx;            // Write index for LORA response buffer
+extern volatile uint32_t UART_lora_last_write_time_ms;          // Last write time in milliseconds for LORA response
+extern volatile uint8_t UART_lora_is_expecting_data;            // Set to 1 when a data is sent, and we're awaiting a response
+
+extern const uint16_t UART_gps_buffer_len;                      // Length of the GPS response buffer
+extern volatile uint8_t UART_gps_buffer[];                      // Buffer for GPS response
+extern volatile uint16_t UART_gps_buffer_write_idx;             // Write index for GPS response buffer
+extern volatile uint32_t UART_gps_last_write_time_ms;           // Last write time in milliseconds for GPS response
+
+extern const uint16_t UART_camera_buffer_len;                   // Length of the CAMERA response buffer
+extern volatile uint8_t UART_camera_buffer[];                   // Buffer for CAMERA response
+extern volatile uint16_t UART_camera_buffer_write_idx;          // Write index for CAMERA response buffer
+extern volatile uint32_t UART_camera_last_write_time_ms;        // Last write time in milliseconds for CAMERA response
+extern volatile uint8_t UART_camera_is_expecting_data;          // Set to 1 when a data is sent, and we're awaiting a response
+extern volatile uint8_t UART_camera_buffer_last_rx_byte;        // Last received byte for CAMERA response
+
+extern const uint16_t UART_eps_buffer_len;                      // Length of the EPS response buffer
+extern volatile uint8_t UART_eps_buffer[];                      // Buffer for EPS response
+extern volatile uint16_t UART_eps_buffer_write_idx;             // Write index for EPS response buffer
+extern volatile uint32_t UART_eps_last_write_time_ms;           // Last write time in milliseconds for EPS response
+extern volatile uint8_t UART_eps_is_expecting_data;             // Set to 1 when a command is sent, and we're awaiting a response
 
 extern const uint16_t UART_gps_buffer_len; 
 extern volatile uint8_t UART_gps_buffer[];          

--- a/firmware/Core/Inc/uart_handler/uart_handler.h
+++ b/firmware/Core/Inc/uart_handler/uart_handler.h
@@ -8,7 +8,6 @@
 // Name the UART interfaces
 extern UART_HandleTypeDef *UART_telecommand_port_handle;  
 extern UART_HandleTypeDef *UART_mpi_port_handle;                
-extern UART_HandleTypeDef *UART_lora_port_handle;              
 extern UART_HandleTypeDef *UART_gps_port_handle;
 extern UART_HandleTypeDef *UART_camera_port_handle;
 extern UART_HandleTypeDef *UART_eps_port_handle;

--- a/firmware/Core/Src/log/log.c
+++ b/firmware/Core/Src/log/log.c
@@ -13,7 +13,6 @@
 // Inspired by uLog: https://github.com/rdpoor/ulog
 
 // Internal interfaces and variables
-
 #define LOG_TIMESTAMP_MAX_LENGTH 30
 #define LOG_SINK_NAME_MAX_LENGTH 20
 #define LOG_SYSTEM_NAME_MAX_LENGTH 20

--- a/firmware/Core/Src/log/log.c
+++ b/firmware/Core/Src/log/log.c
@@ -16,8 +16,7 @@
 #define LOG_TIMESTAMP_MAX_LENGTH 30
 #define LOG_SINK_NAME_MAX_LENGTH 20
 #define LOG_SYSTEM_NAME_MAX_LENGTH 20
-// Messages up to 512 characters
-#define LOG_FORMATTED_MESSAGE_MAX_LENGTH 512
+
 // Includes prefix, with cushion for delimiters, newline, and null terminator
 #define LOG_FULL_MESSAGE_MAX_LENGTH ( LOG_FORMATTED_MESSAGE_MAX_LENGTH + LOG_TIMESTAMP_MAX_LENGTH + LOG_SINK_NAME_MAX_LENGTH + LOG_SYSTEM_NAME_MAX_LENGTH + 1 )
 

--- a/firmware/Core/Src/mpi/mpi_command_handling.c
+++ b/firmware/Core/Src/mpi/mpi_command_handling.c
@@ -2,6 +2,7 @@
 #include "mpi/mpi_types.h"
 #include "mpi/mpi_transceiver.h"
 #include "uart_handler/uart_handler.h"
+
 #include "main.h"
 #include "stm32l4xx_hal.h"
 
@@ -21,21 +22,22 @@ MPI_rx_mode_t MPI_current_uart_rx_mode = MPI_RX_MODE_NOT_LISTENING_TO_MPI;
 /// @param MPI_rx_buffer Buffer to store incoming response from the MPI
 /// @param MPI_rx_buffer_max_size The maximum size of the MPI response buffer
 /// @param MPI_rx_buffer_len Pointer to variable that will contain the length of the populated MPI response buffer 
-/// @return 0: Success, 1: No bytes to send, 2: Failed UART transmission, 3: Failed UART reception, 
-///			4: Timeout waiting for 1st byte from MPI, 5: MPI failed to execute CMD, 6: Invalid response from the MPI
+/// @return 0: Success, 2: Failed UART transmission, 3: Failed UART reception, 
+///         4: Timeout waiting for 1st byte from MPI, 8: Not enough space in the MPI response buffer
 /// @note If the MPI is in "science data" mode, it will be disabled after the command is executed.
 uint8_t MPI_send_telecommand_get_response(const uint8_t *bytes_to_send, const size_t bytes_to_send_len, uint8_t *MPI_rx_buffer, 
                                           const size_t MPI_rx_buffer_max_size, uint16_t *MPI_rx_buffer_len) {
-    // Set the MPI transceiver to MOSI mode
-    MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_MOSI);
     
-    // Store the original MPI mode, then set MPI to command mode.
-    MPI_current_uart_rx_mode = MPI_RX_MODE_COMMAND_MODE;
+    // Assert: MPI_rx_buffer_max_size is >= the length of the bytes_to_send_len + 1 to receive the command echo
+    if (MPI_rx_buffer_max_size < (bytes_to_send_len + 1)) return 8; // Error code: Not enough space in the MPI response buffer
+    
+    MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_MOSI); // Set the MPI transceiver to MOSI mode
+    MPI_current_uart_rx_mode = MPI_RX_MODE_COMMAND_MODE; // Set MPI to command mode.
 
     // Transmit the MPI command
-    HAL_StatusTypeDef transmit_status = HAL_UART_Transmit(&huart1, bytes_to_send, bytes_to_send_len, MPI_TX_TIMEOUT_DURATION_MS);
+    const HAL_StatusTypeDef transmit_status = HAL_UART_Transmit(UART_mpi_port_handle, bytes_to_send, bytes_to_send_len, MPI_TX_TIMEOUT_DURATION_MS);
 
-    // Check UART transmission
+    // Check UART transmission status
     if (transmit_status != HAL_OK) {
         MPI_current_uart_rx_mode = MPI_RX_MODE_NOT_LISTENING_TO_MPI;
         return 2; // Error code: Failed UART transmission
@@ -44,8 +46,18 @@ uint8_t MPI_send_telecommand_get_response(const uint8_t *bytes_to_send, const si
     // Set the MPI transceiver to MISO mode
     MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_MISO);
 
-    // Receive MPI response byte by byte (Note: This is done to account for potential errors from the mpi where it doesnt send back an expected response)
-    HAL_StatusTypeDef receive_status = HAL_UART_Receive_DMA(&huart1, (uint8_t*) &UART_mpi_rx_last_byte, 1);
+    // Clear the MPI response buffer (Note: Can't use memset because UART_mpi_buffer is Volatile)
+    for (uint16_t i = 0; i < UART_mpi_buffer_len; i++) {
+		UART_mpi_buffer[i] = 0;
+	}
+
+    // Reset UART interrupt buffer write index & record start time for mpi response reception
+    UART_mpi_buffer_write_idx = 0;                                      
+    const uint32_t UART_mpi_rx_start_time_ms = HAL_GetTick();
+
+    // Receive MPI response byte by byte 
+    // @note: This is done to account for potential errors from the mpi where it doesnt send back an expected response
+    const HAL_StatusTypeDef receive_status = HAL_UART_Receive_DMA(UART_mpi_port_handle, (uint8_t*) &UART_mpi_last_rx_byte, 1);
     
     // Check for UART reception errors
     if (receive_status != HAL_OK) {
@@ -55,73 +67,66 @@ uint8_t MPI_send_telecommand_get_response(const uint8_t *bytes_to_send, const si
         return 3; // Error code: Failed UART reception
     }
 
-    // Record start time for mpi response reception & reset UART buffer write index
-    UART_mpi_rx_buffer_write_idx = 0;
-    const uint32_t UART_mpi_rx_start_time_ms = HAL_GetTick();
-
-    // Receive until MPI response timesout and verify it
+    // Receive until MPI response timed out
     while (1) {
-        // Check for MPI response at least until a timout event
-        if ((HAL_GetTick() - UART_mpi_rx_start_time_ms) < MPI_RX_TIMEOUT_DURATION_MS) {
-            continue;
+
+        // MPI response has been received upto uart rx buffer capacity
+        if (UART_mpi_buffer_write_idx >= MPI_rx_buffer_max_size) {
+            break;
         }
 
-        // Passing the length of the response buffer back
-        *MPI_rx_buffer_len = UART_mpi_rx_buffer_write_idx;
-
-        // MPI hasn't sent any data and has timed out
-        if ((*MPI_rx_buffer_len == 0)) {
-            // Stop reception from the MPI & Reset mpi UART mode state
-            MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_INACTIVE);
-            HAL_UART_DMAStop(&huart1);
-            MPI_current_uart_rx_mode = MPI_RX_MODE_NOT_LISTENING_TO_MPI;
-            return 4; // Error code: Timeout waiting for 1st byte
+        // Timeout before receiving the first byte from the MPI
+        if (UART_mpi_buffer_write_idx == 0) {
+            if((HAL_GetTick() - UART_mpi_rx_start_time_ms) > MPI_RX_TIMEOUT_DURATION_MS) {
+                // Stop reception from the MPI & Reset mpi UART & transceiver mode states
+                MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_INACTIVE);
+                HAL_UART_DMAStop(UART_mpi_port_handle);
+                MPI_current_uart_rx_mode = MPI_RX_MODE_NOT_LISTENING_TO_MPI;
+                return 4; // Error code: Timeout waiting for 1st byte
+            }            
         }
 
-        // MPI has sent some data and has timed out
-        else if (
-            (*MPI_rx_buffer_len > 0)
-            && ((HAL_GetTick() - UART_mpi_rx_last_byte_write_time_ms) > MPI_RX_TIMEOUT_DURATION_MS)
-        ) {
-            // Stop reception from the MPI & Reset MPI UART mode state
-            MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_INACTIVE);
-            HAL_UART_DMAStop(&huart1);
-            MPI_current_uart_rx_mode = MPI_RX_MODE_NOT_LISTENING_TO_MPI;
-
-            // Copy the buffer to the last received byte index & clear the UART buffer
-            for (uint16_t i = 0; i < *MPI_rx_buffer_len; i++) {
-                MPI_rx_buffer[i] = UART_mpi_rx_buffer[i];
+        // Timeout in between (or end of) receiving bytes from the MPI
+        else {
+            const uint32_t current_time = HAL_GetTick(); // Get current time
+             if (
+                (current_time > UART_mpi_last_write_time_ms) // Important seemingly-obvious safety check.
+                && ((current_time - UART_mpi_last_write_time_ms) > MPI_RX_TIMEOUT_DURATION_MS)
+            ) {
+                *MPI_rx_buffer_len = UART_mpi_buffer_write_idx; // Set the length of the MPI response buffer
+                break;
             }
-            
-            // Clear the buffer (memset to 0, but volatile-compatible)
-            for (uint16_t i = 0; i < UART_mpi_rx_buffer_len; i++) {
-                UART_mpi_rx_buffer[i] = 0;
-            }
-
-            // Reset UART buffer write index
-            UART_mpi_rx_buffer_write_idx = 0;
-
-            // Validate MPI response
-            const uint8_t MPI_response_result = MPI_validate_telecommand_response(bytes_to_send, MPI_rx_buffer, bytes_to_send_len);
-
-            // Check for validation errors & report corresponding error code
-            if (MPI_response_result > 0) {
-                // DMA is already stopped at the top of this if block & MPI UART mode has also
-                // been reset already.
-                return MPI_response_result;
-            }
-
-            return 0; // MPI successfully executed the telecommand
         }
     }
+
+    // Stop reception & reset MPI transceiver mode state, Set MPI UART mode state to previous state
+    MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_INACTIVE);
+    HAL_UART_DMAStop(UART_mpi_port_handle);
+    MPI_current_uart_rx_mode = MPI_RX_MODE_NOT_LISTENING_TO_MPI;
+
+    // Log the response from the MPI
+    // Copy the buffer to the last received byte index & clear the UART buffer
+    for (uint16_t i = 0; i < *MPI_rx_buffer_len; i++) {
+        MPI_rx_buffer[i] = UART_mpi_buffer[i];
+        //UART_mpi_buffer[i] = 0;
+    }
+
+    // Reset UART buffer write index
+    UART_mpi_buffer_write_idx = 0;
+
+    // Return success
+    return 0;
 }
 
-/// @brief The MPI responds to each telecommand with a response code consisting of an echo of the telecommand and a success byte (either 1 for success or 0 for fail).
+/// @brief The MPI responds to each telecommand with a response code consisting of an echo of the 
+///        telecommand and a success byte (either 1 for success or 0 for fail).
 /// @param MPI_tx_buffer MPI telecommand buffer containing bytes sent
 /// @param MPI_rx_buffer MPI response buffer containing bytes received
 /// @param MPI_tx_buffer_size Size of the MPI response buffer
-/// @return 0: MPI successfully executed telecommand, 5: MPI failed to execute telecommand, 6: Invalid response from the MPI
-uint8_t MPI_validate_telecommand_response(const uint8_t *MPI_tx_buffer, uint8_t *MPI_rx_buffer, const uint16_t MPI_tx_buffer_size) {
+/// @return 0: MPI successfully executed telecommand, 5: MPI failed to execute telecommand, 
+///         6: Invalid response from the MPI
+uint8_t MPI_validate_telecommand_response(const uint8_t *MPI_tx_buffer, uint8_t *MPI_rx_buffer, 
+                                          const uint16_t MPI_tx_buffer_size) {
     
     // Verify if the MPI response echos the cmd sent
     if (memcmp(MPI_tx_buffer, MPI_rx_buffer, MPI_tx_buffer_size) != 0) {

--- a/firmware/Core/Src/telecommands/mpi_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/mpi_telecommand_defs.c
@@ -3,6 +3,7 @@
 #include "mpi/mpi_command_handling.h"
 #include "transforms/arrays.h"
 #include "mpi/mpi_transceiver.h"
+#include "log/log.h"
 
 #include <stdio.h>
 #include <stdint.h>
@@ -13,14 +14,14 @@
 #include "main.h"
 
 
-///@brief Send a configuration command & params (IF ANY) to the MPI encoded in hex
+/// @brief Send a configuration command & params (IF ANY) to the MPI encoded in hex
 /// @param args_str 
 /// - Arg 0: Hex-encoded string representing the configuration command + arguments (IF ANY) to send to the MPI, INCLUDING 'TC' (0x54 0x43)
 /// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0: Success, 1: Invalid Input, 2: Failed UART transmission, 3: Failed UART reception,
-///     4: MPI timeout before sending 1 byte, 5: MPI failed to execute CMD
+///         4: MPI timeout before sending 1 byte, 5: MPI failed to execute CMD, 6: Invalid response from the MPI
 uint8_t TCMDEXEC_mpi_send_command_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                                       char *response_output_buf, uint16_t response_output_buf_len) {
     
@@ -38,56 +39,98 @@ uint8_t TCMDEXEC_mpi_send_command_hex(const char *args_str, TCMD_TelecommandChan
     }
 
     // Allocate space to receive incoming MPI response.
-    // Max possible MPI response buffer size allocated to 50 bytes (Considering for the telecommand echo response,
-    // NOT science data. MPI command + arguments can be 7 bytes + 2^N bytes of variable payload).
-    const size_t MPI_rx_buffer_max_size = 50;          
+    // Max possible MPI response buffer size allocated to 256 bytes (Considering for the telecommand echo response,
+    // NOT science data. MPI command + arguments can be 7 bytes + 2^N bytes of variable payload). 
+    const size_t MPI_rx_buffer_max_size = 256;          // TODO: Verify once commands are finalized with payload limits
     uint16_t MPI_rx_buffer_len = 0;                     // Length of MPI response buffer
     uint8_t MPI_rx_buffer[MPI_rx_buffer_max_size];      // Buffer to store incoming response from the MPI
     memset(MPI_rx_buffer, 0, MPI_rx_buffer_max_size);   // Initialize all elements to 0
 
     // Send command to MPI and receive back the response
-    const uint8_t cmd_response = MPI_send_telecommand_get_response(args_bytes, args_bytes_len, MPI_rx_buffer, MPI_rx_buffer_max_size, &MPI_rx_buffer_len);
+    uint8_t cmd_response = MPI_send_telecommand_get_response(args_bytes, args_bytes_len, MPI_rx_buffer, MPI_rx_buffer_max_size, &MPI_rx_buffer_len);
+
+    // If no errors are found during transmission and reception from the mpi, validate the response
+    if(cmd_response == 0) {
+        // Validate MPI response
+        cmd_response = MPI_validate_telecommand_response(args_bytes, MPI_rx_buffer, MPI_rx_buffer_len-1);
+    }
 
     // Send back MPI response log detail
     switch(cmd_response) {
-        case 0: 
-            snprintf(response_output_buf, response_output_buf_len, "MPI successfully executed the command. MPI echoed response code: %u\n", MPI_rx_buffer[args_bytes_len]);
+        case 0:
+            LOG_message(
+                LOG_SYSTEM_MPI, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                "MPI successfully executed the command. MPI echoed response code: %u\n", 
+                MPI_rx_buffer[args_bytes_len]
+            );
             break;
-        case 2: 
-            snprintf(response_output_buf, response_output_buf_len, "Failed UART transmission.\n");
+        case 2:
+            LOG_message(
+                LOG_SYSTEM_MPI, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+                "Failed UART transmission."
+            );
             break;
-        case 3: 
-            snprintf(response_output_buf, response_output_buf_len, "Failed UART reception.\n");
+        case 3:
+            LOG_message(
+                LOG_SYSTEM_MPI, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+                "Failed UART reception."
+            );
             break;
-        case 4: 
-            snprintf(response_output_buf, response_output_buf_len, "Timeout waiting for 1st byte from MPI.\n");
+        case 4:
+            LOG_message(
+                LOG_SYSTEM_MPI, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+                "Timeout waiting for 1st byte from MPI."
+            );
             break;
-        case 5: 
-            snprintf(response_output_buf, response_output_buf_len, "MPI failed to execute telecommand.  MPI echoed response code: %u\n", cmd_response);
+        case 5:
+            LOG_message(
+                LOG_SYSTEM_MPI, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+                "Timeout after receiving bytes from MPI."
+            );
             break;
         case 6:
-            snprintf(response_output_buf, response_output_buf_len, "Invalid response from the MPI.  MPI echoed response code: %u\n", cmd_response);
+            LOG_message(
+                LOG_SYSTEM_MPI, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+                "MPI failed to execute telecommand. MPI echoed response code: %u\n", 
+                cmd_response
+            );
+            break;
+        case 7:
+            LOG_message(
+                LOG_SYSTEM_MPI, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+                "Invalid response from the MPI. MPI echoed response code: %u\n", 
+                cmd_response
+            );
             break;
         default:
-            snprintf(response_output_buf, response_output_buf_len, "Unknown MPI_send_telecommand_get_response() return: %u\n", cmd_response);
+            LOG_message(
+                LOG_SYSTEM_MPI, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+                "Unknown MPI_send_telecommand_get_response() return: %u\n", 
+                cmd_response
+            );
             break;
     }
 
-    // Send back complete response from the MPI               
-    snprintf(
-        &response_output_buf[strlen(response_output_buf)],
-        response_output_buf_len - strlen(response_output_buf) - 1,
-        "MPI telecommand response: "
-    );
-    for (size_t i = 0; i < MPI_rx_buffer_len; i++)
-    {
+    // Send back response from the MPI (if received), Log to console for now
+    // TODO: Change after testing to meet new requirements
+    if(MPI_rx_buffer_len > 0) {                    
         snprintf(
             &response_output_buf[strlen(response_output_buf)],
             response_output_buf_len - strlen(response_output_buf) - 1,
-            "%02X ", MPI_rx_buffer[i]
+            "MPI telecommand response (%u bytes): ",
+            MPI_rx_buffer_len
         );
+        for (size_t i = 0; i < MPI_rx_buffer_len; i++)
+        {
+            snprintf(
+                &response_output_buf[strlen(response_output_buf)],
+                response_output_buf_len - strlen(response_output_buf) - 1,
+                "%02X ", MPI_rx_buffer[i]
+            );
+        }
     }
 
+    // Return response code from the MPI
     return cmd_response;
 }
 

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -126,8 +126,8 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
 
     // ****************** SECTION: uart_telecommand_defs ******************
     {
-        .tcmd_name = "uart_send_bytes_hex",
-        .tcmd_func = TCMDEXEC_uart_send_bytes_hex,
+        .tcmd_name = "uart_send_hex_get_response_hex",
+        .tcmd_func = TCMDEXEC_uart_send_hex_get_response_hex,
         .number_of_args = 2,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -5,6 +5,8 @@
 #include "transforms/arrays.h"
 #include "timekeeping/timekeeping.h"
 #include "debug_tools/debug_uart.h"
+#include "uart_handler/uart_handler.h"
+#include "mpi/mpi_command_handling.h"
 #include "log/log.h"
 
 // Additional telecommand definitions files:
@@ -16,6 +18,7 @@
 #include "telecommands/antenna_telecommand_defs.h"
 #include "telecommands/i2c_telecommand_defs.h"
 #include "telecommands/temperature_sensor_telecommand_defs.h"
+#include "telecommands/uart_telecommand_defs.h"
 #include "telecommands/config_telecommand_defs.h"
 #include "telecommands/testing_telecommand_defs.h"
 #include "telecommands/telecommand_executor.h"
@@ -118,6 +121,14 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .tcmd_name = "scan_i2c_bus",
         .tcmd_func = TCMDEXEC_scan_i2c_bus,
         .number_of_args = 1,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+
+    // ****************** SECTION: uart_telecommand_defs ******************
+    {
+        .tcmd_name = "uart_send_bytes_hex",
+        .tcmd_func = TCMDEXEC_uart_send_bytes_hex,
+        .number_of_args = 2,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
 

--- a/firmware/Core/Src/telecommands/uart_telelecommand_defs.c
+++ b/firmware/Core/Src/telecommands/uart_telelecommand_defs.c
@@ -75,7 +75,7 @@ uint8_t TCMDEXEC_uart_send_bytes_hex(const char *args_str, TCMD_TelecommandChann
         UART_rx_buffer_size_ptr = &UART_mpi_buffer_len;
 
         // Transmit bytes and receive response (DMA enabled reception)
-        const uint8_t MPI_tx_rx_status = MPI_send_telecommand_get_response(tx_buffer, tx_buffer_len, rx_buffer, *UART_rx_buffer_size_ptr, &rx_buffer_len);
+        const uint8_t MPI_tx_rx_status = MPI_send_command_get_response(tx_buffer, tx_buffer_len, rx_buffer, *UART_rx_buffer_size_ptr, &rx_buffer_len);
 
         // Log successful transmission and print rx_buffer response in hex (uint8_t)
         char rx_buffer_str[rx_buffer_len*3];

--- a/firmware/Core/Src/telecommands/uart_telelecommand_defs.c
+++ b/firmware/Core/Src/telecommands/uart_telelecommand_defs.c
@@ -1,0 +1,368 @@
+#include "telecommands/uart_telecommand_defs.h"
+#include "telecommands/telecommand_args_helpers.h"
+
+#include "uart_handler/uart_handler.h"
+#include "mpi/mpi_command_handling.h"
+#include "log/log.h"
+#include "debug_tools/debug_uart.h"
+
+#include <string.h>
+#include <stdio.h>
+
+/// @brief Timeout duration for transmit HAL call, in milliseconds.
+static const uint16_t UART_TX_TIMEOUT_DURATION_MS = 200;
+/// @brief Timeout duration for receive in milliseconds. Same between bytes and at the start.
+static const uint16_t UART_RX_TIMEOUT_DURATION_MS = 300;
+
+// Allocate 5KiB of space for send and receive arrays
+const uint16_t tx_buffer_max_size = 5120;
+const uint16_t rx_buffer_max_size = 5120;
+static uint8_t tx_buffer[5120];
+static uint8_t rx_buffer[5120];
+
+/// @brief Send artibrary configuration commands to a UART peripheral
+/// @param args_str 
+/// - Arg 0: UART port name to send data to: MPI, LORA, GPS, CAMERA, EPS (case insensitive)
+/// - Arg 1: Data to be sent (bytes specified as hex - Max 5KiB buffer)
+/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
+/// @param response_output_buf The buffer to write the response to
+/// @param response_output_buf_len The maximum length of the response_output_buf (its size)
+/// @return 0: Success, 1: Error parsing args, 2: Invalid uart port requested, 3: Error transmitting data, 
+///         4: Error receiving data, 5: Timeout waiting for response / No response, 6: Peripheral specific error, 
+///         7: Unhandled error
+/// @note This function doesn't toggle the EPS power lines for peripherals. Ensure they are powered on before 
+///       using this function.
+uint8_t TCMDEXEC_uart_send_bytes_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+
+    // Parse UART port argument
+    char arg_uart_port_name[10] = "";
+    const uint8_t uart_port_name_parse_result = TCMD_extract_string_arg(args_str, 0, arg_uart_port_name, 10);
+
+    // Parse hex-encoded config command (string to bytes)
+    uint16_t tx_buffer_len = 0;                             // Variable to store the length of the converted byte array
+    const uint8_t bytes_to_send_parse_result = TCMD_extract_hex_array_arg(args_str, 1, tx_buffer, tx_buffer_max_size, &tx_buffer_len);
+
+    // Check for argument parsing errors
+    if(uart_port_name_parse_result != 0 || bytes_to_send_parse_result !=0) {
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+            "Error parsing uart port/data to send arg: Arg 0 Err=%d, Arg 1 Err=%d", 
+            uart_port_name_parse_result, 
+            bytes_to_send_parse_result
+        );
+        return 1;    // Error code: Error parsing args
+    }
+    
+    // Allocate space to receive incoming response      
+    uint16_t rx_buffer_len = 0;                                
+    memset(rx_buffer, 0, rx_buffer_max_size);                   
+
+    // Assign pointers to UART reception variables to unify the interface (Interrupt case only in this function)
+    UART_HandleTypeDef *UART_handle_ptr;                        
+    volatile uint16_t *UART_rx_buffer_write_idx_ptr;            
+    volatile uint8_t *UART_rx_buffer;
+    const uint16_t *UART_rx_buffer_size_ptr;
+    volatile uint32_t *UART_last_write_time_ms_ptr;
+
+    LOG_system_enum_t LOG_source = LOG_SYSTEM_TELECOMMAND;
+    
+    // UART 1 selected (MPI)
+    if(strcasecmp(arg_uart_port_name, "MPI") == 0) {
+
+        // Set log source
+        LOG_source = LOG_SYSTEM_MPI;
+        UART_rx_buffer_size_ptr = &UART_mpi_buffer_len;
+
+        // Transmit bytes and receive response (DMA enabled reception)
+        const uint8_t MPI_tx_rx_status = MPI_send_telecommand_get_response(tx_buffer, tx_buffer_len, rx_buffer, *UART_rx_buffer_size_ptr, &rx_buffer_len);
+
+        // Log successful transmission and print rx_buffer response in hex (uint8_t)
+        char rx_buffer_str[rx_buffer_len*3];
+
+        for(uint16_t i = 0; i < rx_buffer_len; i++) {
+            // Copy received bytes into a string to log it
+            sprintf(&rx_buffer_str[i*3], "%02X ", rx_buffer[i]);
+        }
+
+        // Log mpi response
+        switch(MPI_tx_rx_status) {
+            case 0:
+                LOG_message(
+                    LOG_source, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                    "Transmitted %u byte(s) to %s.", 
+                    tx_buffer_len, 
+                    arg_uart_port_name
+                );
+                LOG_message(
+                    LOG_source, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                    "Received %u byte(s) from %s: %s",
+                    rx_buffer_len,
+                    arg_uart_port_name,
+                    rx_buffer_str
+                );
+                return 0;   // Success
+            case 2:
+                LOG_message(
+                    LOG_source, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+                    "Failed UART transmission."
+                );
+                return 3;   // Error code: Error transmitting data
+            case 3:
+                LOG_message(
+                    LOG_source, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+                    "Failed UART reception."
+                );
+                return 4;   // Error code: Error receiving data
+            case 4:
+                LOG_message(
+                    LOG_source, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+                    "No response received. Timeout waiting for 1st byte."
+                ); 
+                return 5;   // Error code: Error receiving data
+            case 8:
+                LOG_message(
+                    LOG_source, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+                    "Not enough space in the MPI response buffer"
+                ); 
+                return 6;   // Error code: Error receiving data
+            default:
+                LOG_message(
+                    LOG_source, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+                    "Unknown response return: %u", 
+                    MPI_tx_rx_status
+                );
+                return 7;   // Error code: Unhandled error
+        }
+    }
+
+    // UART 4 Selected (CAMERA)
+    else if(strcasecmp(arg_uart_port_name, "CAMERA") == 0) {        
+        UART_handle_ptr = UART_camera_port_handle;
+        UART_rx_buffer_write_idx_ptr = &UART_camera_buffer_write_idx;
+        UART_rx_buffer = &UART_camera_buffer[0];
+        UART_rx_buffer_size_ptr = &UART_camera_buffer_len;
+        UART_camera_is_expecting_data = 1;
+        UART_last_write_time_ms_ptr = &UART_camera_last_write_time_ms;
+        LOG_source = LOG_SYSTEM_BOOM; // Camera is related to the Boom experiment and should hence share the log source
+
+        // TODO: DMA handling function for camera is still under development.
+        // Return error code for now to indicate that the UART handling is not yet implemented. Remove this 
+        // once the UART handling is implemented for the camera. 
+        // Transmit the MPI command for now to test UART line
+        const HAL_StatusTypeDef transmit_status = HAL_UART_Transmit(UART_camera_port_handle, tx_buffer, tx_buffer_len, UART_TX_TIMEOUT_DURATION_MS);
+
+        // Check UART transmission status
+        if (transmit_status != HAL_OK) {
+            MPI_current_uart_rx_mode = MPI_RX_MODE_NOT_LISTENING_TO_MPI;
+            return 2; // Error code: Failed UART transmission
+        }
+
+        // Log successful transmission
+        LOG_message(
+            LOG_source, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Transmitted %u byte(s) to %s.", 
+            tx_buffer_len, 
+            arg_uart_port_name
+        );
+        LOG_message(
+            LOG_source, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+            "Transmitted bytes to camera. The Camera UART reception is not yet implemented."
+        );
+        
+        return 2;
+    }
+
+    // UART 2,3 & 5 use interrupt based reception, set UART handle and buffers according to selection
+    else {
+
+        // UART 2 Selected (LORA)
+        if(strcasecmp(arg_uart_port_name, "LORA") == 0) {
+            UART_handle_ptr = UART_lora_port_handle;
+            UART_rx_buffer_write_idx_ptr = &UART_lora_buffer_write_idx;
+            UART_rx_buffer = UART_lora_buffer;
+            UART_rx_buffer_size_ptr = &UART_lora_buffer_len;
+            UART_lora_is_expecting_data = 1;
+            UART_last_write_time_ms_ptr = &UART_lora_last_write_time_ms;
+            // TODO: LORA is not a system log source, Currently set to TELECOMMAND for the time being
+            LOG_source = LOG_SYSTEM_TELECOMMAND; 
+        }
+
+        // UART 3 Selected (GPS)
+        else if(strcasecmp(arg_uart_port_name, "GPS") == 0) {
+            UART_handle_ptr = UART_gps_port_handle;
+            UART_rx_buffer_write_idx_ptr = &UART_gps_buffer_write_idx;
+            UART_rx_buffer = UART_gps_buffer;
+            UART_rx_buffer_size_ptr = &UART_gps_buffer_len;
+            UART_last_write_time_ms_ptr = &UART_gps_last_write_time_ms;
+            LOG_source = LOG_SYSTEM_GPS;
+        }
+
+        // UART 5 Selected (EPS)
+        else if(strcasecmp(arg_uart_port_name, "EPS") == 0) {
+            UART_handle_ptr = UART_eps_port_handle;
+            UART_rx_buffer_write_idx_ptr = &UART_eps_buffer_write_idx;
+            UART_rx_buffer = UART_eps_buffer;
+            UART_rx_buffer_size_ptr = &UART_eps_buffer_len;
+            UART_eps_is_expecting_data = 1;
+            UART_last_write_time_ms_ptr = &UART_eps_last_write_time_ms;
+            LOG_source = LOG_SYSTEM_EPS;
+        }
+
+        // Invalid UART selected
+        else {
+            LOG_message(
+                LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                "Invalid UART peripheral port requested: %s", 
+                arg_uart_port_name
+            );
+            return 2;   // Error code: Invalid UART port requested
+        }
+
+        // Reset UART buffer write index
+        *UART_rx_buffer_write_idx_ptr = 0;
+
+        // Clear the response buffer (Note: Can't use memset because UART_rx_buffer is Volatile)
+        for (uint16_t i = 0; i < *UART_rx_buffer_size_ptr; i++) {
+            UART_rx_buffer[i] = 0;
+        }
+
+        // Record start time for response reception
+        const uint32_t UART_rx_start_time_ms = HAL_GetTick();
+
+        // Transmit config command to requested peripheral
+        const HAL_StatusTypeDef transmit_status = HAL_UART_Transmit(UART_handle_ptr, tx_buffer, tx_buffer_len, UART_TX_TIMEOUT_DURATION_MS);
+
+        // Check UART transmission
+        if (transmit_status != HAL_OK) {
+            LOG_message(
+                LOG_source, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                "Failed to transmit %u bytes to %s UART port. HAL status: %d", 
+                tx_buffer_len, 
+                arg_uart_port_name,
+                transmit_status
+            );
+            return 3; // Error code: Error transmitting data
+        }
+
+        // Log successful transmission
+        LOG_message(
+            LOG_source, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Transmitted %u byte(s) to %s.",
+            tx_buffer_len, 
+            arg_uart_port_name
+        );
+
+        // Receive from peripheral until a timeout event
+        while (1) {
+            
+            // Check if we have received upto max UART rx buffer size
+            if (*UART_rx_buffer_write_idx_ptr >= *UART_rx_buffer_size_ptr) {
+                break;
+            }
+
+            // Check if we have timed out (Before receiving the first byte)
+            if (*UART_rx_buffer_write_idx_ptr == 0) {
+                if((HAL_GetTick() - UART_rx_start_time_ms) > UART_RX_TIMEOUT_DURATION_MS) {
+                    LOG_message(
+                        LOG_source, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+                        "No response received from %s. Timeout waiting for 1st byte.",
+                        arg_uart_port_name
+                    );
+
+                    return 4; // Error code: Timeout waiting for 1st byte
+                }            
+            }
+
+            // We have received some data but timed out (in between bytes / end of reception)
+            else {
+                const uint32_t current_time = HAL_GetTick(); // Get current time
+
+                // Get last write time (Required to dereference volatile pointer here to prevent race 
+                // condition in the folllowing if statement)
+                const uint32_t last_write_time = *UART_last_write_time_ms_ptr;  
+
+                // Check if we have timed out while receiving bytes
+                if (
+                    (current_time > last_write_time) // Important seemingly-obvious safety check.
+                    && ((current_time - last_write_time) > UART_RX_TIMEOUT_DURATION_MS)
+                ) {
+                    rx_buffer_len = *UART_rx_buffer_write_idx_ptr; // Set the length of the response buffer
+                    break;
+                }
+            }
+        }
+
+        // Log the response received from peripheral
+        // Copy the buffer to the last received byte index & clear the UART buffer
+        for (uint16_t i = 0; i < rx_buffer_len; i++) {
+            rx_buffer[i] = UART_rx_buffer[i];
+            UART_rx_buffer[i] = 0;
+        }
+
+        // Reset UART buffer write index                
+        *UART_rx_buffer_write_idx_ptr = 0;
+
+        // Reset listening flags if used by peripheral (interrupt reception mode case is only handled here)
+        if(UART_handle_ptr == UART_lora_port_handle){
+            UART_lora_is_expecting_data = 0;
+        }
+        else if(UART_handle_ptr == UART_eps_port_handle){
+            UART_eps_is_expecting_data = 0;
+        }
+    }
+
+    // Send back complete response if any
+    if(rx_buffer_len > 0) { 
+
+        // Convert rx_buffer to a string for logging
+        // 2 hex chars, 1 space, +1 for null terminator
+        size_t rx_buffer_str_len = rx_buffer_len*3+1;
+        char rx_buffer_str[rx_buffer_str_len];
+
+        for(uint16_t i = 0; i < rx_buffer_len; i++) {
+            // Format each byte as hex with a trailing space
+            sprintf(&rx_buffer_str[i*3], "%02X ", rx_buffer[i]); 
+        }
+
+        // Null terminator at the end of the string
+        rx_buffer_str[rx_buffer_len*3] = '\0';
+
+        // Format log header and log response in chunks
+        size_t log_buffer_offset = 0;
+        size_t log_message_max_length = LOG_FORMATTED_MESSAGE_MAX_LENGTH-1; // -1 for null terminator
+
+        // Log header at the start of the log message
+        LOG_message(
+            LOG_source, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Received %u byte(s) from %s. Response in Hex:",
+            rx_buffer_len,
+            arg_uart_port_name
+        ); 
+
+        while(log_buffer_offset < rx_buffer_str_len-1) {
+
+            // Calculate the remaining space in the buffer for the log message
+            size_t log_buffer_remaining_space = rx_buffer_str_len - 1 - log_buffer_offset;
+            // The length of the log chunk is the smaller of the remaining space or the maximum log message length
+            size_t chunk_len = (rx_buffer_str_len-1 - log_buffer_offset) < log_message_max_length ? log_buffer_remaining_space : log_message_max_length;
+            
+            // Extract the response chunk to log
+            char log_message[chunk_len+1];
+            strncpy(log_message, rx_buffer_str + log_buffer_offset, chunk_len);
+            log_message[chunk_len] = '\0';
+
+            // Log the log message chunk
+            LOG_message(
+                LOG_source, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                "%s",
+                log_message
+            );
+
+            // Move the offset forward by the chunk size
+            log_buffer_offset += chunk_len;
+        }  
+    }
+
+    return 0;   // Success
+}

--- a/firmware/Core/Src/uart_handler/uart_handler.c
+++ b/firmware/Core/Src/uart_handler/uart_handler.c
@@ -337,7 +337,11 @@ void UART_init_uart_handlers(void) {
     // Enable the UART interrupt
     HAL_UART_Receive_IT(UART_telecommand_port_handle, (uint8_t*) &UART_telecommand_buffer_last_rx_byte, 1);
     HAL_UART_Receive_IT(UART_lora_port_handle, (uint8_t*) &UART_lora_buffer_last_rx_byte, 1);
-    // HAL_UART_Receive_IT(UART_gps_port_handle, (uint8_t*) &UART_gps_buffer_last_rx_byte, 1);
     HAL_UART_Receive_IT(UART_eps_port_handle, (uint8_t*) &UART_eps_buffer_last_rx_byte, 1);
+
+    // GPS is not initialized as always-listening. It is enabled by the GPS telecommands.
+    // Reason: The GPS has a mode where it spams null bytes, which can lock up the entire system.
+    // Thus, its interrupt is disabled by default.
+
     // TODO: Verify these when peripheral implementations are added
 }

--- a/firmware/Core/Src/uart_handler/uart_handler.c
+++ b/firmware/Core/Src/uart_handler/uart_handler.c
@@ -2,27 +2,56 @@
 #include "debug_tools/debug_uart.h"
 #include "mpi/mpi_command_handling.h"
 #include "main.h"
+#include "log/log.h"
 
 // Name the UART interfaces
 UART_HandleTypeDef *UART_telecommand_port_handle = &hlpuart1;
-UART_HandleTypeDef *UART_eps_port_handle = &huart5; // TODO: update this
 UART_HandleTypeDef *UART_mpi_port_handle = &huart1;
+UART_HandleTypeDef *UART_lora_port_handle = &huart2;
 UART_HandleTypeDef *UART_gps_port_handle = &huart3;
+UART_HandleTypeDef *UART_camera_port_handle = &huart4;
+UART_HandleTypeDef *UART_eps_port_handle = &huart5;
 
 // UART telecommand buffer
-const uint16_t UART_telecommand_buffer_len = 256; // extern
-volatile uint8_t UART_telecommand_buffer[256]; // extern // TODO: confirm that this volatile means that the contents are volatile but the pointer is not
-volatile uint16_t UART_telecommand_buffer_write_idx = 0; // extern
-volatile uint32_t UART_telecommand_last_write_time_ms = 0; // extern
-volatile uint8_t UART_telecommand_buffer_last_rx_byte = 0; // not an extern
+const uint16_t UART_telecommand_buffer_len = 256;           // extern
+volatile uint8_t UART_telecommand_buffer[256];              // extern       // TODO: confirm that this volatile means that the contents are volatile but the pointer is not
+volatile uint16_t UART_telecommand_buffer_write_idx = 0;    // extern
+volatile uint32_t UART_telecommand_last_write_time_ms = 0;  // extern
+volatile uint8_t UART_telecommand_buffer_last_rx_byte = 0;  // not an extern
+
+// UART MPI buffer
+// TODO: Update buffer sizes to accomodate for incoming science data. Currently only configured for config commands
+const uint16_t UART_mpi_buffer_len = 256;                   // extern       //Note: Max possible MPI response buffer size allocated to 50 bytes (Considering for the telecommand echo response, NOT science data.
+volatile uint8_t UART_mpi_buffer[256];                      // extern
+volatile uint8_t UART_mpi_last_rx_byte = 0;                 // extern
+volatile uint32_t UART_mpi_last_write_time_ms = 0;          // extern
+volatile uint16_t UART_mpi_buffer_write_idx = 0;            // extern
+
+// UART LORA buffer                                 
+//TODO: Configure with peripheral required specifications
+const uint16_t UART_lora_buffer_len = 1024;                 // extern       // TODO: Set based on expected size requirements for reception
+volatile uint8_t UART_lora_buffer[1024];                    // extern
+volatile uint16_t UART_lora_buffer_write_idx = 0;           // extern
+volatile uint32_t UART_lora_last_write_time_ms = 0;         // extern
+volatile uint8_t UART_lora_is_expecting_data = 0;           // extern;      // TODO: Set to 1 when a command is sent, and we're awaiting a response
+volatile uint8_t UART_lora_buffer_last_rx_byte = 0;         // not an extern
+
+// UART CAMERA buffer
+// TODO: Configure with peripheral required specifications
+const uint16_t UART_camera_buffer_len = 1024;               // extern       // TODO: Set based on expected size requirements for reception
+volatile uint8_t UART_camera_buffer[1024];                  // extern       // TODO: confirm that this volatile means that the contents are volatile but the pointer is not
+volatile uint16_t UART_camera_buffer_write_idx = 0;         // extern
+volatile uint32_t UART_camera_last_write_time_ms = 0;       // extern
+volatile uint8_t UART_camera_is_expecting_data = 0;         // extern       // TODO: Set to 1 when a command is sent, and we're awaiting a response
+volatile uint8_t UART_camera_buffer_last_rx_byte = 0;       // extern
 
 // UART EPS buffer
-const uint16_t UART_eps_buffer_len = 310; // extern // 286 bytes max response, plus a bit for safety and tags
-volatile uint8_t UART_eps_buffer[310]; // extern
-volatile uint16_t UART_eps_buffer_write_idx = 0; // extern
-volatile uint32_t UART_eps_last_write_time_ms = 0; // extern
-volatile uint8_t UART_eps_is_expecting_data = 0; // extern; set to 1 when a command is sent, and we're awaiting a response
-volatile uint8_t UART_eps_buffer_last_rx_byte = 0; // not an extern
+const uint16_t UART_eps_buffer_len = 310;                   // extern       // Note: 286 bytes max response, plus a bit for safety and tags is expected
+volatile uint8_t UART_eps_buffer[310];                      // extern
+volatile uint16_t UART_eps_buffer_write_idx = 0;            // extern
+volatile uint32_t UART_eps_last_write_time_ms = 0;          // extern
+volatile uint8_t UART_eps_is_expecting_data = 0;            // extern       // Note: set to 1 when a command is sent, and we're awaiting a response
+volatile uint8_t UART_eps_buffer_last_rx_byte = 0;          // not an extern
 
 // UART MPI cmd response buffer
 const uint16_t UART_mpi_rx_buffer_len = 50; // extern
@@ -64,29 +93,122 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
             // reset to a valid index
             UART_telecommand_buffer_write_idx = UART_telecommand_buffer_len - 1;
         }
+
+        // Add the received byte to the buffer
         UART_telecommand_buffer[UART_telecommand_buffer_write_idx++] = UART_telecommand_buffer_last_rx_byte;
         UART_telecommand_last_write_time_ms = HAL_GetTick();
+
+        // Restart reception for next byte
         HAL_UART_Receive_IT(UART_telecommand_port_handle, (uint8_t*) &UART_telecommand_buffer_last_rx_byte, 1);
     }
+
+    else if (huart->Instance == UART_mpi_port_handle->Instance) {
+        // DEBUG_uart_print_str("HAL_UART_RxCpltCallback() -> MPI Data\n");
+
+        if (MPI_current_uart_rx_mode == MPI_RX_MODE_COMMAND_MODE) {
+            // Check if buffer is full
+            if (UART_mpi_buffer_write_idx >= UART_mpi_buffer_len) {
+                // DEBUG_uart_print_str("HAL_UART_RxCpltCallback() -> UART mpi response buffer is full\n");
+
+                // Shift all bytes left by 1
+                for(uint16_t i = 1; i < UART_mpi_buffer_len; i++) {
+                    UART_mpi_buffer[i - 1] = UART_mpi_buffer[i];
+                }
+
+                // Reset to a valid index
+                UART_mpi_buffer_write_idx = UART_mpi_buffer_len - 1;
+            }
+
+            // Add the received byte to the buffer
+            UART_mpi_buffer[UART_mpi_buffer_write_idx++] = UART_mpi_last_rx_byte;
+            UART_mpi_last_write_time_ms = HAL_GetTick();
+        }
+        else {
+            DEBUG_uart_print_str("Unhandled MPI Mode\n"); //TODO: HANDLE other MPI MODES
+        }
+    }
+
+    // TODO: Verify implementation with peripheral connected. Currently configured to follow interrupt based receive
+    else if(huart->Instance == UART_lora_port_handle->Instance){
+        // DEBUG_uart_print_str("HAL_UART_RxCpltCallback() -> LORA Data\n");
+
+        if (! UART_lora_is_expecting_data) {
+            // not expecting data, ignore this noise
+            HAL_UART_Receive_IT(UART_lora_port_handle, (uint8_t*) &UART_lora_buffer_last_rx_byte, 1);
+            return;
+        }
+
+        // Add the byte to the buffer
+        if (UART_lora_buffer_write_idx >= UART_lora_buffer_len) {
+            // DEBUG_uart_print_str("HAL_UART_RxCpltCallback() -> UART response buffer is full\n");
+            
+            // Shift all bytes left by 1
+            for (uint16_t i = 1; i < UART_lora_buffer_len; i++) {
+                UART_lora_buffer[i - 1] = UART_lora_buffer[i];
+            }
+
+            // Reset to a valid index
+            UART_lora_buffer_write_idx = UART_lora_buffer_len - 1;
+        }
+
+        // Add the received byte to the buffer
+        UART_lora_buffer[UART_lora_buffer_write_idx++] = UART_lora_buffer_last_rx_byte;
+        UART_lora_last_write_time_ms = HAL_GetTick();
+
+        // Restart reception for next byte
+        HAL_UART_Receive_IT(UART_lora_port_handle, (uint8_t*) &UART_lora_buffer_last_rx_byte, 1);
+    }
+
+    // TODO: Implement function to utilize this DMA reception callback for the CAMERA
+    else if (huart->Instance == UART_camera_port_handle->Instance) {
+        // DEBUG_uart_print_str("HAL_UART_RxCpltCallback() -> CAMERA Data\n");
+
+        if (! UART_camera_is_expecting_data) {
+            // not expecting data, ignore this noise
+            HAL_UART_Receive_IT(UART_camera_port_handle, (uint8_t*) &UART_camera_buffer_last_rx_byte, 1);
+            return;
+        }
+
+        // Check if buffer is full
+        if (UART_camera_buffer_write_idx >= UART_camera_buffer_len) {
+            // DEBUG_uart_print_str("HAL_UART_RxCpltCallback() -> UART response buffer is full\n");
+
+            // Shift all bytes left by 1
+            for(uint16_t i = 1; i < UART_camera_buffer_len; i++) {
+                UART_camera_buffer[i - 1] = UART_camera_buffer[i];
+            }
+
+            // Reset to a valid index
+            UART_camera_buffer_write_idx = UART_camera_buffer_len - 1;
+        }
+
+        // Add a byte to the buffer
+        UART_camera_buffer[UART_camera_buffer_write_idx++] = UART_camera_buffer_last_rx_byte;
+        UART_camera_last_write_time_ms = HAL_GetTick();
+    }           
 
     else if (huart->Instance == UART_eps_port_handle->Instance) {
         // DEBUG_uart_print_str("HAL_UART_RxCpltCallback() -> EPS Data\n");
 
         if (! UART_eps_is_expecting_data) {
-            // not expecting data, ignore this noise
+            // Not expecting data, ignore this noise
             HAL_UART_Receive_IT(UART_eps_port_handle, (uint8_t*) &UART_eps_buffer_last_rx_byte, 1);
             return;
         }
 
         if (UART_eps_buffer_write_idx >= UART_eps_buffer_len) {
-            DEBUG_uart_print_str("HAL_UART_RxCpltCallback() -> UART EPS buffer is full\n");
+            // DEBUG_uart_print_str("HAL_UART_RxCpltCallback() -> UART EPS buffer is full\n"); //TODO: Remove this later
+
             HAL_UART_Receive_IT(UART_eps_port_handle, (uint8_t*) &UART_eps_buffer_last_rx_byte, 1);
-            // exit, with everything the way it is (stop appending)
+            // Exit, with everything the way it is (stop appending)
             return;
         }
 
+        // Add the byte to the buffer
         UART_eps_buffer[UART_eps_buffer_write_idx++] = UART_eps_buffer_last_rx_byte;
         UART_eps_last_write_time_ms = HAL_GetTick();
+
+        // Restart reception for next byte
         HAL_UART_Receive_IT(UART_eps_port_handle, (uint8_t*) &UART_eps_buffer_last_rx_byte, 1);
     }
 
@@ -143,13 +265,6 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
     }
 }
 
-void UART_init_uart_handlers(void) {
-    // enable the UART interrupt
-    HAL_UART_Receive_IT(UART_telecommand_port_handle, (uint8_t*) &UART_telecommand_buffer_last_rx_byte, 1);
-    HAL_UART_Receive_IT(UART_eps_port_handle, (uint8_t*) &UART_eps_buffer_last_rx_byte, 1);
-
-    // TODO: add the rest
-}
 
 
 /// @brief Sets the UART interrupt state (enabled/disabled)
@@ -163,4 +278,66 @@ void GPS_set_uart_interrupt_state(uint8_t new_enabled) {
     else {
         UART_gps_uart_interrupt_enabled = 0;
     }
+}
+
+
+void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart) {
+    // Reception Error callback for MPI UART port
+    if (huart->Instance == UART_mpi_port_handle->Instance) {
+        LOG_message(
+            LOG_SYSTEM_MPI, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+            "MPI UART Reception Error: %lu", huart->ErrorCode
+        );
+
+        HAL_UART_Receive_DMA(UART_mpi_port_handle, (uint8_t*)&UART_mpi_last_rx_byte, 1);
+    }
+
+    // Reception Error callback for LORA UART port
+    if (huart->Instance == UART_lora_port_handle->Instance) {
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+            "LORA UART Reception Error: %lu", huart->ErrorCode
+        ); // TODO: LORA is not registered as a system in the logger yet
+
+        HAL_UART_Receive_IT(UART_lora_port_handle, (uint8_t*)&UART_lora_buffer_last_rx_byte, 1);
+    }
+
+    // Reception Error callback for GPS UART port
+    if (huart->Instance == UART_gps_port_handle->Instance) {
+        LOG_message(
+            LOG_SYSTEM_GPS, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+            "GPS UART Reception Error: %lu", huart->ErrorCode
+        );
+
+        HAL_UART_Receive_IT(UART_gps_port_handle, (uint8_t*)&UART_gps_buffer_last_rx_byte, 1);
+    }
+
+    // Reception Error callback for CAMERA UART port
+    if (huart->Instance == UART_camera_port_handle->Instance) {
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+            "CAMERA UART Reception Error: %lu", huart->ErrorCode
+        ); // TODO: CAMERA is not registered as a system in the logger yet, Telecommand system used instead
+
+        HAL_UART_Receive_DMA(UART_camera_port_handle, (uint8_t*)&UART_camera_buffer_last_rx_byte, 1);
+    }
+
+    // Reception Error callback for EPS UART port
+    if (huart->Instance == UART_eps_port_handle->Instance) {
+        LOG_message(
+            LOG_SYSTEM_EPS, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+            "EPS UART Reception Error: %lu", huart->ErrorCode
+        );
+
+        HAL_UART_Receive_IT(UART_eps_port_handle, (uint8_t*)&UART_eps_buffer_last_rx_byte, 1);
+    }
+}
+
+void UART_init_uart_handlers(void) {
+    // Enable the UART interrupt
+    HAL_UART_Receive_IT(UART_telecommand_port_handle, (uint8_t*) &UART_telecommand_buffer_last_rx_byte, 1);
+    HAL_UART_Receive_IT(UART_lora_port_handle, (uint8_t*) &UART_lora_buffer_last_rx_byte, 1);
+    // HAL_UART_Receive_IT(UART_gps_port_handle, (uint8_t*) &UART_gps_buffer_last_rx_byte, 1);
+    HAL_UART_Receive_IT(UART_eps_port_handle, (uint8_t*) &UART_eps_buffer_last_rx_byte, 1);
+    // TODO: Verify these when peripheral implementations are added
 }

--- a/hardware_emulators/MPI_Emulator.py
+++ b/hardware_emulators/MPI_Emulator.py
@@ -1,19 +1,40 @@
 import serial
+import time
 
-def listen_and_respond(com_port, baudrate=230400):
-     with serial.Serial(com_port, baudrate, timeout=1) as ser:
-        print(f"Listening on {com_port} at {baudrate} baudrate.")
-            
-        # Read in incoming mpi telecommand
+from loguru import logger
+
+def listen_and_respond(com_port, baudrate=230400, receive_timeout=0.2):
+    # Set a shorter serial timeout to avoid unnecessary delays
+    with serial.Serial(com_port, baudrate, timeout=0.05) as ser:
+        logger.info(f"Listening on {com_port} at {baudrate} baudrate.")
+        
+        buffer = bytearray()  # Buffer to hold incoming data
+        last_receive_time = time.time()  # Time when the last byte was received
+        
         while True:
             if ser.in_waiting > 0:
+                # Read in available incoming data
                 incoming_cmd = ser.read(ser.in_waiting)
-                print(f"Received:   {incoming_cmd.hex()}")
-                
-                # Append 1 to the telecommand data received to indicate a successful reception & echo back
-                response = incoming_cmd + bytes([0x01])
+                buffer.extend(incoming_cmd)
+                last_receive_time = time.time()  # Update the last receive time
+                logger.info(f"OBC -> MPI_COMPUTER: {incoming_cmd.hex()}")
+
+            # Check if more than 200 milliseconds have passed since the last received data
+            if len(buffer) > 0 and (time.time() - last_receive_time) > receive_timeout:
+                # Transmission is considered complete
+                # Now echo back the entire buffer at once, not in chunks
+                response = buffer + bytes([0x01])  # Append the echo byte
                 ser.write(response)
-                print(f"Responded:  {response.hex()}")
+                ser.flush()  # Ensure the data is sent immediately
+                logger.info(f"MPI_COMPUTER -> OBC:  {response.hex()}")
+
+                # Clear buffer for the next transmission
+                buffer.clear()
+
+                # Ensure we respond within the total 300ms window
+                time_elapsed = time.time() - last_receive_time
+                if time_elapsed > 0.3:
+                    logger.info("MPI_COMPUTER -> OBC: Warning: Response time exceeded 300ms!")
 
 if __name__ == "__main__":
     # Specify the COM port to listen on


### PR DESCRIPTION
This is a rebase of https://github.com/CalgaryToSpace/CTS-SAT-1-OBC-Firmware/pull/185, with extra consideration taken for the GPS handler (which supports disabling the interrupt).

Fixes #19.