### PR TITLE
LittleFS Bug Fix: Data type conflicts causing overflows leading to unpredictable behavior 

### DIFF
--- a/firmware/Core/Src/littlefs/littlefs_benchmark.c
+++ b/firmware/Core/Src/littlefs/littlefs_benchmark.c
@@ -67,7 +67,7 @@ uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk
     // Write
     const uint32_t write_send_start_time = HAL_GetTick();
     for (uint32_t chunk_num = 0; chunk_num < write_chunk_count; chunk_num++) {
-        const int8_t write_result = lfs_file_write(&LFS_filesystem, &file, write_buffer, write_chunk_size);
+        const ssize_t write_result = lfs_file_write(&LFS_filesystem, &file, write_buffer, write_chunk_size);
         for (uint32_t i = 0; i < write_chunk_size; i++) {
             // Weak checksum, but good enough
             expected_checksum ^= write_buffer[i];
@@ -124,7 +124,7 @@ uint8_t LFS_benchmark_write_read(uint16_t write_chunk_size, uint16_t write_chunk
     uint8_t read_buffer[write_chunk_size];
     uint8_t read_checksum = 0;
     for (uint32_t chunk_num = 0; chunk_num < write_chunk_count; chunk_num++) {
-        const int8_t read_result = lfs_file_read(&LFS_filesystem, &file, read_buffer, write_chunk_size);
+        const ssize_t read_result = lfs_file_read(&LFS_filesystem, &file, read_buffer, write_chunk_size);
         if (read_result < 0) {
             snprintf(
                 &response_str[strlen(response_str)],

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -288,7 +288,7 @@ int8_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t wr
     LOG_message(LOG_SYSTEM_LFS, LOG_SEVERITY_NORMAL, LOG_all_sinks_except(LOG_SINK_FILE), "Opened/created file: %s", file_name);
 
     // Write data to file
-    const int8_t write_result = lfs_file_write(&LFS_filesystem, &file, write_buffer, write_buffer_len);
+    const lfs_ssize_t write_result = lfs_file_write(&LFS_filesystem, &file, write_buffer, write_buffer_len);
     if (write_result < 0)
     {
         LOG_message(LOG_SYSTEM_LFS, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), "Error writing to file: %s", file_name);
@@ -332,13 +332,13 @@ int8_t LFS_append_file(const char file_name[], uint8_t *write_buffer, uint32_t w
         return open_result;
     }
     
-    const int8_t seek_result = lfs_file_seek(&LFS_filesystem, &file, 0, LFS_SEEK_END);
+    const lfs_soff_t seek_result = lfs_file_seek(&LFS_filesystem, &file, 0, LFS_SEEK_END);
     if (seek_result < 0) {
         LOG_message(LOG_SYSTEM_LFS, LOG_SEVERITY_CRITICAL, LOG_all_sinks_except(LOG_SINK_FILE), "Error seeking within file: %s", file_name);
         return seek_result;
     }
 
-    const int8_t write_result = lfs_file_write(&LFS_filesystem, &file, write_buffer, write_buffer_len);
+    const lfs_ssize_t write_result = lfs_file_write(&LFS_filesystem, &file, write_buffer, write_buffer_len);
     if (write_result < 0) {
         LOG_message(LOG_SYSTEM_LFS, LOG_SEVERITY_CRITICAL, LOG_all_sinks_except(LOG_SINK_FILE), "Error writing to file %s", file_name);
         return write_result;


### PR DESCRIPTION
Fixed bug where smaller size data types would cause returned function values to go outside type bounds:

For example:
`uint8_t temp1 = example_function();`

If the`example_function()` returns 257, then the `temp1` variable will have the value 1 because of overflow.