### PR TITLE
Create telecommand: `fs_write_file_hex`

### DIFF
--- a/firmware/Core/Inc/littlefs/littlefs_helper.h
+++ b/firmware/Core/Inc/littlefs/littlefs_helper.h
@@ -32,6 +32,7 @@ int8_t LFS_list_directory(const char root_directory[], uint16_t offset, int16_t 
 int8_t LFS_make_directory(const char dir_name[]);
 int8_t LFS_delete_file(const char file_name[]);
 int8_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t write_buffer_len);
+int8_t LFS_write_file_with_offset(const char file_name[], lfs_soff_t offset, uint8_t *write_buffer, uint32_t write_buffer_len);
 int8_t LFS_append_file(const char file_name[], uint8_t *write_buffer, uint32_t write_buffer_len);
 lfs_ssize_t LFS_read_file(const char file_name[], lfs_soff_t offset, uint8_t *read_buffer, uint32_t read_buffer_len);
 lfs_ssize_t LFS_file_size(const char file_name[]);

--- a/firmware/Core/Inc/telecommands/lfs_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/lfs_telecommand_defs.h
@@ -23,6 +23,9 @@ uint8_t TCMDEXEC_fs_make_directory(const char *args_str, TCMD_TelecommandChannel
 uint8_t TCMDEXEC_fs_write_file_str(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
+uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
 uint8_t TCMDEXEC_fs_delete_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len);
                         

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -406,6 +406,16 @@ int8_t LFS_write_file_with_offset(const char file_name[], lfs_soff_t offset, uin
             
             LOG_message(LOG_SYSTEM_LFS, LOG_SEVERITY_NORMAL, LOG_all_sinks_except(LOG_SINK_FILE), 
                        "Extending file from %ld to %ld bytes", current_size, offset);
+
+            // Start writing zeros from the current file size to the desired offset
+            const lfs_soff_t seek_result_1 = lfs_file_seek(&LFS_filesystem, &file, current_size, LFS_SEEK_SET);
+            if (seek_result_1 < 0)
+            {
+                LOG_message(LOG_SYSTEM_LFS, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), 
+                           "Error seeking to offset %ld in file: %s (error: %ld)", current_size, file_name, seek_result_1);
+                lfs_file_close(&LFS_filesystem, &file);
+                return seek_result_1;
+            }
             
             while (gap_size > 0) 
             {
@@ -427,15 +437,15 @@ int8_t LFS_write_file_with_offset(const char file_name[], lfs_soff_t offset, uin
     else 
     {
         // Seek to the specified offset
-        const lfs_soff_t seek_result = lfs_file_seek(&LFS_filesystem, &file, offset, LFS_SEEK_SET);
-        if (seek_result < 0)
+        const lfs_soff_t seek_result_2 = lfs_file_seek(&LFS_filesystem, &file, offset, LFS_SEEK_SET);
+        if (seek_result_2 < 0)
         {
             LOG_message(LOG_SYSTEM_LFS, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), 
-                       "Error seeking to offset %ld in file: %s (error: %ld)", offset, file_name, seek_result);
+                       "Error seeking to offset %ld in file: %s (error: %ld)", offset, file_name, seek_result_2);
             
             // Close the file before returning
             lfs_file_close(&LFS_filesystem, &file);
-            return seek_result;
+            return seek_result_2;
         }
     }
 

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -416,7 +416,7 @@ int8_t LFS_write_file_with_offset(const char file_name[], lfs_soff_t offset, uin
                 if (write_zeros_result < 0) 
                 {
                     LOG_message(LOG_SYSTEM_LFS, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), 
-                               "Error extending file: %s (error: %d)", file_name, write_zeros_result);
+                               "Error extending file: %s (error: %ld)", file_name, write_zeros_result);
                     lfs_file_close(&LFS_filesystem, &file);
                     return write_zeros_result;
                 }
@@ -445,7 +445,7 @@ int8_t LFS_write_file_with_offset(const char file_name[], lfs_soff_t offset, uin
     if (write_result < 0)
     {
         LOG_message(LOG_SYSTEM_LFS, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), 
-                   "Error writing to file: %s at offset %ld (error: %d)", file_name, offset, write_result);
+                   "Error writing to file: %s at offset %ld (error: %ld)", file_name, offset, write_result);
         
         // Close the file before returning
         lfs_file_close(&LFS_filesystem, &file);

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -360,7 +360,6 @@ int8_t LFS_append_file(const char file_name[], uint8_t *write_buffer, uint32_t w
 /// @param write_buffer - Pointer to buffer holding the data to write
 /// @param write_buffer_len - Size of the data to write
 /// @retval 0 on success, 1 if LFS is unmounted, negative LFS error codes on failure
- 
 int8_t LFS_write_file_with_offset(const char file_name[], lfs_soff_t offset, uint8_t *write_buffer, uint32_t write_buffer_len)
 {
     if (!LFS_is_lfs_mounted)

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -179,7 +179,8 @@ uint8_t TCMDEXEC_fs_write_file_str(const char *args_str, TCMD_TelecommandChannel
 /// @param args_str
 /// - Arg 0: File path as string
 /// - Arg 1: Offset within the file to start writing (uint64)
-/// - Arg 2: Hex string to write to file (e.g., "DEADBEEF" or "DE AD BE EF"). Up to 512 bytes.
+/// - Arg 2: Hex string to write to file (e.g., "DEADBEEF" or "DE AD BE EF")
+/// @note The maximum number of bytes that can be written is 105 bytes
 uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char arg_file_name[LFS_MAX_PATH_LENGTH];
@@ -206,7 +207,7 @@ uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel
     }
 
     // Buffer to hold the converted hex data
-    uint8_t binary_data[512] = {0};
+    uint8_t binary_data[105] = {0};
     uint16_t binary_data_length = 0;
     
     // Extract and convert hex string to binary data

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -175,7 +175,66 @@ uint8_t TCMDEXEC_fs_write_file_str(const char *args_str, TCMD_TelecommandChannel
     return 0;
 }
 
-// TODO: Add a `fs_write_file_hex` telecommand, which supports offsets within the file. (Issue #266)
+/// @brief Telecommand: Write hex data to a file in LittleFS with offset support
+/// @param args_str
+/// - Arg 0: File path as string
+/// - Arg 1: Offset within the file to start writing (uint64)
+/// - Arg 2: Hex string to write to file (e.g., "DEADBEEF" or "DE AD BE EF")
+uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+                        char *response_output_buf, uint16_t response_output_buf_len) {
+    char arg_file_name[LFS_MAX_PATH_LENGTH];
+    const uint8_t parse_file_name_result = TCMD_extract_string_arg(args_str, 0, arg_file_name, sizeof(arg_file_name));
+    if (parse_file_name_result != 0) {
+        // error parsing
+        snprintf(
+            response_output_buf,
+            response_output_buf_len,
+            "Error parsing file name arg: Error %d", parse_file_name_result);
+        return 1;
+    }
+
+    // Extract the offset parameter
+    uint64_t file_offset = 0;
+    const uint8_t parse_offset_result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 1, &file_offset);
+    if (parse_offset_result != 0) {
+        // error parsing
+        snprintf(
+            response_output_buf,
+            response_output_buf_len,
+            "Error parsing offset arg: Error %d", parse_offset_result);
+        return 2;
+    }
+
+    // Buffer to hold the converted hex data
+    uint8_t binary_data[512] = {0};
+    uint16_t binary_data_length = 0;
+    
+    // Extract and convert hex string to binary data
+    const uint8_t parse_hex_result = TCMD_extract_hex_array_arg(
+        args_str, 2, binary_data, sizeof(binary_data), &binary_data_length
+    );
+    
+    if (parse_hex_result != 0) {
+        // error parsing
+        snprintf(
+            response_output_buf,
+            response_output_buf_len,
+            "Error parsing hex data arg: Error %d", parse_hex_result);
+        return 3;
+    }
+
+    // Use our new helper function to write the data at the specified offset
+    const int8_t result = LFS_write_file_with_offset(arg_file_name, file_offset, binary_data, binary_data_length);
+    if (result < 0) {
+        snprintf(response_output_buf, response_output_buf_len, "LittleFS Writing Error: %d", result);
+        return 4;
+    }
+    
+    snprintf(response_output_buf, response_output_buf_len, 
+             "LittleFS Successfully Wrote %d bytes of hex data at offset %llu!", 
+             binary_data_length, file_offset);
+    return 0;
+}
 
 /// @brief Telecommand: Deletes a specified file in LittleFS
 /// @param args_str

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -231,7 +231,7 @@ uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel
     }
     
     snprintf(response_output_buf, response_output_buf_len, 
-             "LittleFS Successfully Wrote %d bytes of hex data at offset %lu!", 
+             "LittleFS Successfully Wrote %d bytes of hex data at offset %ld!", 
              binary_data_length, file_offset);
     return 0;
 }

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -226,7 +226,7 @@ uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel
 
     // Use our new helper function to write the data at the specified offset
     const int8_t result = LFS_write_file_with_offset(arg_file_name, (lfs_soff_t)file_offset, binary_data, binary_data_length);
-    if (result < 0) {
+    if (result != 0) {
         snprintf(response_output_buf, response_output_buf_len, "LittleFS Writing Error: %d", result);
         return 4;
     }

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -231,7 +231,7 @@ uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel
     }
     
     snprintf(response_output_buf, response_output_buf_len, 
-             "LittleFS Successfully Wrote %d bytes of hex data at offset %llu!", 
+             "LittleFS Successfully Wrote %d bytes of hex data at offset %lu!", 
              binary_data_length, file_offset);
     return 0;
 }

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -179,7 +179,7 @@ uint8_t TCMDEXEC_fs_write_file_str(const char *args_str, TCMD_TelecommandChannel
 /// @param args_str
 /// - Arg 0: File path as string
 /// - Arg 1: Offset within the file to start writing (uint64)
-/// - Arg 2: Hex string to write to file (e.g., "DEADBEEF" or "DE AD BE EF")
+/// - Arg 2: Hex string to write to file (e.g., "DEADBEEF" or "DE AD BE EF"). Up to 512 bytes.
 uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char arg_file_name[LFS_MAX_PATH_LENGTH];
@@ -219,20 +219,20 @@ uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel
         snprintf(
             response_output_buf,
             response_output_buf_len,
-            "Error parsing hex data arg: Error %lld", parse_hex_result);
+            "Error parsing hex data arg: Error %d", parse_hex_result);
         return 3;
     }
 
     // Use our new helper function to write the data at the specified offset
-    const int8_t result = LFS_write_file_with_offset(arg_file_name, file_offset, binary_data, binary_data_length);
+    const int8_t result = LFS_write_file_with_offset(arg_file_name, (lfs_soff_t)file_offset, binary_data, binary_data_length);
     if (result < 0) {
         snprintf(response_output_buf, response_output_buf_len, "LittleFS Writing Error: %d", result);
         return 4;
     }
     
     snprintf(response_output_buf, response_output_buf_len, 
-             "LittleFS Successfully Wrote %d bytes of hex data at offset %d!", 
-             binary_data_length, file_offset);
+             "LittleFS Successfully Wrote %d bytes of hex data!", 
+             binary_data_length);
     return 0;
 }
 

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -219,7 +219,7 @@ uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel
         snprintf(
             response_output_buf,
             response_output_buf_len,
-            "Error parsing hex data arg: Error %d", parse_hex_result);
+            "Error parsing hex data arg: Error %lld", parse_hex_result);
         return 3;
     }
 
@@ -231,7 +231,7 @@ uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel
     }
     
     snprintf(response_output_buf, response_output_buf_len, 
-             "LittleFS Successfully Wrote %d bytes of hex data at offset %ld!", 
+             "LittleFS Successfully Wrote %d bytes of hex data at offset %d!", 
              binary_data_length, file_offset);
     return 0;
 }

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -288,6 +288,12 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {
+        .tcmd_name = "fs_write_file_hex",
+        .tcmd_func = TCMDEXEC_fs_write_file_hex,
+        .number_of_args = 3,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+    {
         .tcmd_name = "fs_delete_file",
         .tcmd_func = TCMDEXEC_fs_delete_file,
         .number_of_args = 1,


### PR DESCRIPTION
Resolves #266 

Summary: Creates telecommand `fs_write_file_hex` that allows for storing hex files into a littlefs file. Works by sending a filename, offset to start writing at within the file, and the hex values to store.

Initial testing shows the function working properly, as well as proper error cases when sending the telecommand. 