### PR TITLE
Reading MPI Science Mode Enable / Disable

### DIFF
--- a/firmware/Core/Inc/mpi/mpi_command_handling.h
+++ b/firmware/Core/Inc/mpi/mpi_command_handling.h
@@ -16,6 +16,7 @@ extern uint8_t MPI_science_file_can_close;
 extern uint8_t MPI_science_data_file_is_open;
 extern uint32_t MPI_science_data_bytes_lost;
 extern lfs_file_t MPI_science_data_file_pointer;
+extern uint32_t MPI_recording_start_uptime_ms;
 
 uint8_t MPI_send_command_get_response(
     const uint8_t *bytes_to_send, const size_t bytes_to_send_len, 

--- a/firmware/Core/Inc/mpi/mpi_command_handling.h
+++ b/firmware/Core/Inc/mpi/mpi_command_handling.h
@@ -12,7 +12,6 @@ static const uint8_t MPI_COMMAND_SUCCESS_RESPONSE_VALUE = 0xFE; // 0xFE = 254
 /// @brief Current mode under which the MPI is being operated.
 extern volatile MPI_rx_mode_t MPI_current_uart_rx_mode;
 
-extern uint8_t MPI_science_file_can_close;
 extern uint8_t MPI_science_data_file_is_open;
 extern uint32_t MPI_science_data_bytes_lost;
 extern lfs_file_t MPI_science_data_file_pointer;

--- a/firmware/Core/Inc/mpi/mpi_command_handling.h
+++ b/firmware/Core/Inc/mpi/mpi_command_handling.h
@@ -24,8 +24,8 @@ uint8_t MPI_send_command_get_response(
     uint16_t *rx_buffer_len
 );
 
-int8_t MPI_prepare_receive_data(const char MPI_science_file_name[]);
-uint8_t MPI_enable_active_mode(const char MPI_science_file_name[]);
+int8_t MPI_prepare_receive_data(const char output_file_path[]);
+uint8_t MPI_enable_active_mode(const char output_file_path[]);
 uint8_t MPI_disable_active_mode();
 uint8_t MPI_validate_command_response(
     const uint8_t command_code, uint8_t *rx_buffer, const uint16_t rx_buffer_len

--- a/firmware/Core/Inc/mpi/mpi_command_handling.h
+++ b/firmware/Core/Inc/mpi/mpi_command_handling.h
@@ -12,8 +12,9 @@ static const uint8_t MPI_COMMAND_SUCCESS_RESPONSE_VALUE = 0xFE; // 0xFE = 254
 /// @brief Current mode under which the MPI is being operated.
 extern volatile MPI_rx_mode_t MPI_current_uart_rx_mode;
 
-extern uint8_t MPI_receive_prepared;
+extern uint8_t MPI_science_file_can_close;
 extern uint8_t MPI_science_data_file_is_open;
+extern uint32_t MPI_science_data_bytes_lost;
 extern lfs_file_t MPI_science_data_file_pointer;
 
 uint8_t MPI_send_command_get_response(
@@ -22,8 +23,8 @@ uint8_t MPI_send_command_get_response(
     uint16_t *rx_buffer_len
 );
 
-int8_t MPI_prepare_receive_data();
-uint8_t MPI_enable_active_mode();
+int8_t MPI_prepare_receive_data(const char MPI_science_file_name[]);
+uint8_t MPI_enable_active_mode(const char MPI_science_file_name[]);
 uint8_t MPI_disable_active_mode();
 uint8_t MPI_validate_command_response(
     const uint8_t command_code, uint8_t *rx_buffer, const uint16_t rx_buffer_len

--- a/firmware/Core/Inc/mpi/mpi_command_handling.h
+++ b/firmware/Core/Inc/mpi/mpi_command_handling.h
@@ -5,11 +5,16 @@
 #include <stddef.h>
 
 #include "mpi/mpi_types.h"
+#include "littlefs/lfs.h"
 
 static const uint8_t MPI_COMMAND_SUCCESS_RESPONSE_VALUE = 0xFE; // 0xFE = 254
 
 /// @brief Current mode under which the MPI is being operated.
 extern volatile MPI_rx_mode_t MPI_current_uart_rx_mode;
+
+extern uint8_t MPI_receive_prepared;
+extern uint8_t MPI_science_data_file_is_open;
+extern lfs_file_t MPI_science_data_file_pointer;
 
 uint8_t MPI_send_command_get_response(
     const uint8_t *bytes_to_send, const size_t bytes_to_send_len, 
@@ -17,6 +22,9 @@ uint8_t MPI_send_command_get_response(
     uint16_t *rx_buffer_len
 );
 
+int8_t MPI_prepare_receive_data();
+uint8_t MPI_enable_active_mode();
+uint8_t MPI_disable_active_mode();
 uint8_t MPI_validate_command_response(
     const uint8_t command_code, uint8_t *rx_buffer, const uint16_t rx_buffer_len
 );

--- a/firmware/Core/Inc/mpi/mpi_types.h
+++ b/firmware/Core/Inc/mpi/mpi_types.h
@@ -9,16 +9,17 @@
 #define INCLUDE_GUARD__MPI_TYPES_H
 #include <stdint.h>
 
-/**
- * @enum MPI_rx_mode_t
- * @brief Enumerates the different modes under which the satellite can operate the MPI
- * 
- */
+/// @brief Enumerates the different modes under which the satellite can operate the MPI
 typedef enum {
     MPI_RX_MODE_COMMAND_MODE,               // MPI is in command mode
     MPI_RX_MODE_SENSING_MODE,               // MPI is science data is being collected mode
     MPI_RX_MODE_NOT_LISTENING_TO_MPI        // MPI is recording science data but it is not being collected mode
 } MPI_rx_mode_t;
+
+typedef enum {
+    MPI_MEMORY_WRITE_STATUS_PENDING,        // MPI buffer is waiting to be fully wrote to memory
+    MPI_MEMORY_WRITE_STATUS_READY,          // MPI buffer is ready to be wrote to
+} MPI_buffer_state_enum_t;
 
 /// @brief Represents the state of the MPI transceiver chip.
 typedef enum {

--- a/firmware/Core/Inc/rtos_tasks/rtos_mpi_tasks.h
+++ b/firmware/Core/Inc/rtos_tasks/rtos_mpi_tasks.h
@@ -1,0 +1,6 @@
+#ifndef INCLUDE_GUARD__RTOS_MPI_TASKS_H__
+#define INCLUDE_GUARD__RTOS_MPI_TASKS_H__
+
+void TASK_service_write_mpi_data(void *argument);
+
+#endif // INCLUDE_GUARD__RTOS_MPI_TASKS_H__`

--- a/firmware/Core/Inc/telecommands/mpi_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/mpi_telecommand_defs.h
@@ -19,5 +19,10 @@ uint8_t TCMDEXEC_mpi_demo_set_transceiver_mode(
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
+uint8_t TCMDEXEC_mpi_enable_active_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, 
+    char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_mpi_disable_active_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, 
+    char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif /* INCLUDE_GUARD__MPI_TELECOMMAND_DEFINITIONS_H__ */

--- a/firmware/Core/Inc/uart_handler/uart_handler.h
+++ b/firmware/Core/Inc/uart_handler/uart_handler.h
@@ -4,6 +4,8 @@
 
 #include "stm32l4xx_hal.h"
 #include <stdint.h>
+#include "mpi/mpi_types.h"
+
 
 typedef enum {
     CAMERA_UART_WRITE_STATE_IDLE,
@@ -60,6 +62,16 @@ extern volatile uint16_t UART_gps_buffer_write_idx;
 extern volatile uint32_t UART_gps_last_write_time_ms; 
 extern volatile uint8_t UART_gps_buffer_last_rx_byte;  
 extern volatile uint8_t UART_gps_uart_interrupt_enabled; // Flag to enable or disable the UART GPS ISR
+
+// UART MPI science data buffer
+extern const uint16_t UART_mpi_data_rx_buffer_len; // extern 
+extern volatile uint8_t UART_mpi_data_rx_buffer[]; // extern
+
+extern volatile MPI_buffer_state_enum_t MPI_buffer_state;
+
+extern const uint16_t MPI_active_data_median_buffer_len;
+extern volatile uint8_t MPI_active_data_median_buffer[];
+
 
 
 #define AX100_MAX_KISS_FRAMES_IN_RX_QUEUE  8

--- a/firmware/Core/Src/main.c
+++ b/firmware/Core/Src/main.c
@@ -29,6 +29,7 @@
 #include "rtos_tasks/rtos_eps_tasks.h"
 #include "rtos_tasks/rtos_background_upkeep.h"
 #include "rtos_tasks/rtos_tasks_rx_telecommands.h"
+#include "rtos_tasks/rtos_mpi_tasks.h"
 #include "uart_handler/uart_handler.h"
 #include "adcs_drivers/adcs_types.h"
 #include "adcs_drivers/adcs_commands.h"
@@ -132,6 +133,13 @@ const osThreadAttr_t TASK_service_eps_watchdog_Attributes = {
   .priority = (osPriority_t) osPriorityNormal, //TODO: Figure out which priority makes sense for this task
 };
 
+osThreadId_t TASK_service_write_mpi_data_Handle;
+const osThreadAttr_t TASK_service_write_mpi_data_Attributes = {
+  .name = "TASK_service_write_mpi_data",
+  .stack_size = 512, //in bytes
+  .priority = (osPriority_t) osPriorityNormal, //TODO: Figure out which priority makes sense for this task
+};
+
 osThreadId_t TASK_time_sync_Handle;
 const osThreadAttr_t TASK_time_sync_Attributes = {
   .name = "TASK_time_sync",
@@ -182,6 +190,11 @@ FREERTOS_task_info_struct_t FREERTOS_task_handles_array [] = {
   {
     .task_handle = &TASK_service_eps_watchdog_Handle,
     .task_attribute = &TASK_service_eps_watchdog_Attributes,
+    .lowest_stack_bytes_remaining = UINT32_MAX
+  },
+  {
+    .task_handle = &TASK_service_write_mpi_data_Handle,
+    .task_attribute = &TASK_service_write_mpi_data_Attributes,
     .lowest_stack_bytes_remaining = UINT32_MAX
   },
   {
@@ -338,6 +351,8 @@ int main(void)
   TASK_monitor_freertos_memory_Handle = osThreadNew(TASK_monitor_freertos_memory, NULL, &TASK_monitor_freertos_memory_Attributes);
   
   TASK_service_eps_watchdog_Handle = osThreadNew(TASK_service_eps_watchdog, NULL, &TASK_service_eps_watchdog_Attributes);
+
+  TASK_service_write_mpi_data_Handle = osThreadNew(TASK_service_write_mpi_data, NULL, &TASK_service_write_mpi_data_Attributes);
 
   TASK_time_sync_Handle = osThreadNew(TASK_time_sync, NULL, &TASK_time_sync_Attributes);
 

--- a/firmware/Core/Src/mpi/mpi_command_handling.c
+++ b/firmware/Core/Src/mpi/mpi_command_handling.c
@@ -266,9 +266,6 @@ uint8_t MPI_enable_active_mode(const char MPI_science_file_name[]) {
 
     MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_MISO); // Set the MPI transceiver to MISO mode
     MPI_current_uart_rx_mode = MPI_RX_MODE_SENSING_MODE;
-
-    // FIXME: Do we need this? Had this before to fix an issue now fixed by AbortReceive
-    __HAL_UART_CLEAR_OREFLAG(UART_mpi_port_handle);
     
     // Receive MPI response actively with 8192 buffer size.
     const HAL_StatusTypeDef rx_status = HAL_UART_Receive_DMA(

--- a/firmware/Core/Src/mpi/mpi_command_handling.c
+++ b/firmware/Core/Src/mpi/mpi_command_handling.c
@@ -1,9 +1,11 @@
 #include "mpi/mpi_command_handling.h"
 #include "mpi/mpi_types.h"
 #include "mpi/mpi_transceiver.h"
+#include "eps_drivers/eps_channel_control.h"
 #include "uart_handler/uart_handler.h"
 #include "log/log.h"
 #include "debug_tools/debug_uart.h"
+#include "littlefs/littlefs_helper.h"
 
 #include "main.h"
 #include "stm32l4xx_hal.h"
@@ -19,7 +21,22 @@ static const uint16_t MPI_RX_TIMEOUT_DURATION_MS = 2000;
 
 volatile MPI_rx_mode_t MPI_current_uart_rx_mode = MPI_RX_MODE_NOT_LISTENING_TO_MPI;
 
+/// @brief Current state of the `MPI_active_data_median_buffer` (pending write vs. written).
+volatile MPI_buffer_state_enum_t MPI_buffer_state = MPI_MEMORY_WRITE_STATUS_READY;
 
+uint8_t MPI_receive_prepared = 0;
+uint8_t MPI_science_data_file_is_open = 0;
+lfs_file_t MPI_science_data_file_pointer;
+
+/// @brief Sends commandcode+params to the MPI as bytes
+/// @param bytes_to_send Buffer containing the telecommand + params (IF ANY) as hex bytes
+/// @param bytes_to_send_len Size of telecommand buffer
+/// @param rx_buffer Buffer to store incoming response from the MPI
+/// @param rx_buffer_max_size The maximum size of the MPI response buffer
+/// @param rx_buffer_len Pointer to variable that will contain the length of the populated MPI response buffer 
+/// @return 0: Success, 2: Failed UART transmission, 3: Failed UART reception, 
+///         4: Timeout waiting for 1st byte from MPI, 8: Not enough space in the MPI response buffer
+/// @note If the MPI is in "science data" mode, it will be disabled after the command is executed.
 uint8_t MPI_send_command_get_response(
     const uint8_t *bytes_to_send, const size_t bytes_to_send_len, 
     uint8_t *rx_buffer, const size_t rx_buffer_max_size, 
@@ -127,4 +144,169 @@ uint8_t MPI_validate_command_response(
     }
 
     return 0; //  MPI executed the cmd successfully
+}
+
+
+/// @brief Turns on MPI and prepares a LFS file to store MPI data in.
+/// @return 0: System successfully prepared for MPI data, < 0: Error
+int8_t MPI_prepare_receive_data() {
+    // Power On MPI 5v
+    const uint8_t mpi_5v_result = EPS_set_channel_enabled(EPS_CHANNEL_5V_MPI, 1);
+    if (mpi_5v_result != 0) {
+        LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_SINK_ALL, 
+            "MPI 5v could not be powered on (EPS_set_channel_enabled->%d)",
+            mpi_5v_result
+        );
+    }
+
+    // Power On MPI 12v
+    const uint8_t mpi_12v_result = EPS_set_channel_enabled(EPS_CHANNEL_12V_MPI, 1);
+    if (mpi_12v_result != 0) {
+        LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_SINK_ALL, 
+            "MPI 12v could not be powered on (EPS_set_channel_enabled->%d)",
+            mpi_12v_result
+        );
+    }
+
+    // Start the timer to track time past since we powered on MPI
+    const uint32_t start_time = HAL_GetTick();
+
+    // Mount LFS if not already mounted
+    if (!LFS_is_lfs_mounted) {
+        LFS_mount();
+    }
+        
+    // Create file name
+    char MPI_science_data_file_name[60]; // FIXME: This should be an argument.
+    snprintf(
+        MPI_science_data_file_name,
+        sizeof(MPI_science_data_file_name),
+        "mpi_active_data_file_%lu", HAL_GetTick()
+    );
+
+    // If the old file is open, close the file
+    if (MPI_science_data_file_is_open == 1) {
+        const int8_t close_result = lfs_file_close(&LFS_filesystem, &MPI_science_data_file_pointer);
+        if (close_result < 0) {
+            LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), "Error closing old file: %d", close_result);
+            MPI_receive_prepared = 0;
+            return close_result;
+        }
+        LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), "Old File successfully closed");
+        MPI_science_data_file_is_open = 0;
+    }
+
+    // Open / Create the file
+    const int8_t open_result = lfs_file_opencfg(&LFS_filesystem, &MPI_science_data_file_pointer, MPI_science_data_file_name, LFS_O_WRONLY | LFS_O_CREAT | LFS_O_APPEND, &LFS_file_cfg);
+    
+    // Check if open successful
+    if (open_result < 0) {
+        LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), "Error opening / creating file: %s", MPI_science_data_file_name);
+        MPI_receive_prepared = 0;
+        return open_result;
+    }
+    MPI_science_data_file_is_open = 1;
+    LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_NORMAL, LOG_all_sinks_except(LOG_SINK_FILE), "Opened/created file: %s", MPI_science_data_file_name);
+    MPI_receive_prepared = 1;
+    
+    // Total 5 second delay to make sure MPI is booted
+    HAL_Delay(5000 - (HAL_GetTick() - start_time));
+    return 0;
+}
+
+/// @brief Turns on MPI science mode and Enables DMA interrupt for MPI channel.
+/// @return 0: MPI and DMA successfully enabled, < 0: Error
+uint8_t MPI_enable_active_mode() {
+
+    //FIXME: There are a few issues in the code
+    //       If UART port starts receiving data when it's not listening, the port will be blocked once listening
+    //       If UART port/DMA is stopped while actively receiving data, the port will be blocked once listening again
+    //       The more files there are, the longer the first initial write takes to LFS 
+    
+    // Turn on the MPI and setup LFS
+    const uint8_t prepare_result = MPI_prepare_receive_data();
+    if (prepare_result != 0) {
+        LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_ERROR, LOG_SINK_ALL, 
+            "MPI could not be powered on (MPI_prepare_receive_data result: %d)", prepare_result);
+        return 5;
+    }
+
+    // Abort any previous reception.
+    // Very important. Makes everything work.
+    HAL_UART_AbortReceive(UART_mpi_port_handle);
+
+    MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_MOSI); // Set the MPI transceiver to MOSI mode
+    HAL_Delay(50);
+
+    // Send command to start MPI science data.
+    const uint8_t tx_buffer[3] = {0x54, 0x43, 0x13}; // Start data command (0x13 = d19 = START)
+    const HAL_StatusTypeDef tx_result = HAL_UART_Transmit(
+        UART_mpi_port_handle,
+        tx_buffer, sizeof(tx_buffer),
+        MPI_TX_TIMEOUT_DURATION_MS
+    );
+    if (tx_result != HAL_OK) {
+        LOG_message(
+            LOG_SYSTEM_MPI, LOG_SEVERITY_ERROR, LOG_SINK_ALL, 
+            "MPI HAL_UART_Transmit error (HAL_UART_Transmit result: %d)", tx_result
+        );
+        return 4;
+    }
+
+    MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_MISO); // Set the MPI transceiver to MISO mode
+    MPI_current_uart_rx_mode = MPI_RX_MODE_SENSING_MODE;
+
+    // Receive MPI response actively with 8192 buffer size.
+    __HAL_UART_CLEAR_OREFLAG(UART_mpi_port_handle);
+    const HAL_StatusTypeDef rx_status = HAL_UART_Receive_DMA(
+        UART_mpi_port_handle, (uint8_t*) UART_mpi_data_rx_buffer, UART_mpi_data_rx_buffer_len);
+    
+    if (rx_status != HAL_OK) {
+        // Note: Saksham's original code didn't call HAL_UART_DMAStop here if HAL_BUSY.
+        HAL_UART_DMAStop(UART_mpi_port_handle);
+
+        LOG_message(
+            LOG_SYSTEM_MPI, LOG_SEVERITY_ERROR, LOG_SINK_ALL, 
+            "MPI HAL_UART_Receive_DMA error (HAL_UART_Receive_DMA result: %d)", rx_status
+        );
+        return 3; // Error code: Failed to start UART reception
+    }
+    
+    // Indicates to MPI thread that we are able to receive data
+    // If mpi uart mode is changed, we can close file
+    MPI_receive_prepared = 2;
+    return 0;
+}
+
+uint8_t MPI_disable_active_mode() {
+    // Power off the MPI 5v
+    const uint8_t mpi_5v_result = EPS_set_channel_enabled(EPS_CHANNEL_5V_MPI, 0);
+    if (mpi_5v_result != 0) {
+        LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_SINK_ALL, 
+            "MPI 5v could not be powered off (EPS_set_channel_enabled->%d)",
+            mpi_5v_result
+        );
+    }
+    // Power off the MPI 12v
+    const uint8_t mpi_12v_result = EPS_set_channel_enabled(EPS_CHANNEL_12V_MPI, 0);
+    if (mpi_12v_result != 0) {
+        LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_SINK_ALL, 
+            "MPI 12v could not be powered off (EPS_set_channel_enabled->%d)",
+            mpi_12v_result
+        );
+    }
+
+    // Set the MPI State to not handle any receiving data
+    MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_INACTIVE); // Set the MPI transceiver to inactive
+    MPI_current_uart_rx_mode = MPI_RX_MODE_NOT_LISTENING_TO_MPI; // Set UART mode to not listening.
+    const HAL_StatusTypeDef stop_status = HAL_UART_DMAStop(UART_mpi_port_handle);
+
+    if (stop_status != HAL_OK) {
+        return 1;
+    }
+
+    // TODO: Log stats about the data received
+    // File size, start time, stop time, current EPS power, number of interrupts, any dropped bytes, etc.
+
+    return 0;
 }

--- a/firmware/Core/Src/mpi/mpi_command_handling.c
+++ b/firmware/Core/Src/mpi/mpi_command_handling.c
@@ -28,6 +28,8 @@ uint8_t MPI_science_file_can_close = 0;
 uint8_t MPI_science_data_file_is_open = 0;
 uint32_t MPI_science_data_bytes_lost = 0;
 lfs_file_t MPI_science_data_file_pointer;
+uint32_t MPI_recording_start_uptime_ms;
+
 
 /// @brief Sends commandcode+params to the MPI as bytes
 /// @param bytes_to_send Buffer containing the telecommand + params (IF ANY) as hex bytes
@@ -264,8 +266,9 @@ uint8_t MPI_enable_active_mode(const char MPI_science_file_name[]) {
         return 4;
     }
 
-    MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_MISO); // Set the MPI transceiver to MISO mode
+    MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_MISO); // Set the MPI transceiver to MISO mode (better power efficiency than DUPLEX).
     MPI_current_uart_rx_mode = MPI_RX_MODE_SENSING_MODE;
+    MPI_recording_start_uptime_ms = HAL_GetTick();
     
     // Receive MPI response actively with 8192 buffer size.
     const HAL_StatusTypeDef rx_status = HAL_UART_Receive_DMA(

--- a/firmware/Core/Src/mpi/mpi_command_handling.c
+++ b/firmware/Core/Src/mpi/mpi_command_handling.c
@@ -222,7 +222,11 @@ int8_t MPI_prepare_receive_data(const char MPI_science_file_name[]) {
     );
     
     // Total 5 second delay to make sure MPI is booted
-    HAL_Delay(5000 - (HAL_GetTick() - start_time));
+    int32_t power_on_delay = (5000 - (HAL_GetTick() - start_time));
+    if (power_on_delay > 0) {
+        HAL_Delay(power_on_delay);
+    }
+    
     return 0;
 }
 
@@ -308,25 +312,6 @@ static void MPI_power_off() {
 uint8_t MPI_disable_active_mode() {
     MPI_power_off();
 
-    // TODO: Triple Check with Dr. Burchill if we need to turn off science mode before turning off MPI 
-    // MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_MOSI); // Set the MPI transceiver to MOSI mode
-    // HAL_Delay(50);
-
-    // // Send command to stop MPI science data.
-    // const uint8_t tx_buffer[3] = {0x54, 0x43, 0x14}; // Stop data command (0x14 = d20 = STOP)
-    // const HAL_StatusTypeDef tx_result = HAL_UART_Transmit(
-    //     UART_mpi_port_handle,
-    //     tx_buffer, sizeof(tx_buffer),
-    //     MPI_TX_TIMEOUT_DURATION_MS
-    // );
-    // if (tx_result != HAL_OK) {
-    //     LOG_message(
-    //         LOG_SYSTEM_MPI, LOG_SEVERITY_ERROR, LOG_SINK_ALL, 
-    //         "MPI HAL_UART_Transmit error (HAL_UART_Transmit result: %d)", tx_result
-    //     );
-    //     return 4;
-    // }
-
     // Set the MPI State to not handle any receiving data
     MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_INACTIVE); // Set the MPI transceiver to inactive
     MPI_current_uart_rx_mode = MPI_RX_MODE_NOT_LISTENING_TO_MPI; // Set UART mode to not listening.
@@ -342,8 +327,9 @@ uint8_t MPI_disable_active_mode() {
 
     MPI_science_file_can_close = 1;
     
-    // TODO: Log stats about the data received
     // Current Logs printed in thread: File Size, Bytes Lost, Total Time Taken
+    
+    // TODO: Log stats about the data received
     // File size, start time, stop time, current EPS power, number of interrupts, any dropped bytes, etc.
     return 0;
 }

--- a/firmware/Core/Src/mpi/mpi_command_handling.c
+++ b/firmware/Core/Src/mpi/mpi_command_handling.c
@@ -146,10 +146,7 @@ uint8_t MPI_validate_command_response(
     return 0; //  MPI executed the cmd successfully
 }
 
-
-/// @brief Turns on MPI and prepares a LFS file to store MPI data in.
-/// @return 0: System successfully prepared for MPI data, < 0: Error
-int8_t MPI_prepare_receive_data() {
+static void MPI_power_on() {
     // Power On MPI 5v
     const uint8_t mpi_5v_result = EPS_set_channel_enabled(EPS_CHANNEL_5V_MPI, 1);
     if (mpi_5v_result != 0) {
@@ -167,6 +164,12 @@ int8_t MPI_prepare_receive_data() {
             mpi_12v_result
         );
     }
+}
+
+/// @brief Turns on MPI and prepares a LFS file to store MPI data in.
+/// @return 0: System successfully prepared for MPI data, < 0: Error
+int8_t MPI_prepare_receive_data() {
+    MPI_power_on();
 
     // Start the timer to track time past since we powered on MPI
     const uint32_t start_time = HAL_GetTick();
@@ -278,7 +281,7 @@ uint8_t MPI_enable_active_mode() {
     return 0;
 }
 
-uint8_t MPI_disable_active_mode() {
+static void MPI_power_off() {
     // Power off the MPI 5v
     const uint8_t mpi_5v_result = EPS_set_channel_enabled(EPS_CHANNEL_5V_MPI, 0);
     if (mpi_5v_result != 0) {
@@ -295,6 +298,10 @@ uint8_t MPI_disable_active_mode() {
             mpi_12v_result
         );
     }
+}
+
+uint8_t MPI_disable_active_mode() {
+    MPI_power_off();
 
     // Set the MPI State to not handle any receiving data
     MPI_set_transceiver_state(MPI_TRANSCEIVER_MODE_INACTIVE); // Set the MPI transceiver to inactive

--- a/firmware/Core/Src/mpi/mpi_command_handling.c
+++ b/firmware/Core/Src/mpi/mpi_command_handling.c
@@ -191,25 +191,41 @@ int8_t MPI_prepare_receive_data() {
     if (MPI_science_data_file_is_open == 1) {
         const int8_t close_result = lfs_file_close(&LFS_filesystem, &MPI_science_data_file_pointer);
         if (close_result < 0) {
-            LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), "Error closing old file: %d", close_result);
+            LOG_message(
+                LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE),
+                "Error closing old file: %d", close_result
+            );
             MPI_receive_prepared = 0;
             return close_result;
         }
-        LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), "Old File successfully closed");
+        LOG_message(
+            LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE),
+            "Old File successfully closed"
+        );
         MPI_science_data_file_is_open = 0;
     }
 
     // Open / Create the file
-    const int8_t open_result = lfs_file_opencfg(&LFS_filesystem, &MPI_science_data_file_pointer, MPI_science_data_file_name, LFS_O_WRONLY | LFS_O_CREAT | LFS_O_APPEND, &LFS_file_cfg);
+    const int8_t open_result = lfs_file_opencfg(
+        &LFS_filesystem, &MPI_science_data_file_pointer,
+        MPI_science_data_file_name,
+        LFS_O_WRONLY | LFS_O_CREAT | LFS_O_APPEND, &LFS_file_cfg
+    );
     
     // Check if open successful
     if (open_result < 0) {
-        LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), "Error opening / creating file: %s", MPI_science_data_file_name);
+        LOG_message(
+            LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE),
+            "Error opening / creating file: %s", MPI_science_data_file_name
+        );
         MPI_receive_prepared = 0;
         return open_result;
     }
     MPI_science_data_file_is_open = 1;
-    LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_NORMAL, LOG_all_sinks_except(LOG_SINK_FILE), "Opened/created file: %s", MPI_science_data_file_name);
+    LOG_message(
+        LOG_SYSTEM_MPI, LOG_SEVERITY_NORMAL, LOG_all_sinks_except(LOG_SINK_FILE),
+        "Opened/created file: %s", MPI_science_data_file_name
+    );
     MPI_receive_prepared = 1;
     
     // Total 5 second delay to make sure MPI is booted

--- a/firmware/Core/Src/rtos_tasks/rtos_mpi_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_mpi_tasks.c
@@ -55,47 +55,7 @@ void TASK_service_write_mpi_data(void *argument) {
                 "MPI Task: Write Time: %lu", HAL_GetTick() - start_time
             );
         }
-
-        // If user has sent disable active mode telecommand 
-        else if (MPI_science_file_can_close == 1 && MPI_current_uart_rx_mode != MPI_RX_MODE_SENSING_MODE) {
-
-            // Close the File, the storage is not updated until the file is closed successfully
-            const int8_t close_result = lfs_file_close(&LFS_filesystem, &MPI_science_data_file_pointer);
-            if (close_result < 0) {
-                LOG_message(
-                    LOG_SYSTEM_MPI, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
-                    "MPI Task: Error closing file: %d", close_result
-                );
-            }
-
-            // Log that file has been successfully closed 
-            LOG_message(
-                LOG_SYSTEM_MPI, LOG_SEVERITY_DEBUG, LOG_SINK_ALL,
-                "MPI Task: File closed successfully"
-            );
-
-            // Get the file size before closing the file
-            const lfs_ssize_t file_size = lfs_file_size(&LFS_filesystem, &MPI_science_data_file_pointer);
-
-            if (file_size < 0) {
-                LOG_message(
-                    LOG_SYSTEM_MPI, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
-                    "MPI Task: Error getting file size: %ld", file_size
-                );
-            }
-            
-            // Log MPI science data stats  
-            LOG_message(
-                LOG_SYSTEM_MPI, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
-                "\nData Successfully Stored: %ld bytes\nData Lost: %lu bytes\nTotal Time Taken: %lu ms",
-                file_size, MPI_science_data_bytes_lost, HAL_GetTick() - MPI_recording_start_uptime_ms 
-            );
-
-            MPI_science_file_can_close = 0;
-            MPI_science_data_file_is_open = 0;
-            MPI_science_data_bytes_lost = 0;
-        }
-
+        
         // Do a short delay to allow recording to start right away once enabled.
         osDelay(100);
     }

--- a/firmware/Core/Src/rtos_tasks/rtos_mpi_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_mpi_tasks.c
@@ -1,0 +1,65 @@
+#include "rtos_tasks/rtos_task_helpers.h"
+#include "mpi/mpi_command_handling.h"
+#include "littlefs/littlefs_helper.h"
+#include "debug_tools/debug_uart.h"
+#include "cmsis_os.h"
+#include "log/log.h"
+#include "uart_handler/uart_handler.h"
+
+#include <stdio.h>
+
+void TASK_service_write_mpi_data(void *argument) {
+    TASK_HELP_start_of_task();
+    osDelay(1000);
+    
+    uint32_t start_time;
+
+    while(1) {
+        // Add a check that would see if there is data to be written regardless of RX Mode, we write
+        if (MPI_buffer_state == MPI_MEMORY_WRITE_STATUS_PENDING && MPI_receive_prepared) {
+
+            start_time = HAL_GetTick();
+            if (!LFS_is_lfs_mounted) {
+                LFS_mount();
+                LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), 
+                "Had to mount LFS (System wasn't prepared for MPI data)");
+            }
+            LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_NORMAL, LOG_all_sinks_except(LOG_SINK_FILE), "Mount Time: %lu", HAL_GetTick() - start_time);
+
+
+            // Write data to file
+            const lfs_ssize_t write_result = lfs_file_write(
+                &LFS_filesystem, &MPI_science_data_file_pointer,
+                (uint8_t*)MPI_active_data_median_buffer,
+                MPI_active_data_median_buffer_len
+            );
+
+            if (write_result < 0)
+            {
+                LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), "Error writing to file: %ld", write_result);
+            } else {
+                LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_NORMAL, LOG_all_sinks_except(LOG_SINK_FILE), "Successfully Wrote 4096 bytes");
+                MPI_buffer_state = MPI_MEMORY_WRITE_STATUS_READY;
+            }
+            LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_NORMAL, LOG_all_sinks_except(LOG_SINK_FILE), "Write Time: %lu", HAL_GetTick() - start_time);
+
+        } else {
+            if (MPI_receive_prepared == 2 && MPI_current_uart_rx_mode != MPI_RX_MODE_SENSING_MODE) {
+                // Close the File, the storage is not updated until the file is closed successfully
+                const int8_t close_result = lfs_file_close(&LFS_filesystem, &MPI_science_data_file_pointer);
+                if (close_result < 0)
+                {
+                    LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), "Error closing file: %d", close_result);
+                } 
+                LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), "File Successfully closed");
+                MPI_receive_prepared = 0;
+                MPI_science_data_file_is_open = 0;
+            }
+        }
+        if (MPI_current_uart_rx_mode == MPI_RX_MODE_SENSING_MODE) {
+            osDelay(100);
+        } else {
+            osDelay(1000);
+        }
+    }
+}

--- a/firmware/Core/Src/rtos_tasks/rtos_mpi_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_mpi_tasks.c
@@ -11,21 +11,21 @@
 void TASK_service_write_mpi_data(void *argument) {
     TASK_HELP_start_of_task();
     osDelay(1000);
-    
-    uint32_t start_time;
 
     while(1) {
         // Add a check that would see if there is data to be written regardless of RX Mode, we write
-        if (MPI_buffer_state == MPI_MEMORY_WRITE_STATUS_PENDING && MPI_receive_prepared) {
+        if ((MPI_buffer_state == MPI_MEMORY_WRITE_STATUS_PENDING) && MPI_receive_prepared) {
 
-            start_time = HAL_GetTick();
+            const uint32_t start_time = HAL_GetTick();
             if (!LFS_is_lfs_mounted) {
-                LFS_mount();
-                LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), 
-                "Had to mount LFS (System wasn't prepared for MPI data)");
+                const int8_t mount_result = LFS_mount();
+                LOG_message(
+                    LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_SINK_ALL, 
+                    "MPI Task: Had to mount LFS. LFS_mount->%d. Took %lu ms",
+                    mount_result,
+                    HAL_GetTick() - start_time
+                );
             }
-            LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_NORMAL, LOG_all_sinks_except(LOG_SINK_FILE), "Mount Time: %lu", HAL_GetTick() - start_time);
-
 
             // Write data to file
             const lfs_ssize_t write_result = lfs_file_write(
@@ -34,31 +34,49 @@ void TASK_service_write_mpi_data(void *argument) {
                 MPI_active_data_median_buffer_len
             );
 
-            if (write_result < 0)
-            {
-                LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), "Error writing to file: %ld", write_result);
-            } else {
-                LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_NORMAL, LOG_all_sinks_except(LOG_SINK_FILE), "Successfully Wrote 4096 bytes");
+            if (write_result < 0) {
+                LOG_message(
+                    LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+                    "MPI Task: Error writing to file: %ld", write_result
+                );
+            }
+            else {
+                LOG_message(
+                    LOG_SYSTEM_MPI, LOG_SEVERITY_DEBUG, LOG_SINK_ALL,
+                    "MPI Task: Successfully wrote %ld bytes to file",
+                    write_result
+                );
                 MPI_buffer_state = MPI_MEMORY_WRITE_STATUS_READY;
             }
-            LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_NORMAL, LOG_all_sinks_except(LOG_SINK_FILE), "Write Time: %lu", HAL_GetTick() - start_time);
-
-        } else {
-            if (MPI_receive_prepared == 2 && MPI_current_uart_rx_mode != MPI_RX_MODE_SENSING_MODE) {
+            LOG_message(
+                LOG_SYSTEM_MPI, LOG_SEVERITY_DEBUG, LOG_SINK_ALL,
+                "MPI Task: Write Time: %lu", HAL_GetTick() - start_time
+            );
+        }
+        else {
+            if ((MPI_receive_prepared == 2) && (MPI_current_uart_rx_mode != MPI_RX_MODE_SENSING_MODE)) {
                 // Close the File, the storage is not updated until the file is closed successfully
                 const int8_t close_result = lfs_file_close(&LFS_filesystem, &MPI_science_data_file_pointer);
-                if (close_result < 0)
-                {
-                    LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), "Error closing file: %d", close_result);
-                } 
-                LOG_message(LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), "File Successfully closed");
+                if (close_result < 0) {
+                    LOG_message(
+                        LOG_SYSTEM_MPI, LOG_SEVERITY_WARNING, LOG_SINK_ALL,
+                        "MPI Task: Error closing file: %d", close_result
+                    );
+                }
+                else {
+                    LOG_message(
+                        LOG_SYSTEM_MPI, LOG_SEVERITY_NORMAL, LOG_SINK_ALL,
+                        "MPI Task: File closed successfully"
+                    );
+                }
                 MPI_receive_prepared = 0;
                 MPI_science_data_file_is_open = 0;
             }
         }
         if (MPI_current_uart_rx_mode == MPI_RX_MODE_SENSING_MODE) {
             osDelay(100);
-        } else {
+        }
+        else {
             osDelay(1000);
         }
     }

--- a/firmware/Core/Src/telecommands/mpi_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/mpi_telecommand_defs.c
@@ -3,6 +3,7 @@
 #include "mpi/mpi_command_handling.h"
 #include "transforms/arrays.h"
 #include "mpi/mpi_transceiver.h"
+#include "littlefs/littlefs_helper.h"
 #include "log/log.h"
 #include "uart_handler/uart_handler.h"
 
@@ -84,6 +85,42 @@ uint8_t TCMDEXEC_mpi_send_command_get_response_hex(
 
     // Return response code from the MPI
     return cmd_response;
+}
+
+/// @brief Enables systems to start receiving data actively from MPI and storing using LFS.
+/// @param args_str No args.
+/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
+/// @param response_output_buf The buffer to write the response to
+/// @param response_output_buf_len The maximum length of the response_output_buf (its size)
+/// @return 0: Success, >0: Failure
+uint8_t TCMDEXEC_mpi_enable_active_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, char *response_output_buf, uint16_t response_output_buf_len) {
+    const uint8_t enable_result = MPI_enable_active_mode();
+
+    if (enable_result != 0) {
+        snprintf(response_output_buf, response_output_buf_len,
+            "MPI enable active mode Failed! Error Code: %d", enable_result);
+        return enable_result;
+    }
+
+    return 0;
+}
+
+/// @brief Sets the state to not send or receive data from MPI.
+/// @param args_str No args.
+/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
+/// @param response_output_buf The buffer to write the response to
+/// @param response_output_buf_len The maximum length of the response_output_buf (its size)
+/// @return 0: Success, >0: Failure
+uint8_t TCMDEXEC_mpi_disable_active_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, char *response_output_buf, uint16_t response_output_buf_len) {
+    const uint8_t disable_result = MPI_disable_active_mode();
+
+    if (disable_result != 0) {
+        snprintf(response_output_buf, response_output_buf_len,
+            "MPI disable active mode Failed! Error Code: %d", disable_result);
+        return disable_result;
+    }
+
+    return 0;
 }
 
 

--- a/firmware/Core/Src/telecommands/mpi_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/mpi_telecommand_defs.c
@@ -88,14 +88,27 @@ uint8_t TCMDEXEC_mpi_send_command_get_response_hex(
 }
 
 /// @brief Enables systems to start receiving data actively from MPI and storing using LFS.
-/// @param args_str No args.
+/// @param args_str
+/// - Arg 0: File name as a string
 /// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0: Success, >0: Failure
 uint8_t TCMDEXEC_mpi_enable_active_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, char *response_output_buf, uint16_t response_output_buf_len) {
-    const uint8_t enable_result = MPI_enable_active_mode();
-
+    
+    // Get the file name from the telecommand argument
+    char arg_file_name[LFS_MAX_PATH_LENGTH];
+    const uint8_t parse_file_name_result = TCMD_extract_string_arg(args_str, 0, arg_file_name, sizeof(arg_file_name));
+    if (parse_file_name_result != 0) {
+        snprintf(
+            response_output_buf,
+            response_output_buf_len,
+            "Error parsing file name arg: Error %d", parse_file_name_result);
+        return 1;
+    }
+    
+    // Enable MPI Science Mode
+    const uint8_t enable_result = MPI_enable_active_mode(arg_file_name);
     if (enable_result != 0) {
         snprintf(response_output_buf, response_output_buf_len,
             "MPI enable active mode Failed! Error Code: %d", enable_result);

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -1055,7 +1055,7 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
     {
         .tcmd_name = "mpi_enable_active_mode",
         .tcmd_func = TCMDEXEC_mpi_enable_active_mode,
-        .number_of_args = 0,
+        .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -1052,6 +1052,18 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_GROUND_USAGE_ONLY, // Not useful in space.
     },
+    {
+        .tcmd_name = "mpi_enable_active_mode",
+        .tcmd_func = TCMDEXEC_mpi_enable_active_mode,
+        .number_of_args = 0,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+    {
+        .tcmd_name = "mpi_disable_active_mode",
+        .tcmd_func = TCMDEXEC_mpi_disable_active_mode,
+        .number_of_args = 0,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
     // ****************** END: MPI_telecommand_definitions ********************
     // ****************** START SECTION: stm32_internal_flash_telecommand_defs ******************
 

--- a/firmware/Core/Src/uart_handler/uart_handler.c
+++ b/firmware/Core/Src/uart_handler/uart_handler.c
@@ -5,6 +5,7 @@
 #include "camera/camera_capture.h"
 #include "log/log.h"
 
+#include "mpi/mpi_transceiver.h"
 #include "main.h"
 
 #include <string.h>
@@ -72,10 +73,11 @@ volatile uint8_t UART_gps_buffer_last_rx_byte = 0; // extern
 volatile uint8_t UART_gps_uart_interrupt_enabled = 0; //extern
 
 // UART MPI science data buffer (WILL NEED IN THE FUTURE)
-// const uint16_t UART_mpi_data_rx_buffer_len = 8192; // extern 
-// volatile uint8_t UART_mpi_data_rx_buffer[8192]; // extern
-// const uint16_t UART_mpi_data_buffer_len = 80000; // extern
-// volatile uint8_t UART_mpi_data_buffer[80000]; // extern
+const uint16_t UART_mpi_data_rx_buffer_len = 8192; // extern 
+volatile uint8_t UART_mpi_data_rx_buffer[8192]; // extern
+const uint16_t MPI_active_data_median_buffer_len = 4096;
+volatile uint8_t MPI_active_data_median_buffer[4096];
+
 
 #define KISS_FEND  0xC0
 #define KISS_FESC  0xDB
@@ -122,7 +124,6 @@ static inline void kiss_enqueue_frame(const uint8_t *data, uint16_t len) {
     UART_AX100_kiss_frame_queue_head = (UART_AX100_kiss_frame_queue_head + 1) % AX100_MAX_KISS_FRAMES_IN_RX_QUEUE;
 }
 
-
 void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
     // This ISR function gets called every time a byte is received on the UART.
 
@@ -152,17 +153,33 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
         // Restart reception for next byte
         HAL_UART_Receive_IT(UART_telecommand_port_handle, (uint8_t*) &UART_telecommand_buffer_last_rx_byte, 1);
     }
-
-    else if (huart->Instance == UART_mpi_port_handle->Instance) {
+    else if (huart->Instance == UART_mpi_port_handle->Instance) {        
         // DEBUG_uart_print_str("HAL_UART_RxCpltCallback() -> MPI Data\n");
         UART_mpi_last_write_time_ms = HAL_GetTick();
 
         if (MPI_current_uart_rx_mode == MPI_RX_MODE_COMMAND_MODE) {
             // Command mode is blocking. Nothing to do here.
         }
+        else if (MPI_current_uart_rx_mode == MPI_RX_MODE_SENSING_MODE) {
+            // Store the second half into another buffer
+            if (MPI_buffer_state == MPI_MEMORY_WRITE_STATUS_READY) {
+                for(uint16_t i = (UART_mpi_data_rx_buffer_len/2); i < UART_mpi_data_rx_buffer_len; i++) {
+                    MPI_active_data_median_buffer[i-(UART_mpi_data_rx_buffer_len/2)] = UART_mpi_data_rx_buffer[i];
+                    UART_mpi_data_rx_buffer[i] = 0x00;
+                }
+                MPI_buffer_state = MPI_MEMORY_WRITE_STATUS_PENDING;
+                DEBUG_uart_print_str("COMPLETE - Received 4096 Bytes!\n");
+
+            } else {
+                DEBUG_uart_print_str("COMPLETE - Bytes are being lost!\n");
+            }
+        }
         else {
             DEBUG_uart_print_str("Unhandled MPI Mode\n"); //TODO: HANDLE other MPI MODES
+            DEBUG_uart_print_str("COMPLETE - Receiving some sort of MPI Data!\n");
         }
+
+        UART_mpi_last_write_time_ms = HAL_GetTick();
     }
 
     else if (huart->Instance == UART_ax100_port_handle->Instance) {
@@ -312,8 +329,28 @@ void HAL_UART_RxHalfCpltCallback(UART_HandleTypeDef *huart) {
         CAMERA_uart_half_1_state = CAMERA_UART_WRITE_STATE_HALF_FILLED_WAITING_FS_WRITE;
         CAMERA_uart_half_2_state = CAMERA_UART_WRITE_STATE_HALF_FILLING;
     }
-}
 
+    else if (huart->Instance == UART_mpi_port_handle->Instance) {
+        // DEBUG_uart_print_str("Half callback being called!");
+
+        if (MPI_current_uart_rx_mode == MPI_RX_MODE_SENSING_MODE) {
+            if (MPI_buffer_state == MPI_MEMORY_WRITE_STATUS_READY) {
+                for (uint16_t i = 0; i < UART_mpi_data_rx_buffer_len/2; i++) {
+                    MPI_active_data_median_buffer[i] = UART_mpi_data_rx_buffer[i];
+                    UART_mpi_data_rx_buffer[i] = 0x00;
+                }
+                MPI_buffer_state = MPI_MEMORY_WRITE_STATUS_PENDING;
+            }
+            else {
+                UART_error_mpi_error_info.handler_buffer_full_error_count++;
+                DEBUG_uart_print_str("MPI Half ISR - Data too fast!\n");
+            }
+        }
+        else {
+            DEBUG_uart_print_str("MPI Half ISR - Received MPI Data, rx_mode != SENSING though!\n");
+        }
+    }
+}
 
 
 /// @brief Sets the UART interrupt state (enabled/disabled)

--- a/firmware/Core/Src/uart_handler/uart_handler.c
+++ b/firmware/Core/Src/uart_handler/uart_handler.c
@@ -72,11 +72,11 @@ volatile uint32_t UART_gps_last_write_time_ms = 0; // extern
 volatile uint8_t UART_gps_buffer_last_rx_byte = 0; // extern
 volatile uint8_t UART_gps_uart_interrupt_enabled = 0; //extern
 
-// UART MPI science data buffer (WILL NEED IN THE FUTURE)
-const uint16_t UART_mpi_data_rx_buffer_len = 8192; // extern 
-volatile uint8_t UART_mpi_data_rx_buffer[8192]; // extern
-const uint16_t MPI_active_data_median_buffer_len = 4096;
-volatile uint8_t MPI_active_data_median_buffer[4096];
+// UART MPI science data buffer
+const uint16_t UART_mpi_data_rx_buffer_len = 40960; // extern 
+volatile uint8_t UART_mpi_data_rx_buffer[40960]; // extern
+const uint16_t MPI_active_data_median_buffer_len = 20480;
+volatile uint8_t MPI_active_data_median_buffer[20480];
 
 
 #define KISS_FEND  0xC0
@@ -172,7 +172,7 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
 
             } else {
                 DEBUG_uart_print_str("COMPLETE - *Assumed* 4096 Bytes are being lost!\n");
-                MPI_science_data_bytes_lost += 4096;
+                MPI_science_data_bytes_lost += MPI_active_data_median_buffer_len;
             }
         }
         else {
@@ -344,8 +344,9 @@ void HAL_UART_RxHalfCpltCallback(UART_HandleTypeDef *huart) {
             }
             else {
                 UART_error_mpi_error_info.handler_buffer_full_error_count++;
+                MPI_science_data_bytes_lost += MPI_active_data_median_buffer_len;
+
                 DEBUG_uart_print_str("MPI Half ISR - Data too fast!\n");
-                MPI_science_data_bytes_lost += UART_mpi_data_rx_buffer_len;
             }
         }
         else {

--- a/firmware/Core/Src/uart_handler/uart_handler.c
+++ b/firmware/Core/Src/uart_handler/uart_handler.c
@@ -168,10 +168,11 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
                     UART_mpi_data_rx_buffer[i] = 0x00;
                 }
                 MPI_buffer_state = MPI_MEMORY_WRITE_STATUS_PENDING;
-                DEBUG_uart_print_str("COMPLETE - Received 4096 Bytes!\n");
+                // DEBUG_uart_print_str("COMPLETE - Received 4096 Bytes!\n");
 
             } else {
-                DEBUG_uart_print_str("COMPLETE - Bytes are being lost!\n");
+                DEBUG_uart_print_str("COMPLETE - *Assumed* 4096 Bytes are being lost!\n");
+                MPI_science_data_bytes_lost += 4096;
             }
         }
         else {
@@ -344,6 +345,7 @@ void HAL_UART_RxHalfCpltCallback(UART_HandleTypeDef *huart) {
             else {
                 UART_error_mpi_error_info.handler_buffer_full_error_count++;
                 DEBUG_uart_print_str("MPI Half ISR - Data too fast!\n");
+                MPI_science_data_bytes_lost += UART_mpi_data_rx_buffer_len;
             }
         }
         else {

--- a/firmware/Core/Src/uart_handler/uart_handler.c
+++ b/firmware/Core/Src/uart_handler/uart_handler.c
@@ -163,21 +163,21 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
         else if (MPI_current_uart_rx_mode == MPI_RX_MODE_SENSING_MODE) {
             // Store the second half into another buffer
             if (MPI_buffer_state == MPI_MEMORY_WRITE_STATUS_READY) {
-                for(uint16_t i = (UART_mpi_data_rx_buffer_len/2); i < UART_mpi_data_rx_buffer_len; i++) {
-                    MPI_active_data_median_buffer[i-(UART_mpi_data_rx_buffer_len/2)] = UART_mpi_data_rx_buffer[i];
+                for(uint16_t i = MPI_active_data_median_buffer_len; i < UART_mpi_data_rx_buffer_len; i++) {
+                    MPI_active_data_median_buffer[i - MPI_active_data_median_buffer_len] = UART_mpi_data_rx_buffer[i];
                     UART_mpi_data_rx_buffer[i] = 0x00;
                 }
                 MPI_buffer_state = MPI_MEMORY_WRITE_STATUS_PENDING;
-                // DEBUG_uart_print_str("COMPLETE - Received 4096 Bytes!\n");
-
-            } else {
-                DEBUG_uart_print_str("COMPLETE - *Assumed* 4096 Bytes are being lost!\n");
+            }
+            else {
+                UART_error_mpi_error_info.handler_buffer_full_error_count++;
                 MPI_science_data_bytes_lost += MPI_active_data_median_buffer_len;
+
+                DEBUG_uart_print_str("MPI Full ISR - Data too fast!\n");
             }
         }
         else {
-            DEBUG_uart_print_str("Unhandled MPI Mode\n"); //TODO: HANDLE other MPI MODES
-            DEBUG_uart_print_str("COMPLETE - Receiving some sort of MPI Data!\n");
+            DEBUG_uart_print_str("MPI Full ISR - Received MPI Data, rx_mode != SENSING though!\n");
         }
 
         UART_mpi_last_write_time_ms = HAL_GetTick();
@@ -336,7 +336,7 @@ void HAL_UART_RxHalfCpltCallback(UART_HandleTypeDef *huart) {
 
         if (MPI_current_uart_rx_mode == MPI_RX_MODE_SENSING_MODE) {
             if (MPI_buffer_state == MPI_MEMORY_WRITE_STATUS_READY) {
-                for (uint16_t i = 0; i < UART_mpi_data_rx_buffer_len/2; i++) {
+                for (uint16_t i = 0; i < MPI_active_data_median_buffer_len; i++) {
                     MPI_active_data_median_buffer[i] = UART_mpi_data_rx_buffer[i];
                     UART_mpi_data_rx_buffer[i] = 0x00;
                 }

--- a/hardware_emulators/mpi_data_simulator.py
+++ b/hardware_emulators/mpi_data_simulator.py
@@ -1,0 +1,108 @@
+import serial
+import time
+import struct
+import random
+
+random.seed(42)
+
+# Setup the serial port
+com_port = "COM7"  # Replace with the actual COM port
+baud_rate = 230400  # Baud rate
+
+# Function to create the data frame
+def create_data_frame():
+    # Initialize an empty byte array
+    data = bytearray(160)
+
+    # Sync bytes (0x0c, 0xff, 0xff, 0x0c)
+    data[0] = 0x0c
+    data[1] = 0xff
+    data[2] = 0xff
+    data[3] = 0x0c
+    
+    # Frame counter
+    struct.pack_into('>H', data, 4, 69)  # Store frame counter at bytes 5 and 6
+    
+    # Board temperature
+    data[6] = 0x11
+    data[7] = 0x11
+
+    # Firmware Version
+    data[8] = 0x08
+
+    #MPI Unit ID
+    data[9] = 0x09
+
+    # Director Status
+    data[10] = 0x0a
+    data[11] = 0x0b
+
+    # Inner Dome Voltage Setting
+    data[12] = 0x0c
+    data[13] = 0x0d
+
+    # SPIB
+    data[14] = 0x0e
+
+    # Inner Dome Scan Index
+    data[15] = 0x0f
+
+    # Faceplate Voltage Setting
+    data[16] = 0x10
+    data[17] = 0x11
+
+    # Faceplate Voltage ADC Reading
+    data[18] = 0x12
+    data[19] = 0x13
+
+    # Inner Dome Voltage ADC Reading
+    data[20] = 0x12
+    data[21] = 0x13
+
+    # Image data with 135 bytes. 2 bytes per pixel
+    for i in range(22, 158, 2):
+        pixel_value = random.randint(0, 255)
+        struct.pack_into('>H', data, i, pixel_value)
+    
+    # CRC (last 2 bytes)
+    data[158] = 0xdd
+    data[159] = 0xdd
+
+    return data
+
+# Main function to send data over COM port
+def send_data():
+    ser = serial.Serial(com_port, baud_rate, timeout=1)  # Open COM port
+    
+    bytes_sent = 0
+    start_time = time.time()  # Record start time
+
+    while True:
+        # Create data frame to send
+        data = create_data_frame()
+        hex_data = ' '.join(f'{byte:02x}' for byte in data)
+        # print(hex_data)
+
+        # Send data frame over the COM port
+        ser.write(data)
+        bytes_sent += len(data)
+
+        # If we do end up reading, the 32 frames in a second won't happen
+        if ser.in_waiting > 0:
+            
+            # Read the data available from the buffer
+            incoming_data = ser.read(ser.in_waiting)  # Read all available data
+            print(f"Received data: \n{incoming_data.decode('utf-8', errors='replace')}")
+        
+        # Wait for 0.0262 second before sending the next frame (trying to match the rate of sending 32 frames in a second)
+        # We should be sending 5120 bytes per second
+        time.sleep(0.0262)
+
+        if time.time() - start_time >= 1:
+            # print(bytes_sent)
+            start_time = time.time()
+            bytes_sent = 0
+
+# Run the script
+if __name__ == "__main__":
+    send_data()


### PR DESCRIPTION
This allows us to prepare the system to be ready for reading and storing MPI science data.

Preparation function:
- Mount LFS if not already mounted
- Create a new file with current HAL_Tick appended on the file name to be used as storage
- Open the file and set the readiness state to 1

Enable active function:
- Set system state to accept data from MPI
- Open DMA channel
- If DMA channel opened successfully, set the readiness state to 2 (indicating we can now close the file when active mode is disabled)

Thread functionailty:
- Write to the open file if there is data to be written 
- Close the file if system not in sensing mode anymore and readiness state is 2
- **Currently has debug / log statement, which will be removed after a final review**