### PR TITLE
Migrate logging calls to `LOG_message`

### DIFF
--- a/firmware/Core/Inc/debug_tools/debug_i2c.h
+++ b/firmware/Core/Inc/debug_tools/debug_i2c.h
@@ -8,8 +8,5 @@
 #include <stdint.h>
 
 
-void DEBUG_i2c_scan(I2C_HandleTypeDef *hi2c);
-
-
 
 #endif // INCLUDE_GUARD__DEBUG_I2C_H__

--- a/firmware/Core/Inc/eps_drivers/eps_internal_drivers.h
+++ b/firmware/Core/Inc/eps_drivers/eps_internal_drivers.h
@@ -6,15 +6,6 @@
 
 // #pragma region Constants
 
-// Note: EPS_I2C_ADDR is left-shifted by 1 to be compatible with the HAL_I2C functions
-// const uint8_t EPS_I2C_ADDR = (0x20 << 1); // EPS I2C address
-// const uint8_t EPS_COMMAND_STID = 0x1A; // "System Type Identifier (STID)" (Software ICD, page 17)
-// const uint8_t EPS_COMMAND_IVID = 0x07; // "Interface Version Identifier (IVID)" (Software ICD, page 18)
-// const uint8_t EPS_COMMAND_BID = 0x01; // "Board Identifier (BID)" (Software ICD, page 20)
-// const uint8_t EPS_DEFAULT_RX_LEN_MIN = 5; // for commands with no response params, 5 bytes are returned
-// const uint8_t EPS_ENABLE_DEBUG_PRINT = 1; // bool; 0 to disable
-// const uint32_t EPS_MAX_RESPONSE_POLL_TIME_MS = 100;
-
 #define EPS_I2C_ADDR (0x20 << 1) // EPS I2C address
 
 #define EPS_COMMAND_STID 0x1A // "System Type Identifier (STID)" (Software ICD, page 17)
@@ -22,8 +13,6 @@
 #define EPS_COMMAND_BID 0x00 // "Board Identifier (BID)" (Software ICD, page 20)
 
 #define EPS_DEFAULT_RX_LEN_MIN 5 // for commands with no response params, 5 bytes are returned
-
-#define EPS_ENABLE_DEBUG_PRINT 1 // bool; 0 to disable
 
 #define EPS_MAX_RESPONSE_POLL_TIME_MS 100
 

--- a/firmware/Core/Src/config/configuration.c
+++ b/firmware/Core/Src/config/configuration.c
@@ -6,6 +6,7 @@
 
 extern uint32_t TASK_heartbeat_period_ms;
 extern uint32_t TCMD_require_valid_sha256;
+extern uint32_t CONFIG_EPS_enable_uart_debug_print;
 
 uint32_t CONFIG_int_demo_var_1 = 13345;
 uint32_t CONFIG_int_demo_var_2 = 242344;
@@ -41,6 +42,11 @@ CONFIG_integer_config_entry_t CONFIG_int_config_variables[] = {
         .variable_name = "TCMD_require_unique_tssent",
         .num_config_var = &TCMD_require_unique_tssent,
     },
+
+    {
+        .variable_name = "CONFIG_EPS_enable_uart_debug_print",
+        .num_config_var = &CONFIG_EPS_enable_uart_debug_print,
+    }
 };
 
 // extern

--- a/firmware/Core/Src/debug_tools/debug_i2c.c
+++ b/firmware/Core/Src/debug_tools/debug_i2c.c
@@ -7,25 +7,3 @@
 #include <stdint.h>
 #include <string.h>
 
-
-void DEBUG_i2c_scan(I2C_HandleTypeDef *hi2c) {
-	DEBUG_uart_print_str("Starting I2C scan...\n");
-
-	char msg[5];
-	// Go through all possible i2c addresses
-	for (uint8_t i = 0; i < 128; i++) {
-
-		if (HAL_I2C_IsDeviceReady(hi2c, (uint16_t)(i<<1), 3, 5) == HAL_OK) {
-			// We got an ack
-			sprintf(msg, "%2x ", i);
-			DEBUG_uart_print_str(msg);
-		} else {
-			DEBUG_uart_print_str("-- ");
-		}
-
-	if (i > 0 && (i + 1) % 16 == 0) DEBUG_uart_print_str("\n");
-
-	}
-
-	DEBUG_uart_print_str("\n");
-}

--- a/firmware/Core/Src/eps_drivers/eps_internal_drivers.c
+++ b/firmware/Core/Src/eps_drivers/eps_internal_drivers.c
@@ -15,8 +15,12 @@
 extern UART_HandleTypeDef *UART_eps_port_handle;
 
 // TODO: please verify these numbers in the Software ICD, and remove this comment when satisfied.
-const uint32_t EPS_RX_TIMEOUT_BEFORE_FIRST_BYTE_MS = 50;
-const uint32_t EPS_RX_TIMEOUT_BETWEEN_BYTES_MS = 25;
+static const uint32_t EPS_TX_TIMEOUT_MS = 1000;
+static const uint32_t EPS_RX_TIMEOUT_BEFORE_FIRST_BYTE_MS = 50;
+static const uint32_t EPS_RX_TIMEOUT_BETWEEN_BYTES_MS = 25;
+
+/// @brief When enabled, the EPS's raw data is sent to the debug UART.
+uint32_t CONFIG_EPS_enable_uart_debug_print = 0;
 
 /// @brief Sends a command to the EPS, and receives the response.
 /// @param cmd_buf Array of bytes to send to the EPS, including the command code, STID, IVID, etc.
@@ -25,185 +29,174 @@ const uint32_t EPS_RX_TIMEOUT_BETWEEN_BYTES_MS = 25;
 /// @param rx_buf_len Length of the response buffer. Must be the command length.
 /// @return 0 on success, >0 if error.
 uint8_t EPS_send_cmd_get_response(
-		const uint8_t cmd_buf[], uint8_t cmd_buf_len,
-		uint8_t rx_buf[], uint16_t rx_buf_len
-	) {
+        const uint8_t cmd_buf[], uint8_t cmd_buf_len,
+        uint8_t rx_buf[], uint16_t rx_buf_len
+    ) {
 
-	// ASSERT: rx_buf_len must be >= 5 for all commands. Raise error if it's less.
-	if (rx_buf_len < EPS_DEFAULT_RX_LEN_MIN) return 1;
+    // ASSERT: rx_buf_len must be >= 5 for all commands. Raise error if it's less.
+    if (rx_buf_len < EPS_DEFAULT_RX_LEN_MIN) return 1;
 
-	const uint8_t begin_tag_len = 5; // len of "<cmd>" and "<rsp>", without null terminator
-	const uint8_t end_tag_len = 6; // len of "</cmd>" and "</rsp>", without null terminator
+    const uint8_t begin_tag_len = 5; // len of "<cmd>" and "<rsp>", without null terminator
+    const uint8_t end_tag_len = 6; // len of "</cmd>" and "</rsp>", without null terminator
 
-	// Create place to store "<cmd>ACTUAL COMMAND BYTES</cmd>" (needs about 15 extra chars for tags),
-	// and same for receive buffer.
-	const uint16_t cmd_buf_with_tags_len = cmd_buf_len + begin_tag_len + end_tag_len;
-	const uint16_t rx_len_with_tags = rx_buf_len + begin_tag_len + end_tag_len;
-	uint8_t cmd_buf_with_tags[cmd_buf_with_tags_len];
-	memset(cmd_buf_with_tags, 0, cmd_buf_with_tags_len);
+    // Create place to store "<cmd>ACTUAL COMMAND BYTES</cmd>" (needs about 15 extra chars for tags),
+    // and same for receive buffer.
+    const uint16_t cmd_buf_with_tags_len = cmd_buf_len + begin_tag_len + end_tag_len;
+    const uint16_t rx_len_with_tags = rx_buf_len + begin_tag_len + end_tag_len;
+    uint8_t cmd_buf_with_tags[cmd_buf_with_tags_len];
+    memset(cmd_buf_with_tags, 0, cmd_buf_with_tags_len);
 
-	// pack the cmd_buf_with_tags buffer
+    // pack the cmd_buf_with_tags buffer
     strcpy((char*) cmd_buf_with_tags, "<cmd>");
     memcpy(&cmd_buf_with_tags[begin_tag_len], cmd_buf, cmd_buf_len);
     strcpy((char*)&cmd_buf_with_tags[begin_tag_len+cmd_buf_len], "</cmd>");
 
-	if (EPS_ENABLE_DEBUG_PRINT) {
-		DEBUG_uart_print_str("OBC->EPS DATA (no tags): ");
-		DEBUG_uart_print_array_hex(cmd_buf, cmd_buf_len);
-		DEBUG_uart_print_str("\nOBC->EPS DATA (with tags): ");
-		DEBUG_uart_print_array_hex(cmd_buf_with_tags, cmd_buf_with_tags_len);
-		DEBUG_uart_print_str("\n");
-	}
+    if (CONFIG_EPS_enable_uart_debug_print) {
+        DEBUG_uart_print_str("OBC->EPS DATA (no tags): ");
+        DEBUG_uart_print_array_hex(cmd_buf, cmd_buf_len);
+        DEBUG_uart_print_str("\nOBC->EPS DATA (with tags): ");
+        DEBUG_uart_print_array_hex(cmd_buf_with_tags, cmd_buf_with_tags_len);
+        DEBUG_uart_print_str("\n");
+    }
 
-	// TX TO EPS
-	const HAL_StatusTypeDef tx_status = HAL_UART_Transmit(
-		UART_eps_port_handle,
-		cmd_buf_with_tags, cmd_buf_with_tags_len, 1000); // FIXME: update the timeout
-	if (tx_status != HAL_OK) {
-		if (EPS_ENABLE_DEBUG_PRINT) {
-			char msg[200];
-			sprintf(msg, "OBC->EPS ERROR: tx_status != HAL_OK (%d)\n", tx_status);
-			DEBUG_uart_print_str(msg);
-		}
-		return 2;
-	}
+    // TX TO EPS
+    const HAL_StatusTypeDef tx_status = HAL_UART_Transmit(
+        UART_eps_port_handle,
+        cmd_buf_with_tags, cmd_buf_with_tags_len, EPS_TX_TIMEOUT_MS
+    );
+    if (tx_status != HAL_OK) {
+        LOG_message(
+            LOG_SYSTEM_EPS, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+            "OBC->EPS: tx_status != HAL_OK (%d)", tx_status
+        );
+        return 2;
+    }
 
-	// Reset the EPS UART interrupt variables
-	UART_eps_is_expecting_data = 0; // Lock writing to the UART_eps_buffer while we memset it
-	for (uint16_t i = 0; i < UART_eps_buffer_len; i++) {
-		// Clear the buffer
-		// Can't use memset because UART_eps_buffer is volatile
-		UART_eps_buffer[i] = 0;
-	}
-	UART_eps_buffer_write_idx = 0; // Make it start writing from the start
-	UART_eps_is_expecting_data = 1; // We are now expecting a response
+    // Reset the EPS UART interrupt variables
+    UART_eps_is_expecting_data = 0; // Lock writing to the UART_eps_buffer while we memset it
+    for (uint16_t i = 0; i < UART_eps_buffer_len; i++) {
+        // Clear the buffer
+        // Can't use memset because UART_eps_buffer is volatile
+        UART_eps_buffer[i] = 0;
+    }
+    UART_eps_buffer_write_idx = 0; // Make it start writing from the start
+    UART_eps_is_expecting_data = 1; // We are now expecting a response
 
-	// RX FROM EPS, into UART_eps_buffer
-	// End when we timeout, when we receive the expected number of bytes.
-	const uint32_t start_rx_time = HAL_GetTick();
-	while (1) {
-		// Check if we've received the expected number of bytes
-		if (UART_eps_buffer_write_idx >= rx_len_with_tags) {
-			// Best-case: we've received the expected number of bytes, and can be done!
-			break;
-		}
+    // RX FROM EPS, into UART_eps_buffer
+    // End when we timeout, when we receive the expected number of bytes.
+    const uint32_t start_rx_time = HAL_GetTick();
+    while (1) {
+        // Check if we've received the expected number of bytes
+        if (UART_eps_buffer_write_idx >= rx_len_with_tags) {
+            // Best-case: we've received the expected number of bytes, and can be done!
+            break;
+        }
 
-		if ((UART_eps_buffer_write_idx == 0)) {
-			// Check if we've timed out (before the first byte)
-			if ((HAL_GetTick() - start_rx_time) > EPS_RX_TIMEOUT_BEFORE_FIRST_BYTE_MS) {
-				if (EPS_ENABLE_DEBUG_PRINT) {
-					DEBUG_uart_print_str("EPS->OBC ERROR: timeout before first byte received\n");
-				}
-				// fatal error; return
-				return 3;
-			}
-		}
-		else { // thus, UART_eps_buffer_write_idx > 0
-			// Check if we've timed out (between bytes)
-			const uint32_t cur_time = HAL_GetTick();
-			// Note: Sometimes, because ISRs and C are fun, the UART_eps_last_write_time_ms is
-			// greater than `cur_time`. Thus, we must do a safety check that the time difference
-			// is positive.
-			if (
-				(cur_time > UART_eps_last_write_time_ms) // Important seemingly-obvious safety check.
-				&& ((cur_time - UART_eps_last_write_time_ms) > EPS_RX_TIMEOUT_BETWEEN_BYTES_MS)
-			) {
-				if (EPS_ENABLE_DEBUG_PRINT) {
-					LOG_message(
-						LOG_SYSTEM_EPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
-						"EPS->OBC WARNING: timeout between bytes. UART_eps_last_write_time_ms=%lu, cur_time=%lu",
-						UART_eps_last_write_time_ms,
-						cur_time
-					);
-				}
-				// Non-fatal error; try to parse what we received
-				break;
-			}
-		}
+        if ((UART_eps_buffer_write_idx == 0)) {
+            // Check if we've timed out (before the first byte)
+            if ((HAL_GetTick() - start_rx_time) > EPS_RX_TIMEOUT_BEFORE_FIRST_BYTE_MS) {
+                LOG_message(
+                    LOG_SYSTEM_EPS, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+                    "EPS->OBC: timeout before first byte received"
+                );
+                // fatal error; return
+                return 3;
+            }
+        }
+        else { // thus, UART_eps_buffer_write_idx > 0
+            // Check if we've timed out (between bytes)
+            const uint32_t cur_time = HAL_GetTick();
+            // Note: Sometimes, because ISRs and C are fun, the UART_eps_last_write_time_ms is
+            // greater than `cur_time`. Thus, we must do a safety check that the time difference
+            // is positive.
+            if (
+                (cur_time > UART_eps_last_write_time_ms) // Important seemingly-obvious safety check.
+                && ((cur_time - UART_eps_last_write_time_ms) > EPS_RX_TIMEOUT_BETWEEN_BYTES_MS)
+            ) {
+                LOG_message(
+                    LOG_SYSTEM_EPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+                    "EPS->OBC: timeout between bytes. UART_eps_last_write_time_ms=%lu, cur_time=%lu",
+                    UART_eps_last_write_time_ms,
+                    cur_time
+                );
+                // Non-fatal error; try to parse what we received
+                break;
+            }
+        }
 
-		// TODO: also end when we receive the end tag
-	}
+        // TODO: also end when we receive the end tag
+    }
 
-	// End Receiving
-	UART_eps_is_expecting_data = 0; // We are no longer expecting a response
+    // End Receiving
+    UART_eps_is_expecting_data = 0; // We are no longer expecting a response
 
-	// For now, log the received bytes
-	DEBUG_uart_print_str("EPS->OBC DATA (with tags): ");
-	DEBUG_uart_print_array_hex((uint8_t*)UART_eps_buffer, UART_eps_buffer_write_idx);
-	DEBUG_uart_print_str("\n");
+    // For now, log the received bytes
+    DEBUG_uart_print_str("EPS->OBC DATA (with tags): ");
+    DEBUG_uart_print_array_hex((uint8_t*)UART_eps_buffer, UART_eps_buffer_write_idx);
+    DEBUG_uart_print_str("\n");
 
-	// Check that we've received what we're expecting
-	// TODO: if the following cases happen ever during testing, consider allowing them and treating them as WARNINGs
-	if (UART_eps_buffer_write_idx == 0) {
-		if (EPS_ENABLE_DEBUG_PRINT) {
-			DEBUG_uart_print_str("EPS->OBC ERROR: UART_eps_buffer_write_idx == 0\n");
-		}
-		return 12;
-	}
-	else if (UART_eps_buffer_write_idx < begin_tag_len + EPS_DEFAULT_RX_LEN_MIN + end_tag_len) {
-		if (EPS_ENABLE_DEBUG_PRINT) {
-			char msg[200];
-			snprintf(
-				msg, sizeof(msg),
-				"EPS->OBC ERROR: UART_eps_buffer_write_idx < begin_tag_len + EPS_DEFAULT_RX_LEN_MIN + end_tag_len (%d < %d)\n",
-				UART_eps_buffer_write_idx, begin_tag_len+EPS_DEFAULT_RX_LEN_MIN+end_tag_len);
-			DEBUG_uart_print_str(msg);
-		}
-		return 13;
-	}
-	else if (UART_eps_buffer_write_idx < rx_len_with_tags) {
-		if (EPS_ENABLE_DEBUG_PRINT) {
-			char msg[200];
-			snprintf(
-				msg, sizeof(msg),
-				"EPS->OBC ERROR: UART_eps_buffer_write_idx < rx_len_with_tags (%d < %d)\n",
-				UART_eps_buffer_write_idx, rx_len_with_tags);
-			DEBUG_uart_print_str(msg);
-		}
-		return 14;
-	}
-	else if (UART_eps_buffer_write_idx > (rx_len_with_tags+2)) {
-		// The +2 is for a "\r\n" that might be appended to the end of the response
-		if (EPS_ENABLE_DEBUG_PRINT) {
-			char msg[200];
-			snprintf(
-				msg, sizeof(msg),
-				"EPS->OBC WARNING: UART_eps_buffer_write_idx > rx_len_with_tags+2 (%d > %d+2)\n",
-				UART_eps_buffer_write_idx, rx_len_with_tags);
-			DEBUG_uart_print_str(msg);
-		}
-		return 15;
-	}
+    // Check that we've received what we're expecting
+    // TODO: if the following cases happen ever during testing, consider allowing them and treating them as WARNINGs
+    if (UART_eps_buffer_write_idx == 0) {
+        LOG_message(
+            LOG_SYSTEM_EPS, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+            "EPS->OBC: UART_eps_buffer_write_idx == 0"
+        );
+        
+        return 12;
+    }
+    else if (UART_eps_buffer_write_idx < begin_tag_len + EPS_DEFAULT_RX_LEN_MIN + end_tag_len) {
+        LOG_message(
+            LOG_SYSTEM_EPS, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+            "EPS->OBC: UART_eps_buffer_write_idx < begin_tag_len + EPS_DEFAULT_RX_LEN_MIN + end_tag_len (%d < %d)",
+            UART_eps_buffer_write_idx, begin_tag_len+EPS_DEFAULT_RX_LEN_MIN+end_tag_len
+        );
+        return 13;
+    }
+    else if (UART_eps_buffer_write_idx < rx_len_with_tags) {
+        LOG_message(
+            LOG_SYSTEM_EPS, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+            "EPS->OBC: UART_eps_buffer_write_idx < rx_len_with_tags (%d < %d)",
+            UART_eps_buffer_write_idx, rx_len_with_tags
+        );
+        return 14;
+    }
+    else if (UART_eps_buffer_write_idx > (rx_len_with_tags+2)) {
+        // The +2 is for a "\r\n" that might be appended to the end of the response
+        LOG_message(
+            LOG_SYSTEM_EPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+            "EPS->OBC: UART_eps_buffer_write_idx > rx_len_with_tags+2 (%d > %d+2)",
+            UART_eps_buffer_write_idx, rx_len_with_tags
+        );
+        return 15;
+    }
 
-	// FIXME: pack the rx_buf less-naively (check/confirm the start tag location)
+    // FIXME: pack the rx_buf less-naively (check/confirm the start tag location)
 
-	// Copy the received bytes into the rx_buf.
-	// Can't use memcpy because UART_eps_buffer is volatile.
-	for (uint16_t i = 0; i < rx_buf_len; i++) {
-		rx_buf[i] = UART_eps_buffer[begin_tag_len + i];
-	}
+    // Copy the received bytes into the rx_buf.
+    // Can't use memcpy because UART_eps_buffer is volatile.
+    for (uint16_t i = 0; i < rx_buf_len; i++) {
+        rx_buf[i] = UART_eps_buffer[begin_tag_len + i];
+    }
 
-	if (EPS_ENABLE_DEBUG_PRINT) {
-		DEBUG_uart_print_str("EPS->OBC DATA (no tags): ");
-		DEBUG_uart_print_array_hex(rx_buf, rx_buf_len);
-		DEBUG_uart_print_str("\n");
-	}
+    if (CONFIG_EPS_enable_uart_debug_print) {
+        DEBUG_uart_print_str("EPS->OBC DATA (no tags): ");
+        DEBUG_uart_print_array_hex(rx_buf, rx_buf_len);
+        DEBUG_uart_print_str("\n");
+    }
 
-	// Check STAT field (Table 3-11) - 0x00 and 0x80 mean success
-	// TODO: consider doing this check in the next level up
-	const uint8_t eps_stat_field = rx_buf[4];
-	if ((eps_stat_field != 0x00) && (eps_stat_field != 0x80)) {
-		if (EPS_ENABLE_DEBUG_PRINT) {
-			char msg[100];
-			snprintf(
-				msg, sizeof(msg),
-				"EPS returned an error in the STAT field: 0x%02x (see EPS_SICD Table 3-11)\n",
-				eps_stat_field);
-			DEBUG_uart_print_str(msg);
-		}
-	}
+    // Check STAT field (Table 3-11) - 0x00 and 0x80 mean success.
+    const uint8_t eps_stat_field = rx_buf[4];
+    if ((eps_stat_field != 0x00) && (eps_stat_field != 0x80)) {
+        // Only a warning. Non-fatal. Not propagated up.
+        LOG_message(
+            LOG_SYSTEM_EPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+            "EPS returned an error in the STAT field: 0x%02x (see EPS_SICD Table 3-11)",
+            eps_stat_field
+        );
+    }
 
-	return 0;
+    return 0;
 }
 
 
@@ -211,17 +204,17 @@ uint8_t EPS_send_cmd_get_response(
 /// @param command_code Command code number.
 /// @return 0 on success, >0 if error.
 uint8_t EPS_run_argumentless_cmd(uint8_t command_code) {
-	const uint8_t cmd_len = 4;
-	const uint8_t rx_len = EPS_DEFAULT_RX_LEN_MIN;
+    const uint8_t cmd_len = 4;
+    const uint8_t rx_len = EPS_DEFAULT_RX_LEN_MIN;
 
-	uint8_t cmd_buf[cmd_len];
-	uint8_t rx_buf[rx_len];
-	
-	cmd_buf[0] = EPS_COMMAND_STID;
-	cmd_buf[1] = EPS_COMMAND_IVID;
-	cmd_buf[2] = command_code; // "CC"
-	cmd_buf[3] = EPS_COMMAND_BID;
+    uint8_t cmd_buf[cmd_len];
+    uint8_t rx_buf[rx_len];
+    
+    cmd_buf[0] = EPS_COMMAND_STID;
+    cmd_buf[1] = EPS_COMMAND_IVID;
+    cmd_buf[2] = command_code; // "CC"
+    cmd_buf[3] = EPS_COMMAND_BID;
 
-	const uint8_t comms_err = EPS_send_cmd_get_response(cmd_buf, cmd_len, rx_buf, rx_len);
-	return comms_err;
+    const uint8_t comms_err = EPS_send_cmd_get_response(cmd_buf, cmd_len, rx_buf, rx_len);
+    return comms_err;
 }

--- a/firmware/Core/Src/log/log.c
+++ b/firmware/Core/Src/log/log.c
@@ -56,10 +56,11 @@ static LOG_memory_entry_t LOG_memory_table[LOG_MEMORY_NUMBER_OF_ENTRIES] = {0};
 // Start at last position in table, as first call to LOG_message will roll this to 0
 static uint8_t LOG_memory_index_of_current_log_entry = LOG_MEMORY_NUMBER_OF_ENTRIES - 1;
 
-// severity masking
+// Severity masking.
 static const uint8_t LOG_SEVERITY_MASK_ALL = 0xFF;
-// No debugging messages by default
-static const uint8_t LOG_SEVERITY_MASK_DEFAULT = LOG_SEVERITY_MASK_ALL & ~(uint8_t)LOG_SEVERITY_DEBUG;
+// TODO: Set mask to: No debugging messages by default.
+// static const uint8_t LOG_SEVERITY_MASK_DEFAULT = LOG_SEVERITY_MASK_ALL & ~(uint8_t)LOG_SEVERITY_DEBUG;
+static const uint8_t LOG_SEVERITY_MASK_DEFAULT = LOG_SEVERITY_MASK_ALL;
 
 // Note: LOG_sinks entries must have same order as LOG_sink_enum_t entries.
 // The in-memory log table is a combination of working memory for constructing

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -60,20 +60,16 @@ void TASK_DEBUG_print_heartbeat(void *argument) {
             seconds = (time_t)(unix_time_ms/ 1000U);
             ms = unix_time_ms - 1000U * seconds;
             time_info = gmtime(&seconds);
-            snprintf(
-                TASK_heartbeat_timing_str,
-                sizeof(TASK_heartbeat_timing_str),
-                "FrontierSat time: %d%02d%02dT%02d:%02d:%02d.%03u, Uptime: %lu ms\n",
+            
+            LOG_message(
+                LOG_SYSTEM_OBC, LOG_SEVERITY_DEBUG, LOG_SINK_ALL,
+                "Heartbeat: FrontierSat time: %d%02d%02dT%02d:%02d:%02d.%03u, Uptime: %lu ms\n",
                 time_info->tm_year + 1900, time_info->tm_mon + 1, time_info->tm_mday,
                 time_info->tm_hour, time_info->tm_min, time_info->tm_sec, ms,
                 HAL_GetTick()
             );
 
             // TODO: Radio beacon here, probably.
-            LOG_message(
-                LOG_SYSTEM_OBC, LOG_SEVERITY_DEBUG, LOG_SINK_ALL,
-                TASK_heartbeat_timing_str
-            );
         }
         HAL_GPIO_TogglePin(PIN_LED_DEVKIT_LD2_GPIO_Port, PIN_LED_DEVKIT_LD2_Pin);
         HAL_GPIO_TogglePin(PIN_LED_GP2_OUT_GPIO_Port, PIN_LED_GP2_OUT_Pin);

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks.c
@@ -20,213 +20,219 @@
 #include <time.h>
 
 /// @brief The period of the heartbeat task, in milliseconds. 0 to disable.
-uint32_t TASK_heartbeat_period_ms = 990;
+uint32_t TASK_heartbeat_period_ms = 10990;
 
 char TASK_heartbeat_timing_str[128] = {0};
 
 void TASK_DEBUG_print_heartbeat(void *argument) {
-	TASK_HELP_start_of_task();
+    TASK_HELP_start_of_task();
 
-	LOG_message(
-		LOG_SYSTEM_OBC, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
-		"TASK_DEBUG_print_heartbeat() -> started (booted)."
-	);
+    LOG_message(
+        LOG_SYSTEM_OBC, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+        "TASK_DEBUG_print_heartbeat() -> started (booted)."
+    );
 
-	// Fetch the reset cause right upon boot so that it is logged for each boot immediately.
-	const char* STM32_reset_cause_name = STM32_reset_cause_enum_to_str(STM32_get_reset_cause());
-	LOG_message(
-		LOG_SYSTEM_OBC, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
-		"Reset reason: %s.", STM32_reset_cause_name
-	);
+    // Fetch the reset cause right upon boot so that it is logged for each boot immediately.
+    const char* STM32_reset_cause_name = STM32_reset_cause_enum_to_str(STM32_get_reset_cause());
+    LOG_message(
+        LOG_SYSTEM_OBC, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+        "Reset reason: %s.", STM32_reset_cause_name
+    );
 
-	// Blink the LED a few times to show that the boot just happened.
-	for (uint8_t i = 0; i < 6; i++) {
-		HAL_GPIO_TogglePin(PIN_LED_DEVKIT_LD2_GPIO_Port, PIN_LED_DEVKIT_LD2_Pin);
-		HAL_GPIO_TogglePin(PIN_LED_GP2_OUT_GPIO_Port, PIN_LED_GP2_OUT_Pin);
+    // Blink the LED a few times to show that the boot just happened.
+    for (uint8_t i = 0; i < 6; i++) {
+        HAL_GPIO_TogglePin(PIN_LED_DEVKIT_LD2_GPIO_Port, PIN_LED_DEVKIT_LD2_Pin);
+        HAL_GPIO_TogglePin(PIN_LED_GP2_OUT_GPIO_Port, PIN_LED_GP2_OUT_Pin);
 
-		HAL_Delay(100 + (i*25));
-	}
+        HAL_Delay(100 + (i*25));
+    }
 
-	osDelay(TASK_heartbeat_period_ms > 0 ? TASK_heartbeat_period_ms : 1000);
+    osDelay(TASK_heartbeat_period_ms > 0 ? TASK_heartbeat_period_ms : 1000);
 
     uint64_t unix_time_ms = 0;
     time_t seconds = 0;
     uint16_t ms = 0;
     struct tm *time_info;
 
-	while (1) {
+    while (1) {
         if ((TASK_heartbeat_period_ms > 0)) {
             unix_time_ms = TIM_get_current_unix_epoch_time_ms();
             seconds = (time_t)(unix_time_ms/ 1000U);
             ms = unix_time_ms - 1000U * seconds;
             time_info = gmtime(&seconds);
             snprintf(
-				TASK_heartbeat_timing_str,
-				sizeof(TASK_heartbeat_timing_str),
-				"FrontierSat time: %d%02d%02dT%02d:%02d:%02d.%03u, Uptime: %lu ms\n",
-				time_info->tm_year + 1900, time_info->tm_mon + 1, time_info->tm_mday,
-				time_info->tm_hour, time_info->tm_min, time_info->tm_sec, ms,
-				HAL_GetTick()
-			);
-            DEBUG_uart_print_str(TASK_heartbeat_timing_str);
-		}
-		HAL_GPIO_TogglePin(PIN_LED_DEVKIT_LD2_GPIO_Port, PIN_LED_DEVKIT_LD2_Pin);
-		HAL_GPIO_TogglePin(PIN_LED_GP2_OUT_GPIO_Port, PIN_LED_GP2_OUT_Pin);
+                TASK_heartbeat_timing_str,
+                sizeof(TASK_heartbeat_timing_str),
+                "FrontierSat time: %d%02d%02dT%02d:%02d:%02d.%03u, Uptime: %lu ms\n",
+                time_info->tm_year + 1900, time_info->tm_mon + 1, time_info->tm_mday,
+                time_info->tm_hour, time_info->tm_min, time_info->tm_sec, ms,
+                HAL_GetTick()
+            );
 
-		osDelay(TASK_heartbeat_period_ms > 0 ? TASK_heartbeat_period_ms : 1000);
-	}
+            // TODO: Radio beacon here, probably.
+            LOG_message(
+                LOG_SYSTEM_OBC, LOG_SEVERITY_DEBUG, LOG_SINK_ALL,
+                TASK_heartbeat_timing_str
+            );
+        }
+        HAL_GPIO_TogglePin(PIN_LED_DEVKIT_LD2_GPIO_Port, PIN_LED_DEVKIT_LD2_Pin);
+        HAL_GPIO_TogglePin(PIN_LED_GP2_OUT_GPIO_Port, PIN_LED_GP2_OUT_Pin);
+
+        osDelay(TASK_heartbeat_period_ms > 0 ? TASK_heartbeat_period_ms : 1000);
+    }
 }
 
 
 void TASK_handle_uart_telecommands(void *argument) {
-	TASK_HELP_start_of_task();
+    TASK_HELP_start_of_task();
 
-	// CONFIGURATION PARAMETER
-	uint32_t timeout_duration_ms = 100;
+    // CONFIGURATION PARAMETER
+    uint32_t timeout_duration_ms = 100;
 
-	char latest_tcmd[UART_telecommand_buffer_len];
-	uint16_t latest_tcmd_len = 0;
+    char latest_tcmd[UART_telecommand_buffer_len];
+    uint16_t latest_tcmd_len = 0;
 
-	while (1) {
-		// place the main delay at the top to avoid a "continue" statement skipping it
-		osDelay(400);
+    while (1) {
+        // place the main delay at the top to avoid a "continue" statement skipping it
+        osDelay(400);
 
-		// DEBUG_uart_print_str("TASK_handle_uart_telecommands -> top of while(1)\n");
+        // DEBUG_uart_print_str("TASK_handle_uart_telecommands -> top of while(1)\n");
 
-		memset(latest_tcmd, 0, UART_telecommand_buffer_len);
-		latest_tcmd_len = 0; // 0 means no telecommand available
+        memset(latest_tcmd, 0, UART_telecommand_buffer_len);
+        latest_tcmd_len = 0; // 0 means no telecommand available
 
-		// log the status
-		// char msg[256];
-		// snprintf(msg, sizeof(msg), "UART telecommand buffer: write_index=%d, last_time=%lums\n", UART_telecommand_buffer_write_idx, UART_telecommand_last_write_time_ms);
-		// DEBUG_uart_print_str(msg);
+        // log the status
+        // char msg[256];
+        // snprintf(msg, sizeof(msg), "UART telecommand buffer: write_index=%d, last_time=%lums\n", UART_telecommand_buffer_write_idx, UART_telecommand_last_write_time_ms);
+        // DEBUG_uart_print_str(msg);
 
-		if ((HAL_GetTick() - UART_telecommand_last_write_time_ms > timeout_duration_ms) && (UART_telecommand_buffer_write_idx > 0)) {
-			// Copy the buffer to the latest_tcmd buffer.
-			latest_tcmd_len = UART_telecommand_buffer_write_idx;
-			
-			// MEMCPY, but with volatile-compatible casts.
-			// Copy the whole buffer to ensure nulls get copied too.
-			for (uint16_t i = 0; i < UART_telecommand_buffer_len; i++) {
-				latest_tcmd[i] = (char) UART_telecommand_buffer[i];
-			}
+        if ((HAL_GetTick() - UART_telecommand_last_write_time_ms > timeout_duration_ms) && (UART_telecommand_buffer_write_idx > 0)) {
+            // Copy the buffer to the latest_tcmd buffer.
+            latest_tcmd_len = UART_telecommand_buffer_write_idx;
+            
+            // MEMCPY, but with volatile-compatible casts.
+            // Copy the whole buffer to ensure nulls get copied too.
+            for (uint16_t i = 0; i < UART_telecommand_buffer_len; i++) {
+                latest_tcmd[i] = (char) UART_telecommand_buffer[i];
+            }
 
-			// Set the null terminator at the end of the `latest_tcmd` str.
-			latest_tcmd[latest_tcmd_len] = '\0';
+            // Set the null terminator at the end of the `latest_tcmd` str.
+            latest_tcmd[latest_tcmd_len] = '\0';
 
-			// Clear the buffer (memset to 0, but volatile-compatible) and reset the write pointer.
-			for (uint16_t i = 0; i < UART_telecommand_buffer_len; i++) {
-				UART_telecommand_buffer[i] = 0;
-			}
-			UART_telecommand_buffer_write_idx = 0;
-			// TODO: could do it so that it only clears the part of the buffer which contains a command, to allow multiple commands per buffer
-		}
+            // Clear the buffer (memset to 0, but volatile-compatible) and reset the write pointer.
+            for (uint16_t i = 0; i < UART_telecommand_buffer_len; i++) {
+                UART_telecommand_buffer[i] = 0;
+            }
+            UART_telecommand_buffer_write_idx = 0;
+            // TODO: could do it so that it only clears the part of the buffer which contains a command, to allow multiple commands per buffer
+        }
 
-		if (latest_tcmd_len == 0) {
-			continue;
-		}
+        if (latest_tcmd_len == 0) {
+            continue;
+        }
 
-		DEBUG_uart_print_str("========================= UART Telecommand Received =========================\n");
-		DEBUG_uart_print_str(latest_tcmd);
-		DEBUG_uart_print_str("\n=========================\n");
+        // DEBUG_uart_print_str("========================= UART Telecommand Received =========================\n");
+        // DEBUG_uart_print_str(latest_tcmd);
+        // DEBUG_uart_print_str("\n=========================\n");
 
-		// Parse the telecommand
-		TCMD_parsed_tcmd_to_execute_t parsed_tcmd;
-		uint8_t parse_result = TCMD_parse_full_telecommand(
-			latest_tcmd, TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd
-		);
-		if (parse_result != 0) {
-			DEBUG_uart_print_str("Error parsing telecommand: ");
-			DEBUG_uart_print_uint32(parse_result);
-			DEBUG_uart_print_str("\n");
-			continue;
-		}
+        // Parse the telecommand
+        TCMD_parsed_tcmd_to_execute_t parsed_tcmd;
+        uint8_t parse_result = TCMD_parse_full_telecommand(
+            latest_tcmd, TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd
+        );
+        if (parse_result != 0) {
+            LOG_message(
+                LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+                "Error parsing telecommand: %u", parse_result
+            );
+            continue;
+        }
 
-		// Add the telecommand to the agenda (regardless of whether it's in the future).
-		TCMD_add_tcmd_to_agenda(&parsed_tcmd);
-	
-	} /* End Task's Main Loop */
+        // Add the telecommand to the agenda (regardless of whether it's in the future).
+        TCMD_add_tcmd_to_agenda(&parsed_tcmd);
+    
+    } /* End Task's Main Loop */
 }
 
 void TASK_execute_telecommands(void *argument) {
-	TASK_HELP_start_of_task();
+    TASK_HELP_start_of_task();
 
-	// Note: Must not be less than 200ms since last pet.
-	const uint32_t task_period_for_watchdog_pet_ms = 250;
+    // Note: Must not be less than 200ms since last pet.
+    const uint32_t task_period_for_watchdog_pet_ms = 250;
 
-	// Cannot pet the watchdog too quickly on boot.
-	osDelay(task_period_for_watchdog_pet_ms * 2);
+    // Cannot pet the watchdog too quickly on boot.
+    osDelay(task_period_for_watchdog_pet_ms * 2);
 
-	while (1) {
-		// DEBUG_uart_print_str("TASK_execute_telecommands -> top of while(1)\n");
-		// Pet the watchdog. Must be pet every 16 seconds. Must be >= 200ms since last pet.
-		HAL_IWDG_Refresh(&hiwdg);
+    while (1) {
+        // DEBUG_uart_print_str("TASK_execute_telecommands -> top of while(1)\n");
+        // Pet the watchdog. Must be pet every 16 seconds. Must be >= 200ms since last pet.
+        HAL_IWDG_Refresh(&hiwdg);
 
-		// Get the next telecommand to execute.
-		int16_t next_tcmd_slot = TCMD_get_next_tcmd_agenda_slot_to_execute();
-		if (next_tcmd_slot == -1) {
-			// No telecommands to execute.
-			// DEBUG_uart_print_str("No telecommands to execute.\n");
-			osDelay(task_period_for_watchdog_pet_ms);
-			continue;
-		}
+        // Get the next telecommand to execute.
+        int16_t next_tcmd_slot = TCMD_get_next_tcmd_agenda_slot_to_execute();
+        if (next_tcmd_slot == -1) {
+            // No telecommands to execute.
+            // DEBUG_uart_print_str("No telecommands to execute.\n");
+            osDelay(task_period_for_watchdog_pet_ms);
+            continue;
+        }
 
-		// Execute the telecommand.
-		char response_output_buf[TCMD_MAX_RESPONSE_BUFFER_LENGTH] = {0};
-		TCMD_execute_telecommand_in_agenda(
-			next_tcmd_slot,
-			response_output_buf,
-			sizeof(response_output_buf)
-		);
+        // Execute the telecommand.
+        char response_output_buf[TCMD_MAX_RESPONSE_BUFFER_LENGTH] = {0};
+        TCMD_execute_telecommand_in_agenda(
+            next_tcmd_slot,
+            response_output_buf,
+            sizeof(response_output_buf)
+        );
 
-		// Note: Short yield here only; execute all pending telecommands back-to-back.
-		osDelay(task_period_for_watchdog_pet_ms);
+        // Note: Short yield here only; execute all pending telecommands back-to-back.
+        osDelay(task_period_for_watchdog_pet_ms);
 
-	} /* End Task's Main Loop */
+    } /* End Task's Main Loop */
 }
 
 void TASK_monitor_freertos_memory(void *argument) {
-	TASK_HELP_start_of_task();
+    TASK_HELP_start_of_task();
 
-	osDelay(12000); // Delay for 12 seconds to allow other tasks to start up.
+    osDelay(12000); // Delay for 12 seconds to allow other tasks to start up.
 
-	while (1) {
-		// Place the main delay at the top to avoid a "continue" statement skipping it.
-		osDelay(5000);
+    while (1) {
+        // Place the main delay at the top to avoid a "continue" statement skipping it.
+        osDelay(5000);
 
-		for (uint16_t task_num = 0; task_num < FREERTOS_task_handles_array_size; task_num++) {
-			if (FREERTOS_task_handles_array[task_num].task_handle == NULL) {
-				continue; // Safety check. Should never happen.
-			}
-	
-			// Dereferencing the task_handle pointer
-			const osThreadId_t task_handle = *(FREERTOS_task_handles_array[task_num].task_handle);
+        for (uint16_t task_num = 0; task_num < FREERTOS_task_handles_array_size; task_num++) {
+            if (FREERTOS_task_handles_array[task_num].task_handle == NULL) {
+                continue; // Safety check. Should never happen.
+            }
+    
+            // Dereferencing the task_handle pointer
+            const osThreadId_t task_handle = *(FREERTOS_task_handles_array[task_num].task_handle);
 
-			// Get the highstack watermark
-			const uint32_t task_min_bytes_remaining = uxTaskGetStackHighWaterMark(task_handle) * 4;
+            // Get the highstack watermark
+            const uint32_t task_min_bytes_remaining = uxTaskGetStackHighWaterMark(task_handle) * 4;
 
-			if (task_min_bytes_remaining < FREERTOS_task_handles_array[task_num].lowest_stack_bytes_remaining) {
-				// If this is the new "lowest free space", update that value.
-				FREERTOS_task_handles_array[task_num].lowest_stack_bytes_remaining = task_min_bytes_remaining;
+            if (task_min_bytes_remaining < FREERTOS_task_handles_array[task_num].lowest_stack_bytes_remaining) {
+                // If this is the new "lowest free space", update that value.
+                FREERTOS_task_handles_array[task_num].lowest_stack_bytes_remaining = task_min_bytes_remaining;
 
-				// Determine the threshold of the task
-				const uint32_t task_threshold_bytes = (
-					FREERTOS_task_handles_array[task_num].task_attribute->stack_size
-					* CONFIG_freertos_min_remaining_stack_percent
-					/ 100
-				);
-				
-				// If this new "lowest free space" is below the threshold, warn the user.
-				if (task_min_bytes_remaining < task_threshold_bytes) {
-					LOG_message(
-						LOG_SYSTEM_OBC, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
-						"Warning: Task '%s' approached a stack overflow. Worst remaining stack size was: %lu bytes.",
-						pcTaskGetName(task_handle),
-						task_min_bytes_remaining
-					);
-				}
-			}
-		}
+                // Determine the threshold of the task
+                const uint32_t task_threshold_bytes = (
+                    FREERTOS_task_handles_array[task_num].task_attribute->stack_size
+                    * CONFIG_freertos_min_remaining_stack_percent
+                    / 100
+                );
+                
+                // If this new "lowest free space" is below the threshold, warn the user.
+                if (task_min_bytes_remaining < task_threshold_bytes) {
+                    LOG_message(
+                        LOG_SYSTEM_OBC, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+                        "Warning: Task '%s' approached a stack overflow. Worst remaining stack size was: %lu bytes.",
+                        pcTaskGetName(task_handle),
+                        task_min_bytes_remaining
+                    );
+                }
+            }
+        }
 
-	} /* End Task's Main Loop */
+    } /* End Task's Main Loop */
 }

--- a/firmware/Core/Src/telecommands/agenda_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/agenda_telecommand_defs.c
@@ -15,9 +15,11 @@
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0 on success
-uint8_t TCMDEXEC_agenda_delete_all(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len) {
-    DEBUG_uart_print_str("Deleting all entries from the agenda\n"); 
+uint8_t TCMDEXEC_agenda_delete_all(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len
+) {
+    snprintf(response_output_buf, response_output_buf_len, "Cleared agenda.");
     TCMD_agenda_delete_all();
 
     return 0;

--- a/firmware/Core/Src/telecommands/config_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/config_telecommand_defs.c
@@ -2,6 +2,7 @@
 #include "telecommands/config_telecommand_defs.h"
 #include "config/configuration.h"
 #include "debug_tools/debug_uart.h"
+#include "log/log.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -107,9 +108,10 @@ uint8_t TCMDEXEC_config_get_int_var_json(const char *args_str, TCMD_TelecommandC
 /// @param args_str
 /// - Arg 0: variable name
 /// @return 0 if successful, >0 if an error occurred
-uint8_t TCMDEXEC_config_get_str_var_json(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, char *response_output_buf, uint16_t response_output_buf_len)
-{
-
+uint8_t TCMDEXEC_config_get_str_var_json(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len
+) {
     const uint16_t res = CONFIG_str_var_to_json(args_str, response_output_buf, response_output_buf_len);
     if (res == 1)
     {
@@ -123,9 +125,10 @@ uint8_t TCMDEXEC_config_get_str_var_json(const char *args_str, TCMD_TelecommandC
 /// @brief Get all configuration variables, as JSON. One variable per line.
 /// @param args_str No arguments.
 /// @return 0 if successful, >0 if an error occurred
-uint8_t TCMDEXEC_config_get_all_vars_jsonl(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                                                 char *response_output_buf, uint16_t response_output_buf_len)
-{
+uint8_t TCMDEXEC_config_get_all_vars_jsonl(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len
+) {
     char json_str[CONFIG_MAX_JSON_STRING_LENGTH];
     for (uint8_t i = 0; i < CONFIG_int_config_variables_count; i++)
     {
@@ -134,7 +137,10 @@ uint8_t TCMDEXEC_config_get_all_vars_jsonl(const char *args_str, TCMD_Telecomman
             json_str,
             sizeof(json_str)
         );
-        DEBUG_uart_print_str(json_str);
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            json_str
+        );
     }
     
     for (uint8_t i = 0; i < CONFIG_str_config_variables_count; i++)
@@ -144,7 +150,10 @@ uint8_t TCMDEXEC_config_get_all_vars_jsonl(const char *args_str, TCMD_Telecomman
             json_str,
             sizeof(json_str)
         );
-        DEBUG_uart_print_str(json_str);
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            json_str
+        );
     }
 
     snprintf(

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -5,6 +5,7 @@
 #include "littlefs/flash_driver.h"
 #include "littlefs/flash_benchmark.h"
 #include "debug_tools/debug_uart.h"
+#include "log/log.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -24,17 +25,21 @@ uint8_t TCMDEXEC_flash_activate_each_cs(const char *args_str, TCMD_TelecommandCh
     HAL_Delay(delay_time_ms);
 
     for (uint8_t chip_number = 0; chip_number < FLASH_NUMBER_OF_FLASH_DEVICES; chip_number++) {
-        DEBUG_uart_print_str("Activating CS: ");
-        DEBUG_uart_print_uint32(chip_number);
-        DEBUG_uart_print_str("...\n");
+        LOG_message(
+            LOG_SYSTEM_OBC, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Activating CS: %d", chip_number
+        );
         FLASH_activate_chip_select(chip_number);
         HAL_Delay(delay_time_ms);
 
-        DEBUG_uart_print_str("Deactivated.\n");
+        LOG_message(
+            LOG_SYSTEM_OBC, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Deactivating CS: %d", chip_number
+        );
         FLASH_deactivate_chip_select();
         HAL_Delay(delay_time_ms);
     }
-    strcpy(response_output_buf, "All CS activated and deactivated.\n");
+    snprintf(response_output_buf, response_output_buf_len, "All CS activated and deactivated.");
     return 0;
 }
 

--- a/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
@@ -8,6 +8,7 @@
 #include "telecommands/freertos_telecommand_defs.h"
 #include "debug_tools/debug_uart.h"
 #include "timekeeping/timekeeping.h"
+#include "log/log.h"
 
 #include <stdio.h>
 #include <stdint.h>
@@ -46,15 +47,17 @@ uint8_t TCMDEXEC_freetos_list_tasks_jsonl(const char *args_str, TCMD_Telecommand
     TaskStatus_t task_statuses[number_of_tasks];
 
     if (uxTaskGetSystemState(task_statuses, number_of_tasks, &total_run_time) == 0) {
-        DEBUG_uart_print_str("Error: TCMDEXEC_freetos_list_tasks_jsonl: uxTaskGetSystemState failed.\n");
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+            "Error: TCMDEXEC_freetos_list_tasks_jsonl: uxTaskGetSystemState failed."
+        );
         return 1;
     }
 
     for (UBaseType_t x = 0; x < number_of_tasks; x++) {
         // Get the task state for the x-th task
-        char message_buffer[256];
-        snprintf(
-            message_buffer, sizeof(message_buffer),
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
             "{\"task_name\":\"%s\",\"state\":\"%s\",\"priority\":%lu,\"stack_min_remaining_bytes\":%u,\"runtime\":%lu}\n",
             task_statuses[x].pcTaskName,
             freertos_eTaskState_to_str(task_statuses[x].eCurrentState),
@@ -65,8 +68,6 @@ uint8_t TCMDEXEC_freetos_list_tasks_jsonl(const char *args_str, TCMD_Telecommand
             (task_statuses[x].usStackHighWaterMark * 4),
             task_statuses[x].ulRunTimeCounter
         );
-          
-        DEBUG_uart_print_str(message_buffer);
     }
 
     snprintf(

--- a/firmware/Core/Src/telecommands/telecommand_executor.c
+++ b/firmware/Core/Src/telecommands/telecommand_executor.c
@@ -159,15 +159,20 @@ uint8_t TCMD_execute_parsed_telecommand_now(const uint16_t tcmd_idx, const char 
 ) {
     // Get the telecommand definition.
     if (tcmd_idx >= TCMD_NUM_TELECOMMANDS) {
-        DEBUG_uart_print_str("Error: TCMD_execute_parsed_telecommand: tcmd_idx out of bounds.\n");
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+            "Error: TCMD_execute_parsed_telecommand: tcmd_idx out of bounds (%u).",
+            tcmd_idx
+        );
         return 254;
     }
     TCMD_TelecommandDefinition_t tcmd_def = TCMD_telecommand_definitions[tcmd_idx];
 
-    DEBUG_uart_print_str("=========================");
-    DEBUG_uart_print_str(" Executing telecommand '");
-    DEBUG_uart_print_str(tcmd_def.tcmd_name);
-    DEBUG_uart_print_str("'=========================\n");
+    LOG_message(
+        LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+        "🚀 Executing telecommand '%s'.",
+        tcmd_def.tcmd_name
+    );
 
     // Handle the telecommand by calling the appropriate function.
     // Null-terminate the args string.
@@ -181,17 +186,16 @@ uint8_t TCMD_execute_parsed_telecommand_now(const uint16_t tcmd_idx, const char 
     const uint32_t tcmd_exec_duration_ms = uptime_after_tcmd_exec_ms - uptime_before_tcmd_exec_ms;
 
     // Print back the response.
-    DEBUG_uart_print_str("=========================");
-    DEBUG_uart_print_str(" Response (duration=");
-    DEBUG_uart_print_int32(tcmd_exec_duration_ms);
-    DEBUG_uart_print_str("ms, err=");
-    DEBUG_uart_print_uint32(tcmd_result);
-    if (tcmd_result != 0) {
-        DEBUG_uart_print_str(" !!!!!! ERROR !!!!!!");
-    }
-    DEBUG_uart_print_str(") =========================\n");
-    DEBUG_uart_print_str(response_output_buf);
-    DEBUG_uart_print_str("\n===========================================================================\n");
+    LOG_message(
+        LOG_SYSTEM_TELECOMMAND,
+        (tcmd_result == 0) ? LOG_SEVERITY_NORMAL : LOG_SEVERITY_ERROR,
+        LOG_SINK_ALL,
+        "%s Telecommand '%s' executed. Duration=%lums, err=%u.",
+        (tcmd_result == 0) ? "🟢" : "🔴",
+        tcmd_def.tcmd_name,
+        tcmd_exec_duration_ms,
+        tcmd_result
+    );
 
     return tcmd_result;
 }
@@ -205,7 +209,11 @@ uint8_t TCMD_execute_telecommand_in_agenda(const uint16_t tcmd_agenda_slot_num,
     char *response_output_buf, uint16_t response_output_buf_size
 ) {
     if (! TCMD_agenda_is_valid[tcmd_agenda_slot_num]) {
-        DEBUG_uart_print_str("Error: TCMD_execute_telecommand_in_agenda: slot is invalid.\n");
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
+            "Error: TCMD_execute_telecommand_in_agenda: slot %u is invalidated",
+            tcmd_agenda_slot_num
+        );
         return 253;
     }
 

--- a/firmware/Core/Src/telecommands/telecommand_executor.c
+++ b/firmware/Core/Src/telecommands/telecommand_executor.c
@@ -190,12 +190,16 @@ uint8_t TCMD_execute_parsed_telecommand_now(const uint16_t tcmd_idx, const char 
         LOG_SYSTEM_TELECOMMAND,
         (tcmd_result == 0) ? LOG_SEVERITY_NORMAL : LOG_SEVERITY_ERROR,
         LOG_SINK_ALL,
-        "%s Telecommand '%s' executed. Duration=%lums, err=%u.",
+        "%s Telecommand '%s' executed. Duration=%lums, err=%u",
         (tcmd_result == 0) ? "🟢" : "🔴",
         tcmd_def.tcmd_name,
         tcmd_exec_duration_ms,
         tcmd_result
     );
+
+    // FIXME: Send this response buffer over the radio channel as well.
+    DEBUG_uart_print_str(response_output_buf);
+    DEBUG_uart_print_str("\n");
 
     return tcmd_result;
 }

--- a/firmware/Core/Src/timekeeping/timekeeping.c
+++ b/firmware/Core/Src/timekeeping/timekeeping.c
@@ -1,6 +1,7 @@
 #include "timekeeping/timekeeping.h"
 #include "debug_tools/debug_uart.h"
 #include "transforms/arrays.h"
+#include "log/log.h"
 #include "stm32l4xx_hal.h"
 
 #include <stdio.h>
@@ -41,8 +42,11 @@ void TIM_set_current_unix_epoch_time_ms(uint64_t current_unix_epoch_time_ms, TIM
 
     // Log a warning if the current sync time is before the last sync time.
     if (is_this_sync_before_the_last_sync) {
-        DEBUG_uart_print_str("WARNING: setting current time to before the last sync.");
-        // TODO: use the logger warning function, and add other data with a format string here.
+        LOG_message(
+            LOG_SYSTEM_OBC, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+            "TIM_set_current_unix_epoch_time_ms: current time is before the last sync (last_resync=%s)",
+            TIM_unix_epoch_time_at_last_time_resync_ms_str
+        );
     }
 }
 

--- a/firmware/Core/Src/unit_tests/unit_test_executor.c
+++ b/firmware/Core/Src/unit_tests/unit_test_executor.c
@@ -1,6 +1,7 @@
 #include "unit_tests/unit_test_executor.h"
 #include "unit_tests/unit_test_inventory.h"
 #include "debug_tools/debug_uart.h"
+#include "log/log.h"
 
 #include "main.h"
 
@@ -19,17 +20,16 @@ uint8_t TEST_run_all_unit_tests_and_log(char log_buffer[], uint16_t log_buffer_s
         TEST_Function_Ptr test_function = TEST_definitions[test_num].test_func;
         uint8_t result = test_function();
 
-        char test_log_buffer[200];
-        snprintf(
-            test_log_buffer,
-            sizeof(test_log_buffer),
-            "Test #%03d: %s (%s > %s)\n",
+        LOG_message(
+            LOG_SYSTEM_OBC,
+            (result == 0) ? LOG_SEVERITY_DEBUG : LOG_SEVERITY_WARNING,
+            LOG_SINK_ALL,
+            "Test #%03d: %s (%s > %s)",
             test_num,
             (result == 0) ? "PASS ✅" : "FAIL ❌",
             TEST_definitions[test_num].test_file,
             TEST_definitions[test_num].test_func_name
         );
-        DEBUG_uart_print_str(test_log_buffer);
         
         total_exec_count++;
         if (result == 0) {


### PR DESCRIPTION
Fixes #152.

Areas not migrated:
1. Messages inside callbacks. Should be passing flags out of ISR callbacks, rather than calling the long-running log functions. 
2. Flash system. Need to really see where those messages are required and make sure none are on hot paths. Will defer on those.
3. Comments, generally. Old debugging comments won't be needed anymore. 

Other changes:
* Removed the deprecated `DEBUG_i2c_scan()` function.
* Converted a couple files from tabs to spaces for consistency. 

Will merge in about 24 hours regardless, as this has the potential to cause conflicts with other code as people work on their projects.