### PR TITLE
GPS ASCII Parsers and Unit Test

### DIFF
--- a/firmware/Core/Inc/gps/gps_ascii_parsers.h
+++ b/firmware/Core/Inc/gps/gps_ascii_parsers.h
@@ -1,0 +1,10 @@
+#ifndef __INCLUDE_GUARD__GPS_ASCII_PARSERS_H__
+ #define __INCLUDE_GUARD__GPS_ASCII_PARSERS_H__
+ 
+#include "gps/gps_types.h"
+ 
+ uint8_t GPS_header_response_parser(const char* data_received, GPS_header_response_t *result);
+ uint8_t GPS_bestxyza_data_parser(const char* data_received, GPS_bestxyza_response_t *result);
+ uint8_t GPS_timea_data_parser(const char* data_received, GPS_timea_response_t *result);
+ 
+ #endif // __INCLUDE_GUARD__GPS_ASCII_PARSERS_H__

--- a/firmware/Core/Inc/gps/gps_types.h
+++ b/firmware/Core/Inc/gps/gps_types.h
@@ -1,0 +1,188 @@
+#ifndef INCLUDE_GUARD__GPS_TYPES_H
+ #define INCLUDE_GUARD__GPS_TYPES_H
+ 
+ #include <stdint.h>
+ 
+ // ****************** SECTION: GPS_header_structs ******************
+ 
+ /// @brief  This refers to the status that indicates how well a time is known
+ /// All reported receiver times are subject to a qualifying time status
+ /// Refer to page 51-53 of the OEM7 Commands and Logs Reference Manual
+ typedef enum {
+     GPS_REF_TIME_UNKNOWN = 20,
+     GPS_REF_TIME_APPROXIMATE = 60,
+     GPS_REF_TIME_COARSEADJUSTING = 80,
+     GPS_REF_TIME_COARSE = 100,
+     GPS_REF_TIME_COARSESTEERING = 120,
+     GPS_REF_TIME_FREEWHEELING = 130,
+     GPS_REF_TIME_FINEADJUSTING = 140,
+     GPS_REF_TIME_FINE = 160,
+     GPS_REF_TIME_FINEBACKUPSTEERING = 170,
+     GPS_REF_TIME_FINESTEERING = 180,
+     GPS_REF_TIME_SATTIME = 200
+ } GPS_reference_time_status_t;
+ 
+ 
+ /// @brief This is the first part of the response that every command response from the GNSS receiver has.
+ /// Refer to page 34-35 of the OEM7 Commands and Logs Reference Manual
+ typedef struct {
+     /// @brief The ASCII name of the log or command e.g., "BESTXYZA" or "TIMEA"
+     char log_name[128];
+ 
+     /// @brief Indicates the quality of the GPS reference time
+     GPS_reference_time_status_t time_status;
+ 
+ } GPS_header_response_t;
+ 
+ // ****************** END SECTION: GPS_header_structs ******************
+ 
+ 
+ // ****************** SECTION: GPS_data_structs ******************
+ 
+ /// @brief  This refers to the solution status
+ /// Refer to table 90 page 500-501 of the OEM7 Commands and Logs Reference Manual
+ typedef enum {
+     GPS_SOL_STATUS_SOL_COMPUTED = 0,
+     GPS_SOL_STATUS_INSUFFICIENT_OBS = 1,
+     GPS_SOL_STATUS_NO_CONVERGENCE = 2,
+     GPS_SOL_STATUS_SINGULARITY = 3,
+     GPS_SOL_STATUS_COV_TRACE = 4,
+     GPS_SOL_STATUS_TEST_DIST = 5,
+     GPS_SOL_STATUS_COLD_START = 6,
+     GPS_SOL_STATUS_V_H_LIMIT = 7,
+     GPS_SOL_STATUS_VARIANCE = 8,
+     GPS_SOL_STATUS_RESIDUALS = 9,
+     GPS_SOL_STATUS_RESERVED_10_12 = 10,  // Since 10-12 are reserved
+     GPS_SOL_STATUS_INTEGRITY_WARNING = 13
+     // 14-17 are reserved
+ } GPS_solution_status_enum_t;
+ 
+ 
+ /// @brief  This refers to the position or velocity type
+ /// Refer to table 91 page 501-503 of the OEM7 Commands and Logs Reference Manual
+ typedef enum {
+     GPS_TYPE_NONE = 0,
+     GPS_TYPE_FIXEDPOS = 1,
+     GPS_TYPE_FIXEDHEIGHT = 2,
+     GPS_TYPE_RESERVED_3_7 = 3,  // Values from 3 to 7 are reserved
+     GPS_TYPE_DOPPLER_VELOCITY = 8,
+     GPS_TYPE_RESERVED_9_15 = 9, // Values from 9 to 15 are reserved
+     GPS_TYPE_SINGLE = 16,
+     GPS_TYPE_PSDIFF = 17,
+     GPS_TYPE_WAAS = 18,
+     GPS_TYPE_PROPAGATED = 19,
+     GPS_TYPE_RESERVED_20_31 = 20, // Values from 20 to 31 are reserved
+     GPS_TYPE_L1_FLOAT = 32,
+     GPS_TYPE_RESERVED_33 = 33,
+     GPS_TYPE_NARROW_FLOAT = 34,
+     GPS_TYPE_RESERVED_35_47 = 35, // Values from 35 to 47 are reserved
+     GPS_TYPE_L1_INT = 48,
+     GPS_TYPE_WIDE_INT = 49,
+     GPS_TYPE_NARROW_INT = 50,
+     GPS_TYPE_RTK_DIRECT_INS = 51,
+     GPS_TYPE_INS_SBAS = 52,
+     GPS_TYPE_INS_PSRSP = 53,
+     GPS_TYPE_INS_PSRDIFF = 54,
+     GPS_TYPE_INS_RTKFLOAT = 55,
+     GPS_TYPE_INS_RTKFIXED = 56,
+     GPS_TYPE_RESERVED_57_67 = 57, // Values from 57 to 67 are reserved
+     GPS_TYPE_PPP_CONVERGING = 68,
+     GPS_TYPE_PPP = 69,
+     GPS_TYPE_OPERATIONAL = 70,
+     GPS_TYPE_WARNING = 71,
+     GPS_TYPE_OUT_OF_BOUNDS = 72,
+     GPS_TYPE_INS_PPP_CONVERGING = 73,
+     GPS_TYPE_INS_PPP = 74,
+     GPS_TYPE_PPP_BASIC_CONVERGING = 77,
+     GPS_TYPE_PPP_BASIC = 78,
+     GPS_TYPE_INS_PPP_BASIC_CONVERGING = 79,
+     GPS_TYPE_INS_PPP_BASIC = 80
+ } GPS_position_type_enum_t;
+ 
+ 
+ /// @brief This is the struct for the BESTXYZA Command response.
+ /// Refer to page 515-517 of the OEM7 Commands and Logs Reference Manual
+ typedef struct {
+     /// @brief Position solution status
+     GPS_solution_status_enum_t position_solution_status;
+ 
+     /// @brief Position type.
+     GPS_position_type_enum_t position_type;
+ 
+     /// @brief Documentation says the point coordinates come as a double. 
+     /// We store as an int64 because the earth's radius(6.10^6 m) and we are storing the values as millimeters which fits within an int64.
+     /// Position coordinates in millimeters
+     int64_t position_x_mm;
+     int64_t position_y_mm;
+     int64_t position_z_mm;
+ 
+     /// @brief Documentation says the standard deviation of the position coordinates come as a float. 
+     /// The standard deviation of the position coordinates in millimeters
+     uint32_t position_x_std_mm;
+     uint32_t position_y_std_mm;
+     uint32_t position_z_std_mm;
+ 
+     /// @brief Differential age in seconds. Storing as a uint64 so as to capture the millisecond accuracy
+     uint64_t differential_age_ms;
+ 
+     /// @brief Solution age in seconds. Storing as a uint64 so as to capture the millisecond accuracy 
+     uint64_t solution_age_ms;
+ 
+     /// @brief 32 bit CRC (ASCII and Binary only). 
+     uint32_t crc;
+     
+ } GPS_bestxyza_response_t;
+ 
+ 
+ /// @brief  This refers to the Clock Model Status
+ /// Refer to table 105 page 526 of the OEM7 Commands and Logs Reference Manual
+ typedef enum {
+     GPS_CLOCK_VALID = 0,
+     GPS_CLOCK_CONVERGING = 1,
+     GPS_CLOCK_ITERATING = 2,
+     GPS_CLOCK_INVALID = 3,
+ } GPS_clock_model_status_enum_t;
+ 
+ typedef enum {
+     GPS_UTC_INVALID = 0,
+     GPS_UTC_VALID = 1,
+     GPS_UTC_WARNING = 2
+ } GPS_utc_status_enum_t;
+ 
+ /// @brief This is the struct for the TIMEA Command response.
+ /// Refer to page 941-943 of the OEM7 Commands and Logs Reference Manual
+ typedef struct {
+     /// @brief Clock model status
+     GPS_clock_model_status_enum_t clock_status;
+ 
+     /// @brief /// The offset of GPS system time from UTC time
+     /// Documentation says the utc offset comes as a double. 
+     int64_t utc_offset;
+ 
+     /// @brief UTC status 
+     /// Refer to page 943 of the OEM7 Commands and Logs Reference Manual
+     GPS_utc_status_enum_t utc_status;
+ 
+     /// @brief 32 bit CRC (ASCII and Binary only). 
+     uint32_t crc;
+     
+ } GPS_timea_response_t;
+ 
+ // ****************** END SECTION: GPS_data_structs ******************
+ 
+ // ****************** SECTION: GPS helper functions ******************
+ 
+ uint8_t GPS_reference_time_status_str_to_enum(const char *status_str, GPS_reference_time_status_t *status);
+ const char* GPS_reference_time_status_enum_to_str(GPS_reference_time_status_t status);
+ uint8_t GPS_solution_status_str_to_enum(const char *status_str, GPS_solution_status_enum_t *status);
+ uint8_t GPS_position_type_str_to_enum(const char *type_str, GPS_position_type_enum_t *type);
+ const char* GPS_solution_status_enum_to_str(GPS_solution_status_enum_t status);
+ const char* GPS_position_type_enum_to_string(GPS_position_type_enum_t type);
+ uint8_t GPS_clock_model_status_str_to_enum(const char *status_str, GPS_clock_model_status_enum_t *status);
+ uint8_t GPS_utc_status_str_to_enum(const char *status_str, GPS_utc_status_enum_t *status);
+ const char* GPS_clock_model_status_enum_to_string(GPS_clock_model_status_enum_t status);
+ const char* GPS_utc_status_enum_to_string(GPS_utc_status_enum_t status);
+ 
+ // ****************** END SECTION: GPS_header_structs ******************
+ 
+ #endif // INCLUDE_GUARD__GPS_TYPES_H

--- a/firmware/Core/Inc/unit_tests/unit_test_gps.h
+++ b/firmware/Core/Inc/unit_tests/unit_test_gps.h
@@ -1,0 +1,14 @@
+#ifndef __INCLUDE_GUARD__UNIT_TEST_GPS_H__
+ #define __INCLUDE_GUARD__UNIT_TEST_GPS_H__
+ 
+ #include <stdint.h>
+ 
+ uint8_t TEST_EXEC__GPS_reference_time_status_str_to_enum();
+ uint8_t TEST_EXEC__GPS_solution_status_str_to_enum();
+ uint8_t TEST_EXEC__GPS_position_type_str_to_enum();
+ 
+ uint8_t TEST_EXEC__GPS_header_response_parser();
+ uint8_t TEST_EXEC__GPS_bestxyza_data_parser();
+ uint8_t TEST_EXEC__GPS_timea_data_parser();
+ 
+ #endif // __INCLUDE_GUARD__UNIT_TEST_GPS_H__

--- a/firmware/Core/Src/gps/gps_ascii_parsers.c
+++ b/firmware/Core/Src/gps/gps_ascii_parsers.c
@@ -1,0 +1,559 @@
+#include "gps/gps_ascii_parsers.h"
+#include "gps/gps_types.h"
+#include "log/log.h"
+#include "telecommand_args_helpers.h"
+#include "transforms/arrays.h"
+
+#include <stdio.h>
+#include <stdlib.h> 
+#include <string.h>
+#include <stdint.h>
+
+
+/// @brief Parse the received GPS header into a struct
+/// @param data_received - The string obtained from the buffer that is to be parsed into the GPS_header_response_t struct
+/// @param result - GPS_header_response_t struct that is returned
+/// @return 0 if successful, > 0 if an error occurred
+uint8_t GPS_header_response_parser(const char *data_received, GPS_header_response_t *result){
+
+    // TODO: What if there are multiple responses in the string?
+
+    // Check if the buffer is empty
+    if (data_received == NULL || data_received[0] == '\0') {
+        // Empty or NULL string, return an error
+        return 1;
+    }
+
+    // Find the start and end of the header, which is # and ; resepectively
+    const char *sync_char = strchr(data_received,'#');
+    const char *delimiter_char = strchr(data_received,';');
+
+    if (!sync_char || !delimiter_char) {
+        // Invalid data: No header in gps response
+        return 2; 
+    }
+
+    // Calculate the length of the header string
+    const int header_length = delimiter_char - sync_char + 1;
+    if (header_length < 0) {
+        //Sync character occurs after delimiter character
+        return 3;
+    }
+
+    char header_buffer[256];
+    if ((size_t)header_length >= sizeof(header_buffer)) {
+        //Header is too large for the buffer
+        return 4;  
+    }
+
+    // Copy header string into a buffer
+    strncpy(header_buffer, sync_char, header_length);
+    header_buffer[header_length] = '\0';  // Null-terminate the substring
+
+    // Parse the data in the header buffer
+    uint8_t parse_result;
+    char token_buffer[128];
+
+    // Log Name
+    parse_result = TCMD_extract_string_arg(header_buffer, 0, token_buffer, sizeof(token_buffer));
+    if (parse_result != 0) {  
+        return parse_result;  
+    }
+    strcpy(result->log_name, token_buffer + 1);
+
+    // Time Status
+    parse_result = TCMD_extract_string_arg(header_buffer, 4, token_buffer, sizeof(token_buffer));
+    if (parse_result != 0) {  
+        return parse_result;  
+    }
+    const uint8_t status_result = GPS_reference_time_status_str_to_enum(token_buffer, &result->time_status);
+    if (status_result != 0) {
+        // Time Status not recognized
+        return status_result;
+    }
+
+    char message_buffer[256];
+    snprintf(
+        message_buffer, sizeof(message_buffer),
+        "{\"log_name\":\"%s\",\"time_status\":\"%s\"}\n",
+        result->log_name,
+        GPS_reference_time_status_enum_to_str(result->time_status)
+    );
+    
+    LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Header Response: %s",
+            message_buffer
+        );
+        
+    return 0;
+}
+
+
+/// @brief Parse Received Data
+/// @param data_received - Number of bytes in the data block
+/// @return 0 if successful, >0 if an error occurred
+uint8_t GPS_bestxyza_data_parser(const char* data_received, GPS_bestxyza_response_t *result) {
+
+    // Check if the buffer is empty
+    if (data_received[0] == '\0') {
+        // Empty or NULL string, return an error
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Error 1: Empty buffer"
+        );
+        return 1;
+    }
+
+    GPS_header_response_t bestxyza_header;
+    const uint8_t header_parse_result = GPS_header_response_parser(data_received,&bestxyza_header);
+
+    if(header_parse_result != 0){
+        // Error in parsing header section
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Error 2: Error parising the gps header"
+        );
+        return 2;
+    }
+
+    if(strcmp(bestxyza_header.log_name, "BESTXYZA") != 0){
+        // Incorrect log function
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Error 3: Incorrect log function ie not BESTXYZA"
+        );
+        return 3;
+    }
+
+    // TODO: What if there is multiple commands in the string?
+    const char *header_delimiter_char = strchr(data_received,';');
+    const char* bestxyza_data_start = header_delimiter_char + 1;
+    const char* asterisk = strchr(bestxyza_data_start, '*');  
+
+    if(strcmp(bestxyza_data_start, "\0") == 0){
+        // No data after the gps header within the response
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Error 4: Missing Data after the header"
+        );
+        return 4;
+    }  
+
+    if(!asterisk){
+        // No terminator at the end of the bestxyza data, ie no CRC present
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Error 5: Missing Astericks in response"
+        );
+        return 5;
+    }
+
+    const int bestxyza_data_length = asterisk - bestxyza_data_start + 1;
+    char bestxyza_data_buffer[512];
+    if ((size_t)bestxyza_data_length >= sizeof(bestxyza_data_buffer)) {
+        //Buffer Overflow Error
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Error 6: Buffer overflow"
+        );
+        return 6;  
+    }
+
+    strncpy(bestxyza_data_buffer, bestxyza_data_start, bestxyza_data_length);
+    bestxyza_data_buffer[bestxyza_data_length] = '\0';
+
+    // Parse the data in the bestxyza data buffer
+    uint8_t parse_result;
+    char token_buffer[128];
+    char *end_ptr;
+    
+    // Position Solution Status
+    parse_result = TCMD_extract_string_arg(bestxyza_data_buffer, 0, token_buffer, sizeof(token_buffer));
+    if (parse_result != 0) {  
+        return parse_result;  
+    }
+    uint8_t status_result = GPS_solution_status_str_to_enum(token_buffer, &result->position_solution_status);
+    if(status_result != 0){
+        // Invalid string passed
+        return status_result;
+    }
+
+    // Position Type
+    parse_result = TCMD_extract_string_arg(bestxyza_data_buffer, 1, token_buffer, sizeof(token_buffer));
+    if (parse_result != 0) {  
+        return parse_result;  
+    }
+    status_result = GPS_position_type_str_to_enum(token_buffer, &result->position_type);
+    if(status_result != 0){
+        // Invalid string passed
+        return status_result;
+    }
+
+    // Position Coordinates 
+    parse_result = TCMD_extract_string_arg(bestxyza_data_buffer, 2, token_buffer, sizeof(token_buffer));
+    if (parse_result != 0) {  
+        return parse_result;  
+    }
+
+    double value = strtod(token_buffer, &end_ptr);
+    if(strcmp(end_ptr, token_buffer) == 0){
+        // Improper string to double conversion
+        return 7;
+    }
+    double conv_result = value * 1000;
+
+    //TODO: Determine what to do when we exceed data type value
+    if(conv_result > INT64_MAX){
+        conv_result = INT64_MAX;
+    }
+    else if(conv_result < INT64_MIN){
+        conv_result = INT64_MIN;
+    }
+    result->position_x_mm = (int64_t) conv_result;
+
+    parse_result = TCMD_extract_string_arg(bestxyza_data_buffer, 3, token_buffer, sizeof(token_buffer));
+    if (parse_result != 0) {  
+        return parse_result;  
+    }
+    value = strtod(token_buffer, &end_ptr);
+    if(strcmp(end_ptr, token_buffer) == 0){
+        // Improper string to double conversion
+        return 7;
+    }
+    conv_result = value * 1000;
+
+    //TODO: Determine what to do when we exceed data type value
+    if(conv_result > INT64_MAX){
+        conv_result = INT64_MAX;
+    }
+    else if(conv_result < INT64_MIN){
+        conv_result = INT64_MIN;
+    }
+    result->position_y_mm = (int64_t) conv_result;
+
+    parse_result = TCMD_extract_string_arg(bestxyza_data_buffer, 4, token_buffer, sizeof(token_buffer));
+    if (parse_result != 0) {  
+        return parse_result;  
+    }
+    value = strtod(token_buffer, &end_ptr);
+    if(strcmp(end_ptr, token_buffer) == 0){
+        // Improper string to double conversion
+        return 7;
+    }
+    conv_result = value * 1000;
+
+    //TODO: Determine what to do when we exceed data type value
+    if(conv_result > INT64_MAX){
+        conv_result = INT64_MAX;
+    }
+    else if(conv_result < INT64_MIN){
+        conv_result = INT64_MIN;
+    }
+    result->position_z_mm = (int64_t) conv_result;
+
+    // Position Coordinates Standard Deviation
+    parse_result = TCMD_extract_string_arg(bestxyza_data_buffer, 5, token_buffer, sizeof(token_buffer));
+    if (parse_result != 0) {  
+        return parse_result;  
+    }
+    value = strtod(token_buffer, &end_ptr);
+    if(strcmp(end_ptr, token_buffer) == 0){
+        // Improper string to double conversion
+        return 7;
+    }
+    conv_result = value * 1000;
+
+    //TODO: Determine what to do when we exceed data type value
+    if(conv_result > INT32_MAX){
+        conv_result = INT32_MAX;
+    }
+    else if(conv_result < INT32_MIN){
+        conv_result = INT32_MIN;
+    }
+    result->position_x_std_mm = (int32_t) conv_result;
+
+    parse_result = TCMD_extract_string_arg(bestxyza_data_buffer, 6, token_buffer, sizeof(token_buffer));
+    if (parse_result != 0) {  
+        return parse_result;  
+    }
+    value = strtod(token_buffer, &end_ptr);
+    if(strcmp(end_ptr, token_buffer) == 0){
+        // Improper string to double conversion
+        return 7;
+    }
+    conv_result = value * 1000;
+
+    //TODO: Determine what to do when we exceed data type value
+    if(conv_result > INT32_MAX){
+        conv_result = INT32_MAX;
+    }
+    else if(conv_result < INT32_MIN){
+        conv_result = INT32_MIN;
+    }
+    result->position_y_std_mm = (int32_t) conv_result;
+
+    parse_result = TCMD_extract_string_arg(bestxyza_data_buffer, 7, token_buffer, sizeof(token_buffer));
+    if (parse_result != 0) {  
+        return parse_result;  
+    }
+    value = strtod(token_buffer, &end_ptr);
+    if(strcmp(end_ptr, token_buffer) == 0){
+        // Improper string to double conversion
+        return 7;
+    }
+    conv_result = value * 1000;
+
+    //TODO: Determine what to do when we exceed data type value
+    if(conv_result > INT32_MAX){
+        conv_result = INT32_MAX;
+    }
+    else if(conv_result < INT32_MIN){
+        conv_result = INT32_MIN;
+    }
+    result->position_z_std_mm = (int32_t) conv_result;
+
+    // Differential Age
+    parse_result = TCMD_extract_string_arg(bestxyza_data_buffer, 18, token_buffer, sizeof(token_buffer));
+    if (parse_result != 0) {  
+        return parse_result;  
+    }
+    value = strtod(token_buffer, &end_ptr);
+    if(strcmp(end_ptr, token_buffer) == 0){
+        // Improper string to double conversion
+        return 7;
+    }
+    conv_result = value * 1000;
+
+    //TODO: Determine what to do when we exceed data type value
+    if(conv_result > INT64_MAX){
+        conv_result = INT64_MAX;
+    }
+    else if(conv_result < INT64_MIN){
+        conv_result = INT64_MIN;
+    }
+    result->differential_age_ms = (int64_t) conv_result;
+
+    // Solution Age
+    parse_result = TCMD_extract_string_arg(bestxyza_data_buffer, 19, token_buffer, sizeof(token_buffer));
+    if (parse_result != 0) {  
+        return parse_result;  
+    }
+    value = strtod(token_buffer, &end_ptr);
+    if(strcmp(end_ptr, token_buffer) == 0){
+        // Improper string to double conversion
+        return 7;
+    }
+    conv_result = value * 1000;
+
+    //TODO: Determine what to do when we exceed data type value
+    if(conv_result > INT64_MAX){
+        conv_result = INT64_MAX;
+    }
+    else if(conv_result < INT64_MIN){
+        conv_result = INT64_MIN;
+    }
+    result->solution_age_ms = (int64_t) conv_result;
+
+    char crc[9];
+    strncpy(crc, asterisk + 1, 8);
+    crc[sizeof(crc)-1] = '\0';
+    result->crc = strtoul(crc,&end_ptr, 16);
+
+    // TODO: Add a check for the CRC
+
+
+    char sol_age[32];
+    GEN_uint64_to_str(result->solution_age_ms, sol_age);
+    char diff_age[32];
+    GEN_uint64_to_str(result->differential_age_ms, diff_age);
+    char pos_x[32];
+    GEN_int64_to_str(result->position_x_mm,pos_x);
+    char pos_y[32];
+    GEN_int64_to_str(result->position_y_mm,pos_y);
+    char pos_z[32];
+    GEN_int64_to_str(result->position_z_mm,pos_z);
+
+    char message_buffer[2048];
+    snprintf(
+        message_buffer, sizeof(message_buffer),
+        "{\"Position Solution Status\":\"%s\",\"Position Type\":\"%s\",\"Position x in mm\":\"%s\",\"Position y in mm\":\"%s\",\"Position z in mm\":\"%s\","
+        "\"Position x std in mm\":\"%lu\",\"Position y std in mm\":\"%lu\",\"Position z std in mm\":\"%lu\",\"Solution Age in ms\":\"%s\",\"Differential age in ms\":\"%s\",\"CRC\":\"%ld\"}\n",
+        GPS_solution_status_enum_to_str(result->position_solution_status),
+        GPS_position_type_enum_to_string(result->position_type),
+        pos_x,
+        pos_y,
+        pos_z,
+        result->position_x_std_mm,
+        result->position_y_std_mm,
+        result->position_z_std_mm,
+        sol_age,
+        diff_age,
+        result->crc
+    );
+
+    LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Bestxyza Response: %s",
+            message_buffer
+        );
+
+    return 0;
+}
+
+
+/// @brief Parse Received Data
+/// @param data_received - Number of bytes in the data block
+/// @return 0 if successful, >0 if an error occurred
+uint8_t GPS_timea_data_parser(const char* data_received, GPS_timea_response_t *result) {
+
+    // Check if the buffer is empty
+    if (data_received[0] == '\0') {
+        // Empty or NULL string, return an error
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Error 1: Empty buffer"
+        );
+        return 1;
+    }
+
+    GPS_header_response_t timea_header;
+    const uint8_t header_parse_result = GPS_header_response_parser(data_received,&timea_header);
+
+    if(header_parse_result != 0){
+        // Error in parsing header section
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Error 2: Header Parsing Error"
+        );
+        return 2;
+    }
+
+    if(strcmp(timea_header.log_name, "TIMEA") != 0){
+        // Incorrect log function
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Error 3: Invalid log function ie not TIMEA"
+        );
+        return 3;
+    }
+
+    // TODO: What if there is multiple commands in the string?
+    const char *header_delimiter_char = strchr(data_received,';');
+    const char* timea_data_start = header_delimiter_char + 1;
+    const char* asterisk = strchr(timea_data_start, '*');
+
+    const int timea_data_length = asterisk - timea_data_start + 1;
+
+    if(strcmp(timea_data_start, "\0") == 0){
+        // No data after the gps header within the response
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Error 4: Missing Data after the header"
+        );
+        return 4;
+    }
+
+    if(!asterisk){
+        // No terminator at the end of the bestxyza data, ie no CRC present
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Error 5: Missing Astericks in response"
+        );
+        return 5;
+    }
+
+    // TODO: Change this to be more conservative of storage space
+    char timea_data_buffer[512];
+    if ((size_t)timea_data_length >= sizeof(timea_data_buffer)) {
+        //Header is too large for the buffer
+        LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Error 6: Buffer Oveflow"
+        );
+        return 6;  
+    }
+
+    strncpy(timea_data_buffer, timea_data_start, timea_data_length);
+    timea_data_buffer[timea_data_length] = '\0';
+
+    // Parse the data in the bestxyza data buffer
+    uint8_t parse_result;
+    char token_buffer[128];
+    char *end_ptr;
+    
+    // Clock Model Status
+    parse_result = TCMD_extract_string_arg(timea_data_buffer, 0, token_buffer, sizeof(token_buffer));
+    if (parse_result != 0) {  
+        return parse_result;  
+    }
+    uint8_t status_result = GPS_clock_model_status_str_to_enum(token_buffer, &result->clock_status);
+    if(status_result != 0){
+        // Invalid string passed
+        return status_result;
+    }
+
+    // UTC Offset
+    parse_result = TCMD_extract_string_arg(timea_data_buffer, 3, token_buffer, sizeof(token_buffer));
+    if (parse_result != 0) {  
+        return parse_result;  
+    }
+
+    double value = strtod(token_buffer, &end_ptr);
+    if(strcmp(end_ptr,token_buffer)==0){
+        return 7;
+    }
+    
+    // TODO: Determine what to do when we exceed data limit ie fall out of bounds of valid int64_t values
+    // May have to change to int32_t for optimization.
+    if(value > INT64_MAX){
+        value = INT64_MAX;
+    } else if (value < INT64_MIN){
+        value = INT64_MIN;
+    }
+    result->utc_offset = (int64_t) value;
+
+
+    // UTC Status
+    parse_result = TCMD_extract_string_arg(timea_data_buffer, 10, token_buffer, sizeof(token_buffer));
+    if (parse_result != 0) {  
+        return parse_result;  
+    }
+
+    char *asterisk_pos = strchr(token_buffer, '*');
+    if (asterisk_pos) {
+        *asterisk_pos = '\0';  
+    }
+    status_result = GPS_utc_status_str_to_enum(token_buffer, &result->utc_status);
+    if(status_result != 0){
+        // Invalid string passed
+        return status_result;
+    }
+
+    // TODO: Look into using TCMD_extract_hex_array
+    // TODO: Add a check for the CRC
+    char crc[9];
+    strncpy(crc, asterisk + 1, 8);
+    crc[sizeof(crc)-1] = '\0';
+    result->crc = strtoul(crc,&end_ptr, 16);
+
+    char utc_offset[32];
+    GEN_int64_to_str(result->utc_offset,utc_offset);
+    char message_buffer[1024];
+    snprintf(
+        message_buffer, sizeof(message_buffer),
+        "{\"Clock Status\":\"%s\",\"UTC Status\":%s,\"UTC Offset\":\"%s\",\"CRC\":%lx}\n",
+        GPS_clock_model_status_enum_to_string(result->clock_status),
+        utc_offset,
+        GPS_utc_status_enum_to_string(result->utc_status),
+        result->crc
+    );
+    
+    LOG_message(
+            LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+            "Timea Response: %s",
+            message_buffer
+        );
+
+    return 0;
+}

--- a/firmware/Core/Src/gps/gps_ascii_parsers.c
+++ b/firmware/Core/Src/gps/gps_ascii_parsers.c
@@ -1,7 +1,7 @@
 #include "gps/gps_ascii_parsers.h"
 #include "gps/gps_types.h"
 #include "log/log.h"
-#include "telecommand_args_helpers.h"
+#include "telecommand_exec/telecommand_args_helpers.h"
 #include "transforms/arrays.h"
 
 #include <stdio.h>

--- a/firmware/Core/Src/gps/gps_types.c
+++ b/firmware/Core/Src/gps/gps_types.c
@@ -1,0 +1,348 @@
+#include "gps/gps_types.h"
+ 
+ #include <string.h>
+ 
+ /// @brief Assigns a GPS time status based on the provided string.
+ /// @param status_str The status string to parse.
+ /// @param status Pointer to GPS_reference_time_status_t where the status will be stored.
+ /// @return Returns 0 on success, 1 if the status string is unrecognized.
+ uint8_t GPS_reference_time_status_str_to_enum(const char *status_str, GPS_reference_time_status_t *status) {
+     if (strcmp(status_str, "UNKNOWN") == 0) {
+         *status = GPS_REF_TIME_UNKNOWN;
+     } else if (strcmp(status_str, "APPROXIMATE") == 0) {
+         *status = GPS_REF_TIME_APPROXIMATE;
+     } else if (strcmp(status_str, "COARSEADJUSTING") == 0) {
+         *status = GPS_REF_TIME_COARSEADJUSTING;
+     } else if (strcmp(status_str, "COARSE") == 0) {
+         *status = GPS_REF_TIME_COARSE;
+     } else if (strcmp(status_str, "COARSESTEERING") == 0) {
+         *status = GPS_REF_TIME_COARSESTEERING;
+     } else if (strcmp(status_str, "FREEWHEELING") == 0) {
+         *status = GPS_REF_TIME_FREEWHEELING;
+     } else if (strcmp(status_str, "FINEADJUSTING") == 0) {
+         *status = GPS_REF_TIME_FINEADJUSTING;
+     } else if (strcmp(status_str, "FINE") == 0) {
+         *status = GPS_REF_TIME_FINE;
+     } else if (strcmp(status_str, "FINEBACKUPSTEERING") == 0) {
+         *status = GPS_REF_TIME_FINEBACKUPSTEERING;
+     } else if (strcmp(status_str, "FINESTEERING") == 0) {
+         *status = GPS_REF_TIME_FINESTEERING;
+     } else if (strcmp(status_str, "SATTIME") == 0) {
+         *status = GPS_REF_TIME_SATTIME;
+     } else {
+         return 1;  // Unrecognized status string
+     }
+     return 0;  // Success
+ }
+ 
+ 
+ /// @brief Assigns a string value based on the provided GPS time status.
+ /// @param status GPS_reference_time_status_t value.
+ /// @return Returns the assigned string value for the GPS time status.
+ const char* GPS_reference_time_status_enum_to_str(GPS_reference_time_status_t status) {
+     switch (status) {
+         case GPS_REF_TIME_UNKNOWN:
+             return "UNKNOWN";
+         case GPS_REF_TIME_APPROXIMATE:
+             return "APPROXIMATE";
+         case GPS_REF_TIME_COARSEADJUSTING:
+             return "COARSEADJUSTING";
+         case GPS_REF_TIME_COARSE:
+             return "COARSE";
+         case GPS_REF_TIME_COARSESTEERING:
+             return "COARSESTEERING";
+         case GPS_REF_TIME_FREEWHEELING:
+             return "FREEWHEELING";
+         case GPS_REF_TIME_FINEADJUSTING:
+             return "FINEADJUSTING";
+         case GPS_REF_TIME_FINE:
+             return "FINE";
+         case GPS_REF_TIME_FINEBACKUPSTEERING:
+             return "FINEBACKUPSTEERING";
+         case GPS_REF_TIME_FINESTEERING:
+             return "FINESTEERING";
+         case GPS_REF_TIME_SATTIME:
+             return "SATTIME";
+         default:
+             return "UNKNOWN STATUS";  // If status is unrecognized
+     }
+ }
+ 
+ 
+ /// @brief Assigns a GPS solution status based on the provided string.
+ /// @param status_str The status string to parse.
+ /// @param status Pointer to GPS_solution_status_enum_t where the status will be stored.
+ /// @return Returns 0 on success, 1 if the status string is unrecognized.
+ uint8_t GPS_solution_status_str_to_enum(const char *status_str, GPS_solution_status_enum_t *status) {
+     if (strcmp(status_str, "SOL_COMPUTED") == 0) {
+         *status = GPS_SOL_STATUS_SOL_COMPUTED;
+     } else if (strcmp(status_str, "INSUFFICIENT_OBS") == 0) {
+         *status = GPS_SOL_STATUS_INSUFFICIENT_OBS;
+     } else if (strcmp(status_str, "NO_CONVERGENCE") == 0) {
+         *status = GPS_SOL_STATUS_NO_CONVERGENCE;
+     } else if (strcmp(status_str, "SINGULARITY") == 0) {
+         *status = GPS_SOL_STATUS_SINGULARITY;
+     } else if (strcmp(status_str, "COV_TRACE") == 0) {
+         *status = GPS_SOL_STATUS_COV_TRACE;
+     } else if (strcmp(status_str, "TEST_DIST") == 0) {
+         *status = GPS_SOL_STATUS_TEST_DIST;
+     } else if (strcmp(status_str, "COLD_START") == 0) {
+         *status = GPS_SOL_STATUS_COLD_START;
+     } else if (strcmp(status_str, "V_H_LIMIT") == 0) {
+         *status = GPS_SOL_STATUS_V_H_LIMIT;
+     } else if (strcmp(status_str, "VARIANCE") == 0) {
+         *status = GPS_SOL_STATUS_VARIANCE;
+     } else if (strcmp(status_str, "RESIDUALS") == 0) {
+         *status = GPS_SOL_STATUS_RESIDUALS;
+     } else if (strcmp(status_str, "INTEGRITY_WARNING") == 0) {
+         *status = GPS_SOL_STATUS_INTEGRITY_WARNING;
+     } else {
+         return 1;  // Unrecognized status string
+     }
+     return 0;  // Success
+ }
+ 
+ 
+ /// @brief Assigns a GPS position or velocity type based on the provided string.
+ /// @param type_str The type string to parse.
+ /// @param type Pointer to GPS_position_velocity_type_enum_t where the type will be stored.
+ /// @return Returns 0 on success, 1 if the type string is unrecognized.
+ uint8_t GPS_position_type_str_to_enum(const char *type_str, GPS_position_type_enum_t *type) {
+     if (strcmp(type_str, "NONE") == 0) {
+         *type = GPS_TYPE_NONE;
+     } else if (strcmp(type_str, "FIXEDPOS") == 0) {
+         *type = GPS_TYPE_FIXEDPOS;
+     } else if (strcmp(type_str, "FIXEDHEIGHT") == 0) {
+         *type = GPS_TYPE_FIXEDHEIGHT;
+     } else if (strcmp(type_str, "DOPPLER_VELOCITY") == 0) {
+         *type = GPS_TYPE_DOPPLER_VELOCITY;
+     } else if (strcmp(type_str, "SINGLE") == 0) {
+         *type = GPS_TYPE_SINGLE;
+     } else if (strcmp(type_str, "PSDIFF") == 0) {
+         *type = GPS_TYPE_PSDIFF;
+     } else if (strcmp(type_str, "WAAS") == 0) {
+         *type = GPS_TYPE_WAAS;
+     } else if (strcmp(type_str, "PROPAGATED") == 0) {
+         *type = GPS_TYPE_PROPAGATED;
+     } else if (strcmp(type_str, "L1_FLOAT") == 0) {
+         *type = GPS_TYPE_L1_FLOAT;
+     } else if (strcmp(type_str, "NARROW_FLOAT") == 0) {
+         *type = GPS_TYPE_NARROW_FLOAT;
+     } else if (strcmp(type_str, "L1_INT") == 0) {
+         *type = GPS_TYPE_L1_INT;
+     } else if (strcmp(type_str, "WIDE_INT") == 0) {
+         *type = GPS_TYPE_WIDE_INT;
+     } else if (strcmp(type_str, "NARROW_INT") == 0) {
+         *type = GPS_TYPE_NARROW_INT;
+     } else if (strcmp(type_str, "RTK_DIRECT_INS") == 0) {
+         *type = GPS_TYPE_RTK_DIRECT_INS;
+     } else if (strcmp(type_str, "INS_SBAS") == 0) {
+         *type = GPS_TYPE_INS_SBAS;
+     } else if (strcmp(type_str, "INS_PSRSP") == 0) {
+         *type = GPS_TYPE_INS_PSRSP;
+     } else if (strcmp(type_str, "INS_PSRDIFF") == 0) {
+         *type = GPS_TYPE_INS_PSRDIFF;
+     } else if (strcmp(type_str, "INS_RTKFLOAT") == 0) {
+         *type = GPS_TYPE_INS_RTKFLOAT;
+     } else if (strcmp(type_str, "INS_RTKFIXED") == 0) {
+         *type = GPS_TYPE_INS_RTKFIXED;
+     } else if (strcmp(type_str, "PPP_CONVERGING") == 0) {
+         *type = GPS_TYPE_PPP_CONVERGING;
+     } else if (strcmp(type_str, "PPP") == 0) {
+         *type = GPS_TYPE_PPP;
+     } else if (strcmp(type_str, "OPERATIONAL") == 0) {
+         *type = GPS_TYPE_OPERATIONAL;
+     } else if (strcmp(type_str, "WARNING") == 0) {
+         *type = GPS_TYPE_WARNING;
+     } else if (strcmp(type_str, "OUT_OF_BOUNDS") == 0) {
+         *type = GPS_TYPE_OUT_OF_BOUNDS;
+     } else if (strcmp(type_str, "INS_PPP_CONVERGING") == 0) {
+         *type = GPS_TYPE_INS_PPP_CONVERGING;
+     } else if (strcmp(type_str, "INS_PPP") == 0) {
+         *type = GPS_TYPE_INS_PPP;
+     } else if (strcmp(type_str, "PPP_BASIC_CONVERGING") == 0) {
+         *type = GPS_TYPE_PPP_BASIC_CONVERGING;
+     } else if (strcmp(type_str, "PPP_BASIC") == 0) {
+         *type = GPS_TYPE_PPP_BASIC;
+     } else if (strcmp(type_str, "INS_PPP_BASIC_CONVERGING") == 0) {
+         *type = GPS_TYPE_INS_PPP_BASIC_CONVERGING;
+     } else if (strcmp(type_str, "INS_PPP_BASIC") == 0) {
+         *type = GPS_TYPE_INS_PPP_BASIC;
+     } else {
+         return 1;  // Unrecognized type string
+     }
+     return 0;  // Success
+ }
+ 
+ /// @brief Assigns a string value based on the provided GPS solution status.
+ /// @param status GPS_solution_status_enum_t value.
+ /// @return Returns the assigned string value for the GPS_solution_status_enum_t.
+ const char* GPS_solution_status_enum_to_str(GPS_solution_status_enum_t status) {
+     switch (status) {
+         case GPS_SOL_STATUS_SOL_COMPUTED:
+             return "SOL_COMPUTED";
+         case GPS_SOL_STATUS_INSUFFICIENT_OBS:
+             return "INSUFFICIENT_OBS";
+         case GPS_SOL_STATUS_NO_CONVERGENCE:
+             return "NO_CONVERGENCE";
+         case GPS_SOL_STATUS_SINGULARITY:
+             return "SINGULARITY";
+         case GPS_SOL_STATUS_COV_TRACE:
+             return "COV_TRACE";
+         case GPS_SOL_STATUS_TEST_DIST:
+             return "TEST_DIST";
+         case GPS_SOL_STATUS_COLD_START:
+             return "COLD_START";
+         case GPS_SOL_STATUS_V_H_LIMIT:
+             return "V_H_LIMIT";
+         case GPS_SOL_STATUS_VARIANCE:
+             return "VARIANCE";
+         case GPS_SOL_STATUS_RESIDUALS:
+             return "RESIDUALS";
+         case GPS_SOL_STATUS_INTEGRITY_WARNING:
+             return "INTEGRITY_WARNING";
+         default:
+             return "UNKNOWN STATUS";  // For unrecognized enum values
+     }
+ }
+ 
+ /// @brief Assigns a string value based on the provided GPS position type.
+ /// @param type GPS_position_type_enum_t value.
+ /// @return Returns the assigned string value for the GPS_position_type_enum_t.
+ const char* GPS_position_type_enum_to_string(GPS_position_type_enum_t type) {
+     switch (type) {
+         case GPS_TYPE_NONE:
+             return "NONE";
+         case GPS_TYPE_FIXEDPOS:
+             return "FIXEDPOS";
+         case GPS_TYPE_FIXEDHEIGHT:
+             return "FIXEDHEIGHT";
+         case GPS_TYPE_DOPPLER_VELOCITY:
+             return "DOPPLER_VELOCITY";
+         case GPS_TYPE_SINGLE:
+             return "SINGLE";
+         case GPS_TYPE_PSDIFF:
+             return "PSDIFF";
+         case GPS_TYPE_WAAS:
+             return "WAAS";
+         case GPS_TYPE_PROPAGATED:
+             return "PROPAGATED";
+         case GPS_TYPE_L1_FLOAT:
+             return "L1_FLOAT";
+         case GPS_TYPE_NARROW_FLOAT:
+             return "NARROW_FLOAT";
+         case GPS_TYPE_L1_INT:
+             return "L1_INT";
+         case GPS_TYPE_WIDE_INT:
+             return "WIDE_INT";
+         case GPS_TYPE_NARROW_INT:
+             return "NARROW_INT";
+         case GPS_TYPE_RTK_DIRECT_INS:
+             return "RTK_DIRECT_INS";
+         case GPS_TYPE_INS_SBAS:
+             return "INS_SBAS";
+         case GPS_TYPE_INS_PSRSP:
+             return "INS_PSRSP";
+         case GPS_TYPE_INS_PSRDIFF:
+             return "INS_PSRDIFF";
+         case GPS_TYPE_INS_RTKFLOAT:
+             return "INS_RTKFLOAT";
+         case GPS_TYPE_INS_RTKFIXED:
+             return "INS_RTKFIXED";
+         case GPS_TYPE_PPP_CONVERGING:
+             return "PPP_CONVERGING";
+         case GPS_TYPE_PPP:
+             return "PPP";
+         case GPS_TYPE_OPERATIONAL:
+             return "OPERATIONAL";
+         case GPS_TYPE_WARNING:
+             return "WARNING";
+         case GPS_TYPE_OUT_OF_BOUNDS:
+             return "OUT_OF_BOUNDS";
+         case GPS_TYPE_INS_PPP_CONVERGING:
+             return "INS_PPP_CONVERGING";
+         case GPS_TYPE_INS_PPP:
+             return "INS_PPP";
+         case GPS_TYPE_PPP_BASIC_CONVERGING:
+             return "PPP_BASIC_CONVERGING";
+         case GPS_TYPE_PPP_BASIC:
+             return "PPP_BASIC";
+         case GPS_TYPE_INS_PPP_BASIC_CONVERGING:
+             return "INS_PPP_BASIC_CONVERGING";
+         case GPS_TYPE_INS_PPP_BASIC:
+             return "INS_PPP_BASIC";
+         default:
+             return "UNKNOWN TYPE";  // If type is unrecognized
+     }
+ }
+ 
+ 
+ /// @brief Assigns a GPS Clock Model status based on the provided string.
+ /// @param status_str The status string to parse.
+ /// @param status Pointer to GPS_clock_model_status_enum_t where the status will be stored.
+ /// @return Returns 0 on success, 1 if the status string is unrecognized.
+ uint8_t GPS_clock_model_status_str_to_enum(const char *status_str, GPS_clock_model_status_enum_t *status) {
+     if (strcmp(status_str, "VALID") == 0) {
+         *status = GPS_CLOCK_VALID;
+     } else if (strcmp(status_str, "CONVERGING") == 0) {
+         *status = GPS_CLOCK_CONVERGING;
+     } else if (strcmp(status_str, "ITERATING") == 0) {
+         *status = GPS_CLOCK_ITERATING;
+     } else if (strcmp(status_str, "INVALID") == 0) {
+         *status = GPS_CLOCK_INVALID;
+     } else {
+         return 1;  // Unrecognized status string
+     }
+     return 0;  // Success
+ }
+ 
+ /// @brief Assigns a GPS UTC status based on the provided string.
+ /// @param status_str The status string to parse.
+ /// @param status Pointer to GPS_utc_status_enum_t where the status will be stored.
+ /// @return Returns 0 on success, 1 if the status string is unrecognized.
+ uint8_t GPS_utc_status_str_to_enum(const char *status_str, GPS_utc_status_enum_t *status) {
+     if (strcmp(status_str, "INVALID") == 0) {
+         *status = GPS_UTC_INVALID;
+     } else if (strcmp(status_str, "VALID") == 0) {
+         *status = GPS_UTC_VALID;
+     } else if (strcmp(status_str, "WARNING") == 0) {
+         *status = GPS_UTC_WARNING;
+     } else {
+         return 1;  // Unrecognized status string
+     }
+     return 0;  // Success
+ }
+ 
+ /// @brief Assigns a string value based on the provided GPS clock model status.
+ /// @param status GPS_clock_model_status_enum_t value.
+ /// @return Returns the assigned string value for the GPS_clock_model_status_enum_t.
+ const char* GPS_clock_model_status_enum_to_string(GPS_clock_model_status_enum_t status) {
+     switch (status) {
+         case GPS_CLOCK_VALID:
+             return "VALID";
+         case GPS_CLOCK_CONVERGING:
+             return "CONVERGING";
+         case GPS_CLOCK_ITERATING:
+             return "ITERATING";
+         case GPS_CLOCK_INVALID:
+             return "INVALID";
+         default:
+             return "UNKNOWN STATUS";  // For unrecognized enum values
+     }
+ }
+ 
+ /// @brief Assigns a string value based on the provided GPS UTC status.
+ /// @param status GPS_utc_status_enum_t value.
+ /// @return Returns the assigned string value for the GPS_utc_status_enum_t.
+ const char* GPS_utc_status_enum_to_string(GPS_utc_status_enum_t status) {
+     switch (status) {
+         case GPS_UTC_INVALID:
+             return "INVALID";
+         case GPS_UTC_VALID:
+             return "VALID";
+         case GPS_UTC_WARNING:
+             return "WARNING";
+         default:
+             return "UNKNOWN STATUS";  // For unrecognized enum values
+     }
+ }

--- a/firmware/Core/Src/unit_tests/unit_test_gps.c
+++ b/firmware/Core/Src/unit_tests/unit_test_gps.c
@@ -1,0 +1,387 @@
+#include "unit_tests/unit_test_gps.h"
+ #include "unit_tests/unit_test_helpers.h"
+ #include "transforms/number_comparisons.h"
+ #include "gps/gps_ascii_parsers.h"
+ #include "gps/gps_types.h"
+ 
+ #include <string.h>
+ 
+ 
+ uint8_t TEST_EXEC__GPS_reference_time_status_str_to_enum() {
+     GPS_reference_time_status_t status;
+ 
+     // Test with recognized status strings
+     TEST_ASSERT_TRUE(GPS_reference_time_status_str_to_enum("UNKNOWN", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_REF_TIME_UNKNOWN);
+     TEST_ASSERT_TRUE(GPS_reference_time_status_str_to_enum("APPROXIMATE", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_REF_TIME_APPROXIMATE);
+     TEST_ASSERT_TRUE(GPS_reference_time_status_str_to_enum("COARSEADJUSTING", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_REF_TIME_COARSEADJUSTING);
+     TEST_ASSERT_TRUE(GPS_reference_time_status_str_to_enum("COARSE", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_REF_TIME_COARSE);
+     TEST_ASSERT_TRUE(GPS_reference_time_status_str_to_enum("COARSESTEERING", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_REF_TIME_COARSESTEERING);
+     TEST_ASSERT_TRUE(GPS_reference_time_status_str_to_enum("FREEWHEELING", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_REF_TIME_FREEWHEELING);
+     TEST_ASSERT_TRUE(GPS_reference_time_status_str_to_enum("FINEADJUSTING", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_REF_TIME_FINEADJUSTING);
+     TEST_ASSERT_TRUE(GPS_reference_time_status_str_to_enum("FINE", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_REF_TIME_FINE);
+     TEST_ASSERT_TRUE(GPS_reference_time_status_str_to_enum("FINEBACKUPSTEERING", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_REF_TIME_FINEBACKUPSTEERING);
+     TEST_ASSERT_TRUE(GPS_reference_time_status_str_to_enum("FINESTEERING", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_REF_TIME_FINESTEERING);
+     TEST_ASSERT_TRUE(GPS_reference_time_status_str_to_enum("SATTIME", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_REF_TIME_SATTIME);
+ 
+     // Test with an unrecognized status string
+     TEST_ASSERT_TRUE(GPS_reference_time_status_str_to_enum("INVALID_STATUS", &status) == 1);
+ 
+     // Test with an empty string
+     TEST_ASSERT_TRUE(GPS_reference_time_status_str_to_enum("", &status) == 1);
+ 
+     // Test with a NULL string
+     TEST_ASSERT_TRUE(GPS_reference_time_status_str_to_enum(NULL, &status) == 1);
+ 
+     return 0;
+ 
+ }
+ 
+ uint8_t TEST_EXEC__GPS_solution_status_str_to_enum() {
+     GPS_solution_status_enum_t status;
+ 
+     // Test with recognized status strings
+     TEST_ASSERT_TRUE(GPS_solution_status_str_to_enum("SOL_COMPUTED", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_SOL_STATUS_SOL_COMPUTED);
+     TEST_ASSERT_TRUE(GPS_solution_status_str_to_enum("INSUFFICIENT_OBS", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_SOL_STATUS_INSUFFICIENT_OBS);
+     TEST_ASSERT_TRUE(GPS_solution_status_str_to_enum("NO_CONVERGENCE", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_SOL_STATUS_NO_CONVERGENCE);
+     TEST_ASSERT_TRUE(GPS_solution_status_str_to_enum("SINGULARITY", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_SOL_STATUS_SINGULARITY);
+     TEST_ASSERT_TRUE(GPS_solution_status_str_to_enum("COV_TRACE", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_SOL_STATUS_COV_TRACE);
+     TEST_ASSERT_TRUE(GPS_solution_status_str_to_enum("TEST_DIST", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_SOL_STATUS_TEST_DIST);
+     TEST_ASSERT_TRUE(GPS_solution_status_str_to_enum("COLD_START", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_SOL_STATUS_COLD_START);
+     TEST_ASSERT_TRUE(GPS_solution_status_str_to_enum("V_H_LIMIT", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_SOL_STATUS_V_H_LIMIT);
+     TEST_ASSERT_TRUE(GPS_solution_status_str_to_enum("VARIANCE", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_SOL_STATUS_VARIANCE);
+     TEST_ASSERT_TRUE(GPS_solution_status_str_to_enum("RESIDUALS", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_SOL_STATUS_RESIDUALS);
+     TEST_ASSERT_TRUE(GPS_solution_status_str_to_enum("INTEGRITY_WARNING", &status) == 0);
+     TEST_ASSERT_TRUE(status == GPS_SOL_STATUS_INTEGRITY_WARNING);
+ 
+     // Test with an unrecognized status string
+     TEST_ASSERT_TRUE(GPS_solution_status_str_to_enum("UNKNOWN_STATUS", &status) == 1);
+ 
+     // Test with an empty string
+     TEST_ASSERT_TRUE(GPS_solution_status_str_to_enum("", &status) == 1);
+ 
+     // Test with a NULL string
+     TEST_ASSERT_TRUE(GPS_solution_status_str_to_enum(NULL, &status) == 1);
+ 
+     return 0;
+ }
+ 
+ 
+ uint8_t TEST_EXEC__GPS_position_type_str_to_enum() {
+     GPS_position_type_enum_t type;
+ 
+     // Test with recognized type strings
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("NONE", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_NONE);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("FIXEDPOS", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_FIXEDPOS);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("FIXEDHEIGHT", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_FIXEDHEIGHT);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("DOPPLER_VELOCITY", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_DOPPLER_VELOCITY);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("SINGLE", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_SINGLE);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("PSDIFF", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_PSDIFF);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("WAAS", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_WAAS);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("PROPAGATED", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_PROPAGATED);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("L1_FLOAT", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_L1_FLOAT);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("NARROW_FLOAT", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_NARROW_FLOAT);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("L1_INT", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_L1_INT);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("WIDE_INT", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_WIDE_INT);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("NARROW_INT", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_NARROW_INT);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("RTK_DIRECT_INS", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_RTK_DIRECT_INS);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("INS_SBAS", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_INS_SBAS);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("INS_PSRSP", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_INS_PSRSP);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("INS_PSRDIFF", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_INS_PSRDIFF);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("INS_RTKFLOAT", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_INS_RTKFLOAT);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("INS_RTKFIXED", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_INS_RTKFIXED);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("PPP_CONVERGING", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_PPP_CONVERGING);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("PPP", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_PPP);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("OPERATIONAL", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_OPERATIONAL);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("WARNING", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_WARNING);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("OUT_OF_BOUNDS", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_OUT_OF_BOUNDS);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("INS_PPP_CONVERGING", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_INS_PPP_CONVERGING);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("INS_PPP", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_INS_PPP);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("PPP_BASIC_CONVERGING", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_PPP_BASIC_CONVERGING);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("PPP_BASIC", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_PPP_BASIC);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("INS_PPP_BASIC_CONVERGING", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_INS_PPP_BASIC_CONVERGING);
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("INS_PPP_BASIC", &type) == 0);
+     TEST_ASSERT_TRUE(type == GPS_TYPE_INS_PPP_BASIC);
+ 
+     // Test with an unrecognized type string
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("INVALID_TYPE", &type) == 1);
+ 
+     // Test with an empty string
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum("", &type) == 1);
+ 
+     // Test with a NULL string
+     TEST_ASSERT_TRUE(GPS_position_type_str_to_enum(NULL, &type) == 1);
+ 
+     return 0;
+ }
+ 
+ uint8_t TEST_EXEC__GPS_header_response_parser(){
+     // TODO: Try testing with another header string
+     
+     // Testing with a Valid GPS Header
+     char gps_data[600] = "#BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724;"
+                   "SOL_COMPUTED,NARROW_INT,-1634531.5683,-3664618.0326,4942496.3270,0.0099,"
+                   "0.0219,0.0115,SOL_COMPUTED,NARROW_INT,0.0011,-0.0049,-0.0001,0.0199,0.0439,"
+                   "0.0230,\"AAAA\",0.250,1.000,0.000,12,11,11,11,0,01,0,33*e9eafeca";
+ 
+     GPS_header_response_t gps_header_result;
+ 
+     uint8_t result = GPS_header_response_parser(gps_data, &gps_header_result);
+     TEST_ASSERT_TRUE(result == 0);
+     TEST_ASSERT_TRUE(strcmp(gps_header_result.log_name, "BESTXYZA") == 0);
+     TEST_ASSERT_TRUE(gps_header_result.time_status == GPS_REF_TIME_FINESTEERING);
+ 
+     // Testing with a different Valid GPS Header
+     strcpy(gps_data,
+     "#TIMEA,COM1,0,86.5,FINESTEERING,1930,428348.000,02000020,"
+     "9924,32768;VALID,1.667187222e-10,9.641617960e-10,-18.00000000000,"
+     "2017,1,5,22,58,50000,VALID*2a066e78");
+     
+     result = GPS_header_response_parser(gps_data, &gps_header_result);
+     TEST_ASSERT_TRUE(result == 0);
+ 
+     // Testing an empty string
+     strcpy(gps_data,"");
+     result = GPS_header_response_parser(gps_data, &gps_header_result);
+     TEST_ASSERT_TRUE(result == 1);
+ 
+     // Testing Missing Sync Character
+     strcpy(gps_data,"BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724;");
+     result = GPS_header_response_parser(gps_data, &gps_header_result);
+     TEST_ASSERT_TRUE(result == 2);
+ 
+     // Testing missing Terminating character
+     strcpy(gps_data,"#BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724");
+     result = GPS_header_response_parser(gps_data, &gps_header_result);
+     TEST_ASSERT_TRUE(result == 2);
+ 
+     // Testing missing both Sync and Terminating Character
+     strcpy(gps_data,"BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724");
+     result = GPS_header_response_parser(gps_data, &gps_header_result);
+     TEST_ASSERT_TRUE(result == 2);
+ 
+     // Testing missing both Sync and Terminating Character
+     strcpy(gps_data,"BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724");
+     result = GPS_header_response_parser(gps_data, &gps_header_result);
+     TEST_ASSERT_TRUE(result == 2);
+ 
+     // Testing when the ; charcacter comes before the # character
+     strcpy(gps_data,
+                   "02000040,d821,2724;SOL_COMPUTED,NARROW_INT,-1634531.5683,-3664618.0326,4942496.3270,"
+                   "0.0099,0.0219,0.0115,SOL_COMPUTED,NARROW_INT,0.0011,-0.0049,-0.0001,0.0199,0.0439,"
+                   "0.0230,\"AAAA\",0.250,1.000,0.000,12,11,11,11,0,01,0,33*e9eafeca"
+                   "#BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724;" );
+     result = GPS_header_response_parser(gps_data, &gps_header_result);
+     TEST_ASSERT_TRUE(result == 3);
+ 
+     // Testing when the header buffer is exceeded
+     strcpy(gps_data,"#BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724"
+                     "BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724"
+                     "BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724"
+                     "BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724;");
+     result = GPS_header_response_parser(gps_data, &gps_header_result);
+     TEST_ASSERT_TRUE(result == 4);
+ 
+     return 0;
+ }
+ 
+ uint8_t TEST_EXEC__GPS_bestxyza_data_parser(){
+     char gps_data[600] = "#BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724;"
+                   "SOL_COMPUTED,NARROW_INT,-1634531.5683,-3664618.0326,-3664618.0326,0.0099,"
+                   "0.0219,0.0115,SOL_COMPUTED,NARROW_INT,0.0011,-0.0049,-0.0001,0.0199,0.0439,"
+                   "0.0230,\"AAAA\",0.250,1.000,0.000,12,11,11,11,0,01,0,33*e9eafeca";
+ 
+     GPS_bestxyza_response_t result;
+ 
+     // Call bestxyza parser
+     uint8_t parse_result = GPS_bestxyza_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 0);
+     TEST_ASSERT_TRUE(result.position_solution_status == GPS_SOL_STATUS_SOL_COMPUTED);
+     TEST_ASSERT_TRUE(result.position_type == GPS_TYPE_NARROW_INT);
+     TEST_ASSERT_TRUE(result.position_x_mm == -1634531568);
+     TEST_ASSERT_TRUE(result.position_y_mm == -3664618032);
+     TEST_ASSERT_TRUE(result.position_z_mm == -3664618032);
+     TEST_ASSERT_TRUE(result.position_x_std_mm == 9);
+     TEST_ASSERT_TRUE(result.position_y_std_mm == 21);
+     TEST_ASSERT_TRUE(result.position_z_std_mm == 11);
+     TEST_ASSERT_TRUE(result.differential_age_ms == 1000);
+     TEST_ASSERT_TRUE(result.solution_age_ms == 0000);
+     TEST_ASSERT_TRUE(result.crc == 0xe9eafeca);
+ 
+     
+ 
+     // Testing with an empty string
+     strcpy(gps_data, "");
+     parse_result = GPS_bestxyza_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 1);
+ 
+     // Introducing an error within the header of the GPS response: Missing delimiting character
+     strcpy(gps_data, "#BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724"
+                   "SOL_COMPUTED,NARROW_INT,-1634531.5683,-3664618.0326,-3664618.0326,0.0099,"
+                   "0.0219,0.0115,SOL_COMPUTED,NARROW_INT,0.0011,-0.0049,-0.0001,0.0199,0.0439,"
+                   "0.0230,\"AAAA\",0.250,1.000,0.000,12,11,11,11,0,01,0,33*e9eafeca");
+     parse_result = GPS_bestxyza_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 2);
+ 
+     // Testing with a different GPS Header
+     strcpy(gps_data,
+     "#TIMEA,COM1,0,86.5,FINESTEERING,1930,428348.000,02000020,9924,32768;"
+     "VALID,1.667187222e-10,9.641617960e-10,-18.00000000000,2017,1,5,22,58,50000,VALID*2a066e78"
+     );
+     parse_result = GPS_bestxyza_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 3);
+ 
+     // Missing bestxyza data response
+     strcpy(gps_data,"#BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724;");
+     parse_result = GPS_bestxyza_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 4);
+ 
+     // Missing delimiting character * which denotes the end of the data response
+     strcpy(gps_data, "#BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724;"
+                     "SOL_COMPUTED,NARROW_INT,-1634531.5683,-3664618.0326,-3664618.0326,0.0099,"
+                     "0.0219,0.0115,SOL_COMPUTED,NARROW_INT,0.0011,-0.0049,-0.0001,0.0199,0.0439,"
+                     "0.0230,\"AAAA\",0.250,1.000,0.000,12,11,11,11,0,01,0,33");
+     parse_result = GPS_bestxyza_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 5);
+ 
+     // Data Response is larger than the buffer
+     strcpy(gps_data, "#BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724;"
+                     "SOL_COMPUTED,NARROW_INT,-1634531.5683,-3664618.0326,-3664618.0326,0.0099,"
+                     "0.0219,0.0115,SOL_COMPUTED,NARROW_INT,0.0011,-0.0049,-0.0001,0.0199,0.0439,"
+                     "0.0219,0.0115,SOL_COMPUTED,NARROW_INT,0.0011,-0.0049,-0.0001,0.0199,0.0439,"
+                     "0.0219,0.0115,SOL_COMPUTED,NARROW_INT,0.0011,-0.0049,-0.0001,0.0199,0.0439,"
+                     "0.0219,0.0115,SOL_COMPUTED,NARROW_INT,0.0011,-0.0049,-0.0001,0.0199,0.0439,"
+                     "0.0219,0.0115,SOL_COMPUTED,NARROW_INT,0.0011,-0.0049,-0.0001,0.0199,0.0439,"
+                     "0.0219,0.0115,0.11,"
+                     "0.0230,\"AAAA\",0.250,1.000,0.000,12,11,11,11,0,01,0,33*2a066e78");
+     parse_result = GPS_bestxyza_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 6);
+ 
+     // Error within the integer section of the string ie postion_x_mm has an invalid number
+     strcpy(gps_data, "#BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724;"
+                     "SOL_COMPUTED,NARROW_INT,abcd123.456,-3664618.0326,-3664618.0326,0.0099,"
+                     "0.0219,0.0115,SOL_COMPUTED,NARROW_INT,0.0011,-0.0049,-0.0001,0.0199,0.0439,"
+                     "0.0230,\"AAAA\",0.250,1.000,0.000,12,11,11,11,0,01,0,33*2a066e78");
+     parse_result = GPS_bestxyza_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 7);
+ 
+     return 0;
+ }
+ 
+ 
+ uint8_t TEST_EXEC__GPS_timea_data_parser(){
+     char gps_data[600] = "#TIMEA,COM1,0,86.5,FINESTEERING,1930,428348.000,02000020,9924,32768;VALID,"
+                         "1.667187222e-10,9.641617960e-10,-18.00000000000,2017,1,5,22,58,50000,VALID*2a066e78";
+ 
+     GPS_timea_response_t result;
+ 
+     // Call timea parser
+     uint8_t parse_result = GPS_timea_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 0);
+     TEST_ASSERT_TRUE(result.clock_status == GPS_CLOCK_VALID);
+     TEST_ASSERT_TRUE(result.utc_offset == -18.00000000000);
+     TEST_ASSERT_TRUE(result.utc_status == GPS_UTC_VALID);
+     TEST_ASSERT_TRUE(result.crc == 0x2a066e78);
+ 
+     // Testing with an empty string
+     strcpy(gps_data, "");
+     parse_result = GPS_timea_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 1);
+ 
+     // Introducing an error within the header of the GPS response: Missing delimiting character
+     strcpy(gps_data, "#TIMEA,COM1,0,86.5,FINESTEERING,1930,428348.000,02000020,9924,32768,VALID,"
+                     "1.667187222e-10,9.641617960e-10,-18.00000000000,2017,1,5,22,58,50000,VALID*2a066e78");
+     parse_result = GPS_timea_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 2);
+ 
+     // Testing with a different GPS Header
+     strcpy(gps_data,
+     "#RAWEPHEMA,COM1,0,55.5,SATTIME,2072,133140.000,02000000,58ba,15761;32,2072,"
+     "136800,8b00602b57a606100004389101eefa4e0eeed24e012f216600007608cd27,"
+     "8b00602b58282f02373454d33b986d01bd01a76ba710a2a10d008e21667f,"
+     "8b00602b58ae003384abe701001226ff6c6c1c9999f3c99fffa77c2f05c8*d3806ea3"
+     );
+     parse_result = GPS_timea_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 3);
+ 
+     // Missing timea data response after the header
+     strcpy(gps_data, "#TIMEA,COM1,0,86.5,FINESTEERING,1930,428348.000,02000020,9924,32768;");
+     parse_result = GPS_timea_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 4);
+ 
+     // Missing delimiting character * ie no CRC
+     strcpy(gps_data, "#TIMEA,COM1,0,86.5,FINESTEERING,1930,428348.000,02000020,9924,32768;VALID,"
+                     "1.667187222e-10,9.641617960e-10,-18.00000000000,2017,1,5,22,58,50000,VALID");
+     parse_result = GPS_timea_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 5);
+ 
+     // Data Response Exceeding Buffer Size
+     strcpy(gps_data, "#TIMEA,COM1,0,86.5,FINESTEERING,1930,428348.000,02000020,9924,32768;VALID,"
+                         "1.667187222e-10,9.641617960e-10,-18.00000000000,2017,1,5,22,58,50000,VALID,"
+                         "1.667187222e-10,9.641617960e-10,-18.00000000000,2017,1,5,22,58,50000,VALID,"
+                         "1.667187222e-10,9.641617960e-10,-18.00000000000,2017,1,5,22,58,50000,VALID,"
+                         "1.667187222e-10,9.641617960e-10,-18.00000000000,2017,1,5,22,58,50000,VALID,"
+                         "1.667187222e-10,9.641617960e-10,-18.00000000000,2017,1,5,22,58,50000,VALID,"
+                         "1.667187222e-10,9.641617960e-10,-18.00000000000,2017,1,5,22,58,"
+                         "1.667187222e-10,9.641617960e-10,-18.00000000000,2017,1,5,22,58,50000,VALID*d3806ea3");
+     parse_result = GPS_timea_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 6);
+ 
+     // Error within the integer section of the string ie utc_offset has an invalid number
+     strcpy(gps_data, "#TIMEA,COM1,0,86.5,FINESTEERING,1930,428348.000,02000020,9924,32768;VALID,"
+                     "1.667187222e-10,9.641617960e-10,usdhnd18.00000000000,2017,1,5,22,58,50000,VALID*2a066e78");
+     parse_result = GPS_timea_data_parser(gps_data, &result);
+     TEST_ASSERT_TRUE(parse_result == 7);
+     
+ 
+     return 0;
+ }

--- a/firmware/Core/Src/unit_tests/unit_test_inventory.c
+++ b/firmware/Core/Src/unit_tests/unit_test_inventory.c
@@ -11,6 +11,7 @@
 #include "unit_tests/unit_test_helpers.h"
 #include "unit_tests/test_configuration_variables.h"
 #include "unit_tests/test_obc_temperature_sensor.h"
+#include "unit_tests/unit_test_gps.h"
 
 #include "unit_tests/test_eps_drivers.h"
 #include "unit_tests/test_eps_struct_packers.h"
@@ -496,6 +497,40 @@ const TEST_Definition_t TEST_definitions[] = {
         .test_file = "crc/crc",
         .test_func_name = "GEN_crc32_checksum"
     },
+    // ****************** SECTION: unit_test_gps ******************
+ 
+    {
+        .test_func = TEST_EXEC__GPS_reference_time_status_str_to_enum,
+        .test_file = "gps/gps_types",
+        .test_func_name = "GPS_reference_time_status_str_to_enum"
+    },
+    {
+        .test_func = TEST_EXEC__GPS_solution_status_str_to_enum,
+        .test_file = "gps/gps_types",
+        .test_func_name = "GPS_solution_status_str_to_enum"
+    },
+    {
+        .test_func = TEST_EXEC__GPS_position_type_str_to_enum,
+        .test_file = "gps/gps_types",
+        .test_func_name = "GPS_position_type_str_to_enum"
+    },
+    {
+        .test_func = TEST_EXEC__GPS_header_response_parser,
+        .test_file = "gps/gps_ascii_parsers",
+        .test_func_name = "GPS_header_response_parser"
+    },
+    {
+        .test_func = TEST_EXEC__GPS_bestxyza_data_parser,
+        .test_file = "gps/gps_ascii_parsers",
+        .test_func_name = "GPS_bestxyza_data_parser"
+    },
+    {
+        .test_func = TEST_EXEC__GPS_timea_data_parser,
+        .test_file = "gps/gps_ascii_parsers",
+        .test_func_name = "GPS_timea_data_parser"
+    },
+
+    // ****************** END SECTION: unit_test_gps ******************
 };
 
 // extern


### PR DESCRIPTION
Summary
This PR contains functions to perform ASCII parsing for the following GPS log functions:

BESTXYZA
TIMEA
Respective unit tests have been created for the functions to achieve this.

Testing Instructions
I verified the accuracy of the GPS ASCII parsing functions by running the run_all_unit_tests telecommand and ensured that all my unit tests passed. I left my LOG_message function calls in to show the error being invoked. However, this will be removed during the review to declutter the unit test call function with all the prints to UART.