### PR TITLE
EPS: When enabling a channel, print its name; warn if disabling stack channel

### DIFF
--- a/firmware/Core/Src/telecommands/eps_telecommands.c
+++ b/firmware/Core/Src/telecommands/eps_telecommands.c
@@ -192,6 +192,19 @@ uint8_t TCMDEXEC_eps_set_channel_enabled(
     const char *eps_channel_name_str = EPS_channel_to_str(eps_channel);
     const uint8_t eps_channel_num = (uint8_t) eps_channel;
 
+    if (
+        ((eps_channel == EPS_CHANNEL_3V3_STACK)
+        || (eps_channel == EPS_CHANNEL_5V_STACK)
+        || (eps_channel == EPS_CHANNEL_VBATT_STACK))
+        && (enabled_val_u64 == 0)
+    ) {
+        LOG_message(
+            LOG_SYSTEM_EPS, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+            "Cannot disable the stack channels: %s. Trying anyway.",
+            eps_channel_name_str
+        );
+        return 8;
+    }
 
     const uint8_t eps_result = EPS_set_channel_enabled(eps_channel, (uint8_t)enabled_val_u64);
 

--- a/firmware/Core/Src/telecommands/eps_telecommands.c
+++ b/firmware/Core/Src/telecommands/eps_telecommands.c
@@ -7,7 +7,7 @@
 #include "eps_drivers/eps_power_management.h"
 #include "telecommands/eps_telecommands.h"
 #include "telecommand_exec/telecommand_args_helpers.h"
-
+#include "log/log.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -188,13 +188,18 @@ uint8_t TCMDEXEC_eps_set_channel_enabled(
         return 4;
     }
 
+    // Convert to a nice string/channel number.
+    const char *eps_channel_name_str = EPS_channel_to_str(eps_channel);
+    const uint8_t eps_channel_num = (uint8_t) eps_channel;
+
 
     const uint8_t eps_result = EPS_set_channel_enabled(eps_channel, (uint8_t)enabled_val_u64);
 
     if (eps_result != 0) {
         snprintf(
             response_output_buf, response_output_buf_len,
-            "EPS set channel %s failed (err %d)",
+            "EPS set channel %d (%s) %s failed (err %d)",
+            eps_channel_num, eps_channel_name_str,
             enabled_str,
             eps_result
         );
@@ -202,7 +207,8 @@ uint8_t TCMDEXEC_eps_set_channel_enabled(
     }
     snprintf(
         response_output_buf, response_output_buf_len,
-        "EPS set channel %s successful.",
+        "EPS set channel %d (%s) %s successful.",
+        eps_channel_num, eps_channel_name_str,
         enabled_str
     );
     return 0;

--- a/firmware/Core/Src/telecommands/eps_telecommands.c
+++ b/firmware/Core/Src/telecommands/eps_telecommands.c
@@ -167,10 +167,10 @@ uint8_t TCMDEXEC_eps_set_channel_enabled(
     }
     char enabled_str[20] = "?";
     if (enabled_val_u64 == 0) {
-        strcpy(enabled_str, "disabled");
+        strcpy(enabled_str, "disable");
     }
     else if (enabled_val_u64 == 1) {
-        strcpy(enabled_str, "enabled");
+        strcpy(enabled_str, "enable");
     }
     else {
         snprintf(
@@ -211,18 +211,21 @@ uint8_t TCMDEXEC_eps_set_channel_enabled(
     if (eps_result != 0) {
         snprintf(
             response_output_buf, response_output_buf_len,
-            "EPS set channel %d (%s) %s failed (err %d)",
-            eps_channel_num, eps_channel_name_str,
+            "EPS %s channel %d (%s) failed (err %d).",
             enabled_str,
+            eps_channel_num, eps_channel_name_str,
             eps_result
         );
         return 5;
     }
     snprintf(
         response_output_buf, response_output_buf_len,
-        "EPS set channel %d (%s) %s successful.",
-        eps_channel_num, eps_channel_name_str,
-        enabled_str
+        // Note: The word "success" is intentionally omitted here, because attempting to disable
+        // certain channels (e..g, the always-on stack channels) will return success, but will not
+        // actually disable the channel.
+        "EPS %s channel %d (%s) executed.",
+        enabled_str,
+        eps_channel_num, eps_channel_name_str
     );
     return 0;
 }


### PR DESCRIPTION
Fixes #303

### Test Procedure

1. Enable a random channel using its number. Ensure its name and number is printed. 
2. Enable a random channel using its name. Ensure its name and number is printed. 
3. Try disabling the 3V3_STACK channel, the 5V_STACK channel, and the VBATT_STACK channel. Ensure each of them log a warning, and then continue their attempt. 