### PR TITLE
Rename old I2C scanner to 'i2c_scan_bus_verbose', add smaller-output version

### DIFF
--- a/firmware/Core/Inc/telecommands/i2c_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/i2c_telecommand_defs.h
@@ -4,9 +4,13 @@
 #include <stdint.h>
 #include "telecommand_exec/telecommand_definitions.h"
 
+uint8_t TCMDEXEC_scan_i2c_bus_verbose(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len);
 
-
-uint8_t TCMDEXEC_scan_i2c_bus(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len);
+uint8_t TCMDEXEC_scan_i2c_bus(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len
+);
 
 #endif /* INCLUDE_GUARD__I2C_TELECOMMAND_DEFS_H__*/

--- a/firmware/Core/Src/eps_drivers/eps_channel_control.c
+++ b/firmware/Core/Src/eps_drivers/eps_channel_control.c
@@ -21,7 +21,7 @@ EPS_CHANNEL_enum_t EPS_channel_from_str(const char channel_name[]) {
     if (strcmp(channel_name, "5") == 0) return EPS_CHANNEL_3V3_STACK;
     if (strcmp(channel_name, "6") == 0) return EPS_CHANNEL_3V3_CAMERA;
     if (strcmp(channel_name, "7") == 0) return EPS_CHANNEL_3V3_UHF_ANTENNA_DEPLOY;
-    if (strcmp(channel_name, "8") == 0) return EPS_CHANNEL_3V3_LORA_MODULE;
+    if (strcmp(channel_name, "8") == 0) return EPS_CHANNEL_3V3_LORA_MODULE; // Engg Model ADCS
     if (strcmp(channel_name, "9") == 0) return EPS_CHANNEL_VBATT_CH9_UNUSED;
     if (strcmp(channel_name, "10") == 0) return EPS_CHANNEL_VBATT_CH10_UNUSED;
     if (strcmp(channel_name, "11") == 0) return EPS_CHANNEL_VBATT_CH11_UNUSED;

--- a/firmware/Core/Src/telecommands/i2c_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/i2c_telecommand_defs.c
@@ -7,13 +7,14 @@
 const uint32_t I2C_scan_number_of_trials = 3;
 const uint32_t I2C_scan_timeout_ms = 5;
 
-/// @brief Scans the I2C bus for devices. Prints out the addresses of devices found.
+/// @brief Scans the I2C bus for devices. Prints out a grid of all devices, with addresses for those found.
 /// @param args_str
 /// - Arg 0: I2C bus to scan (1-4)
 /// @return 0 if successful, 1 if error.
-uint8_t TCMDEXEC_scan_i2c_bus(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len) {
-
+uint8_t TCMDEXEC_scan_i2c_bus_verbose(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len
+) {
     I2C_HandleTypeDef* hi2c;
     const uint8_t bus_to_scan = atoi(args_str);
 
@@ -92,5 +93,79 @@ uint8_t TCMDEXEC_scan_i2c_bus(const char *args_str, TCMD_TelecommandChannel_enum
         count_success, count_error, count_timeout, count_busy, count_misc
     );
     
+    return 0;
+}
+
+/// @brief Scans the I2C bus for devices. Prints out the addresses of devices found.
+/// @param args_str
+/// - Arg 0: I2C bus to scan (1-4)
+/// @return 0 if successful, 1 if error.
+uint8_t TCMDEXEC_scan_i2c_bus(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len
+) {
+    I2C_HandleTypeDef* hi2c;
+    const uint8_t bus_to_scan = atoi(args_str);
+
+    switch(bus_to_scan) {
+        case 1: hi2c = &hi2c1; break;
+        case 2: hi2c = &hi2c2; break;
+        case 3: hi2c = &hi2c3; break;
+        case 4: hi2c = &hi2c4; break;
+        default:
+            snprintf(response_output_buf, response_output_buf_len, "Enter a valid I2C bus!\n");
+            return 1;
+    }
+
+    uint8_t state_counts[5] = {0}; // [OK, ERROR, BUSY, TIMEOUT, MISC]
+    HAL_StatusTypeDef address_states[128];
+
+    // Scan the bus
+    for (uint16_t i = 0; i < 128; i++) {
+        address_states[i] = HAL_I2C_IsDeviceReady(hi2c, (i<<1), I2C_scan_number_of_trials, I2C_scan_timeout_ms);
+        switch (address_states[i]) {
+            case HAL_OK: state_counts[0]++; break;
+            case HAL_ERROR: state_counts[1]++; break;
+            case HAL_BUSY: state_counts[2]++; break;
+            case HAL_TIMEOUT: state_counts[3]++; break;
+            default: state_counts[4]++; break;
+        }
+    }
+
+    // Determine majority state
+    uint8_t majority_state = 0;
+    uint8_t max_count = state_counts[0];
+    for (uint8_t j = 1; j < 5; j++) {
+        if (state_counts[j] > max_count) {
+            max_count = state_counts[j];
+            majority_state = j;
+        }
+    }
+
+    // Print deviating addresses
+    snprintf(
+        response_output_buf, response_output_buf_len, "Majority State: %s\n", 
+        majority_state == 0 ? "OK" : 
+        majority_state == 1 ? "ERROR" : 
+        majority_state == 2 ? "BUSY" : 
+        majority_state == 3 ? "TIMEOUT" : "MISC"
+    );
+
+    size_t buf_len = strlen(response_output_buf);
+    for (uint16_t i = 0; i < 128; i++) {
+        if (address_states[i] != majority_state) {
+            const size_t remaining_space = response_output_buf_len - buf_len - 1;
+            if (remaining_space <= 0) break;
+
+            char msg[32];
+            snprintf(msg, sizeof(msg), "0x%02x: %s\n", i, 
+            address_states[i] == HAL_OK ? "OK" : 
+            address_states[i] == HAL_ERROR ? "ERROR" : 
+            address_states[i] == HAL_TIMEOUT ? "TIMEOUT" : 
+            address_states[i] == HAL_BUSY ? "BUSY" : "MISC");
+            strncat(response_output_buf, msg, remaining_space);
+            buf_len = strlen(response_output_buf);
+        }
+    }
     return 0;
 }

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -109,6 +109,12 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
+    {
+        .tcmd_name = "scan_i2c_bus_verbose",
+        .tcmd_func = TCMDEXEC_scan_i2c_bus_verbose,
+        .number_of_args = 1,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
 
     // ****************** SECTION: uart_telecommand_defs ******************
     {


### PR DESCRIPTION
Telecommand to test: `scan_i2c_bus`.

The old telecommand, which was previously named `scan_i2c_bus`, is now named `scan_i2c_bus_verbose`. Test with the flatsat using the ADCS.