### PR TITLE
TCMD for retrieving battery voltage percent from PBU

### DIFF
--- a/firmware/Core/Inc/eps_drivers/eps_calculations.h
+++ b/firmware/Core/Inc/eps_drivers/eps_calculations.h
@@ -1,0 +1,9 @@
+#ifndef INCLUDE_GUARD__EPS_CALCULATIONS
+#define INCLUDE_GUARD__EPS_CALCULATIONS
+
+#include "eps_drivers/eps_types.h"
+
+float EPS_convert_battery_voltage_to_percent(EPS_battery_pack_datatype_eng_t battery);
+
+#endif // INCLUDE_GUARD__EPS_CALCULATIONS
+

--- a/firmware/Core/Inc/telecommands/eps_telecommands.h
+++ b/firmware/Core/Inc/telecommands/eps_telecommands.h
@@ -91,5 +91,11 @@ uint8_t TCMDEXEC_eps_get_piu_housekeeping_data_run_avg_json(
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
+uint8_t TCMDEXEC_eps_get_current_battery_percent(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len
+);
+
+
 #endif // INCLUDE_GUARD__EPS_TELECOMMANDS_H__
 

--- a/firmware/Core/Inc/unit_tests/test_eps_calculations.h
+++ b/firmware/Core/Inc/unit_tests/test_eps_calculations.h
@@ -1,0 +1,8 @@
+#ifndef INCLUDE_GUARD__TEST_EPS_CALCULATIONS_H
+#define INCLUDE_GUARD__TEST_EPS_CALCULATIONS_H
+
+#include <stdint.h>
+
+uint8_t TEST_EXEC__EPS_convert_battery_voltage_to_percent();
+
+#endif // INCLUDE_GUARD__TEST_EPS_CALCULATIONS_H

--- a/firmware/Core/Src/eps_drivers/eps_calculations.c
+++ b/firmware/Core/Src/eps_drivers/eps_calculations.c
@@ -2,15 +2,11 @@
 
 
 float EPS_convert_battery_voltage_to_percent(EPS_battery_pack_datatype_eng_t battery) {
-    const int16_t cell_1_mV = battery.cell_voltage_each_cell_mV[0];
-    const int16_t cell_2_mV = battery.cell_voltage_each_cell_mV[1];
-    const int16_t cell_3_mV = battery.cell_voltage_each_cell_mV[2];
-    const int16_t cell_4_mV = battery.cell_voltage_each_cell_mV[3];
 
     const uint8_t min_total_voltage_V = 12;
     const uint8_t max_total_voltage_V = 16;
 
-    const float cell_total_voltage_V = (cell_1_mV + cell_2_mV + cell_3_mV + cell_4_mV) * 0.001; 
+    const float cell_total_voltage_V = (battery.vip_bp_input.voltage_mV) * 0.001; 
     
     const float calc = (float)(cell_total_voltage_V - min_total_voltage_V) / (max_total_voltage_V - min_total_voltage_V);
 

--- a/firmware/Core/Src/eps_drivers/eps_calculations.c
+++ b/firmware/Core/Src/eps_drivers/eps_calculations.c
@@ -3,13 +3,13 @@
 
 float EPS_convert_battery_voltage_to_percent(EPS_battery_pack_datatype_eng_t battery) {
 
-    const uint8_t min_total_voltage_V = 12;
-    const uint8_t max_total_voltage_V = 16;
+    const uint32_t min_total_voltage_mV = 12000;
+    const uint32_t max_total_voltage_mV = 16000;
 
-    const float cell_total_voltage_V = (battery.vip_bp_input.voltage_mV) * 0.001; 
+    const int16_t battery_total_voltage_mV = battery.vip_bp_input.voltage_mV; 
     
-    const float calc = (float)(cell_total_voltage_V - min_total_voltage_V) / (max_total_voltage_V - min_total_voltage_V);
+    const float calc = ((float)(battery_total_voltage_mV - min_total_voltage_mV)) / ((float)(max_total_voltage_mV - min_total_voltage_mV));
 
     // convert to percent
-    return calc * 100;
+    return calc * 100.0;
 }

--- a/firmware/Core/Src/eps_drivers/eps_calculations.c
+++ b/firmware/Core/Src/eps_drivers/eps_calculations.c
@@ -1,0 +1,19 @@
+#include "eps_drivers/eps_calculations.h"
+
+
+float EPS_convert_battery_voltage_to_percent(EPS_battery_pack_datatype_eng_t battery) {
+    const int16_t cell_1_mV = battery.cell_voltage_each_cell_mV[0];
+    const int16_t cell_2_mV = battery.cell_voltage_each_cell_mV[1];
+    const int16_t cell_3_mV = battery.cell_voltage_each_cell_mV[2];
+    const int16_t cell_4_mV = battery.cell_voltage_each_cell_mV[3];
+
+    const uint8_t min_total_voltage_V = 12;
+    const uint8_t max_total_voltage_V = 16;
+
+    const float cell_total_voltage_V = (cell_1_mV + cell_2_mV + cell_3_mV + cell_4_mV) * 0.001; 
+    
+    const float calc = (float)(cell_total_voltage_V - min_total_voltage_V) / (max_total_voltage_V - min_total_voltage_V);
+
+    // convert to percent
+    return calc * 100;
+}

--- a/firmware/Core/Src/telecommands/eps_telecommands.c
+++ b/firmware/Core/Src/telecommands/eps_telecommands.c
@@ -540,7 +540,7 @@ uint8_t TCMDEXEC_eps_get_current_battery_percent(
     const float battery_percent = EPS_convert_battery_voltage_to_percent(data.battery_pack_info_each_pack[0]);
 
     snprintf(response_output_buf, response_output_buf_len, 
-             "Battery Percentage: %0.2f", battery_percent);
+             "Battery Percentage: %0.2f%%", battery_percent);
 
     
     return 0;    

--- a/firmware/Core/Src/telecommands/eps_telecommands.c
+++ b/firmware/Core/Src/telecommands/eps_telecommands.c
@@ -3,6 +3,7 @@
 #include "eps_drivers/eps_types_to_json.h"
 #include "eps_drivers/eps_channel_control.h"
 #include "eps_drivers/eps_time.h"
+#include "eps_drivers/eps_calculations.h"
 #include "telecommands/eps_telecommands.h"
 #include "telecommands/telecommand_args_helpers.h"
 
@@ -519,4 +520,26 @@ uint8_t TCMDEXEC_eps_get_piu_housekeeping_data_run_avg_json(
         return 2;
     }
     return 0;
+}
+
+uint8_t TCMDEXEC_eps_get_current_battery_percent(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len) {
+
+    EPS_struct_pbu_housekeeping_data_eng_t data;
+    const uint8_t result = EPS_CMD_get_pbu_housekeeping_data_eng(&data);
+
+    if (result != 0) {
+        snprintf(response_output_buf, response_output_buf_len,
+            "EPS_CMD_get_pbu_housekeeping_data_eng (err %d)", result);
+        return 1;
+    }
+
+    const float battery_percent = EPS_convert_battery_voltage_to_percent(data.battery_pack_info_each_pack[0]);
+
+    snprintf(response_output_buf, response_output_buf_len, 
+             "Battery Percentage: %0.2f", battery_percent);
+
+    
+    return 0;    
 }

--- a/firmware/Core/Src/telecommands/eps_telecommands.c
+++ b/firmware/Core/Src/telecommands/eps_telecommands.c
@@ -522,6 +522,8 @@ uint8_t TCMDEXEC_eps_get_piu_housekeeping_data_run_avg_json(
     return 0;
 }
 
+/// @brief Get current battery voltage percent from PBU
+/// @return 0 if successful, > 0 otherwise
 uint8_t TCMDEXEC_eps_get_current_battery_percent(
     const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
     char *response_output_buf, uint16_t response_output_buf_len) {

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -938,6 +938,13 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .number_of_args = 0,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
+
+    {
+        .tcmd_name = "eps_get_current_battery_percent",
+        .tcmd_func = TCMDEXEC_eps_get_current_battery_percent,
+        .number_of_args = 0,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION
+    },
     /* *************************** END EPS Section ************************************** */
     
     

--- a/firmware/Core/Src/unit_tests/test_eps_calculations.c
+++ b/firmware/Core/Src/unit_tests/test_eps_calculations.c
@@ -18,10 +18,7 @@ uint8_t TEST_EXEC__EPS_convert_battery_voltage_to_percent()
     
     // Success Cases
     // Case 1: Minimum voltage (12V -> 0%)
-    battery.cell_voltage_each_cell_mV[0] = 3000;
-    battery.cell_voltage_each_cell_mV[1] = 3000;
-    battery.cell_voltage_each_cell_mV[2] = 3000;
-    battery.cell_voltage_each_cell_mV[3] = 3000;
+    battery.vip_bp_input.voltage_mV = 12000;
 
     expected_value = 0;
     
@@ -30,11 +27,7 @@ uint8_t TEST_EXEC__EPS_convert_battery_voltage_to_percent()
     TEST_ASSERT(calc <= (expected_value + TOLERANCE));
 
     // Case 2: Maximum voltage (16V -> 100%)
-    battery.cell_voltage_each_cell_mV[0] = 4000;
-    battery.cell_voltage_each_cell_mV[1] = 4000;
-    battery.cell_voltage_each_cell_mV[2] = 4000;
-    battery.cell_voltage_each_cell_mV[3] = 4000;
-
+    battery.vip_bp_input.voltage_mV = 16000;
     expected_value = 100;
     
     calc = EPS_convert_battery_voltage_to_percent(battery);
@@ -43,10 +36,7 @@ uint8_t TEST_EXEC__EPS_convert_battery_voltage_to_percent()
 
 
     // Case 3: Midpoint (14V -> 50%)
-    battery.cell_voltage_each_cell_mV[0] = 3500;
-    battery.cell_voltage_each_cell_mV[1] = 3500;
-    battery.cell_voltage_each_cell_mV[2] = 3500;
-    battery.cell_voltage_each_cell_mV[3] = 3500;
+    battery.vip_bp_input.voltage_mV = 14000;
 
     expected_value = 50;
     
@@ -56,13 +46,10 @@ uint8_t TEST_EXEC__EPS_convert_battery_voltage_to_percent()
 
 
     // Case 4: Over 16V (Should be greater than 100%)
-    battery.cell_voltage_each_cell_mV[0] = 4500;
-    battery.cell_voltage_each_cell_mV[1] = 4500;
-    battery.cell_voltage_each_cell_mV[2] = 4500;
-    battery.cell_voltage_each_cell_mV[3] = 4500;
+    battery.vip_bp_input.voltage_mV = 18000;
 
     // 16 - 12 = 4V
-    // total voltage above = 18 V
+    // voltage above = 18 V
     // 18 - 16 = 2
     // 2 / 4 = .5 = 50%, 50% above maximum total voltage
     expected_value = 150;
@@ -72,13 +59,10 @@ uint8_t TEST_EXEC__EPS_convert_battery_voltage_to_percent()
     TEST_ASSERT(calc <= (expected_value + TOLERANCE));
 
     // Case 5: Under 12V (Should be negative)
-    battery.cell_voltage_each_cell_mV[0] = 2500;
-    battery.cell_voltage_each_cell_mV[1] = 2500;
-    battery.cell_voltage_each_cell_mV[2] = 2500;
-    battery.cell_voltage_each_cell_mV[3] = 2500;
-    
+    battery.vip_bp_input.voltage_mV = 10000;
+
     // 16 - 12 = 4 V
-    // total voltage above is 1000 mV = 1 V
+    // total voltage above is 10 V
     // 10 - 12 = -2
     // -2 / 4 = -0.5 = -50%, 50% less than minimum
     expected_value = -50;

--- a/firmware/Core/Src/unit_tests/test_eps_calculations.c
+++ b/firmware/Core/Src/unit_tests/test_eps_calculations.c
@@ -1,0 +1,91 @@
+#include "unit_tests/test_eps_calculations.h"
+#include "unit_tests/unit_test_helpers.h"
+
+#include "eps_drivers/eps_types.h"
+#include "eps_drivers/eps_calculations.h"
+
+
+uint8_t TEST_EXEC__EPS_convert_battery_voltage_to_percent()
+{
+    EPS_battery_pack_datatype_eng_t battery;
+    float calc = 0;
+    float expected_value = 0;
+
+    // The max tolerance of the floating point calculation
+    // should be +/- 0.1 percent of the actual calculation
+    const float TOLERANCE = 0.1;
+
+    
+    // Success Cases
+    // Case 1: Minimum voltage (12V -> 0%)
+    battery.cell_voltage_each_cell_mV[0] = 3000;
+    battery.cell_voltage_each_cell_mV[1] = 3000;
+    battery.cell_voltage_each_cell_mV[2] = 3000;
+    battery.cell_voltage_each_cell_mV[3] = 3000;
+
+    expected_value = 0;
+    
+    calc = EPS_convert_battery_voltage_to_percent(battery);
+    TEST_ASSERT(calc >= (expected_value - TOLERANCE));
+    TEST_ASSERT(calc <= (expected_value + TOLERANCE));
+
+    // Case 2: Maximum voltage (16V -> 100%)
+    battery.cell_voltage_each_cell_mV[0] = 4000;
+    battery.cell_voltage_each_cell_mV[1] = 4000;
+    battery.cell_voltage_each_cell_mV[2] = 4000;
+    battery.cell_voltage_each_cell_mV[3] = 4000;
+
+    expected_value = 100;
+    
+    calc = EPS_convert_battery_voltage_to_percent(battery);
+    TEST_ASSERT(calc >= (expected_value - TOLERANCE));
+    TEST_ASSERT(calc <= (expected_value + TOLERANCE));
+
+
+    // Case 3: Midpoint (14V -> 50%)
+    battery.cell_voltage_each_cell_mV[0] = 3500;
+    battery.cell_voltage_each_cell_mV[1] = 3500;
+    battery.cell_voltage_each_cell_mV[2] = 3500;
+    battery.cell_voltage_each_cell_mV[3] = 3500;
+
+    expected_value = 50;
+    
+    calc = EPS_convert_battery_voltage_to_percent(battery);
+    TEST_ASSERT(calc >= (expected_value - TOLERANCE));
+    TEST_ASSERT(calc <= (expected_value + TOLERANCE));
+
+
+    // Case 4: Over 16V (Should be greater than 100%)
+    battery.cell_voltage_each_cell_mV[0] = 4500;
+    battery.cell_voltage_each_cell_mV[1] = 4500;
+    battery.cell_voltage_each_cell_mV[2] = 4500;
+    battery.cell_voltage_each_cell_mV[3] = 4500;
+
+    // 16 - 12 = 4V
+    // total voltage above = 18 V
+    // 18 - 16 = 2
+    // 2 / 4 = .5 = 50%, 50% above maximum total voltage
+    expected_value = 150;
+    
+    calc = EPS_convert_battery_voltage_to_percent(battery);
+    TEST_ASSERT(calc >= (expected_value - TOLERANCE));
+    TEST_ASSERT(calc <= (expected_value + TOLERANCE));
+
+    // Case 5: Under 12V (Should be negative)
+    battery.cell_voltage_each_cell_mV[0] = 2500;
+    battery.cell_voltage_each_cell_mV[1] = 2500;
+    battery.cell_voltage_each_cell_mV[2] = 2500;
+    battery.cell_voltage_each_cell_mV[3] = 2500;
+    
+    // 16 - 12 = 4 V
+    // total voltage above is 1000 mV = 1 V
+    // 10 - 12 = -2
+    // -2 / 4 = -0.5 = -50%, 50% less than minimum
+    expected_value = -50;
+    
+    calc = EPS_convert_battery_voltage_to_percent(battery);
+    TEST_ASSERT(calc >= (expected_value - TOLERANCE));
+    TEST_ASSERT(calc <= (expected_value + TOLERANCE));
+    
+    return 0;
+}

--- a/firmware/Core/Src/unit_tests/unit_test_inventory.c
+++ b/firmware/Core/Src/unit_tests/unit_test_inventory.c
@@ -14,6 +14,7 @@
 
 #include "unit_tests/test_eps_drivers.h"
 #include "unit_tests/test_eps_struct_packers.h"
+#include "unit_tests/test_eps_calculations.h"
 #include "unit_tests/test_sha256.h"
 #include "unit_tests/test_crc.h"
 
@@ -439,6 +440,11 @@ const TEST_Definition_t TEST_definitions[] = {
         .test_func = TEST_EXEC__EPS_check_type_sizes,
         .test_file = "unit_tests/test_eps_struct_packers",
         .test_func_name = "TEST_EXEC__EPS_check_type_sizes",
+    },
+    {
+        .test_func = TEST_EXEC__EPS_convert_battery_voltage_to_percent,
+        .test_file = "unit_tests/test_eps_calculations",
+        .test_func_name = "TEST_EXEC__EPS_convert_battery_voltage_to_percent"
     },
     {
         .test_func = TEST_EXEC__ANT_convert_raw_temp_to_cCelsius,

--- a/firmware/STM32-for-VSCode.config.yaml
+++ b/firmware/STM32-for-VSCode.config.yaml
@@ -51,7 +51,7 @@ assemblyFlags:
   - -Wextra # CTS: Enable extra warnings for safety
 
 linkerFlags: 
-  - -Wl,--print-memory-usage
+  - -Wl,--print-memory-usage,-u_printf_float
 
 
 # libraries to be included. The -l prefix to the library will be automatically added.


### PR DESCRIPTION
Completes #267.

TCMD for getting the battery voltage percent from PBU.

Independent function which calculates battery percentage with unit tests.