### PR TITLE
fix: GNSS buffer overrun, `rx_buf_len_dest` assignment

### DIFF
--- a/docs/C_Namespaces.md
+++ b/docs/C_Namespaces.md
@@ -25,10 +25,10 @@ following uppercase identifiers to indicate which subsystem/region of code it be
 
 ## Satellite Subsystems
 
-* `ADCS_`: duh
+* `ADCS_`: Attitude Determination and Control System
 * `EPS_`: related to the Electrical Power System
 * `EPS_CMD_`: functions which trigger a command to the EPS subsystem
-* `GPS_`: duh
+* `GPS_`: GPS/GNSS receiver
 * `COMMS_ANT_`: related to the I2C communications for the deployable communications antenna
 * `AX100_`: related to the AX100 communication module, at a low level
 * `COMMS_`: related to higher-level functions for command and data handling, which calls into the `AX100_` prefix
@@ -39,6 +39,7 @@ following uppercase identifiers to indicate which subsystem/region of code it be
 * `ENVIRO_`: related to monitoring the environment (e.g., the on-OBC temperature sensor)
 * `FLASH_`: driver functions for the SPI flash system, which the `lfs_` implementation can call into
 * `STM32_`: driver functions for features within the STM32, including internal flash, boot metadata, etc.
+* `CTS1_`: related to CTS-SAT-1/FrontierSat as a whole
 
 ## Other Categories
 * `TIM_`: related to the timer peripheral, or timing in general

--- a/firmware/Core/Inc/gps/gps_internal_drivers.h
+++ b/firmware/Core/Inc/gps/gps_internal_drivers.h
@@ -4,8 +4,12 @@
 
 #include <stdint.h>
 
-uint8_t GPS_send_cmd_get_response(const char *cmd_buf, uint8_t cmd_buf_len, uint8_t rx_buf[],
-                                  uint16_t rx_buf_len, const uint16_t rx_buf_max_size);
+uint8_t GPS_send_cmd_get_response(
+    const char *cmd_buf, uint8_t cmd_buf_len,
+    uint8_t rx_buf[],
+    const uint16_t rx_buf_max_size,
+    uint16_t* rx_buf_len_dest
+);
 
 
 #endif /* INCLUDE_GUARD__GPS_INTERNAL_DRIVERS_H__ */

--- a/firmware/Core/Src/adcs_drivers/adcs_commands.c
+++ b/firmware/Core/Src/adcs_drivers/adcs_commands.c
@@ -21,8 +21,6 @@
 
 #include "stm32l4xx_hal.h"
 
-extern I2C_HandleTypeDef hi2c1; // allows not needing the parameters
-
 /// @brief Initialize the ADCS CRC, timestamp, and file system directory. 
 /// @return 0 when successful
 uint8_t ADCS_initialize() {

--- a/firmware/Core/Src/telecommands/gps_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/gps_telecommand_defs.c
@@ -17,18 +17,10 @@
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0 on success, > 0 error
-uint8_t TCMDEXEC_gps_send_cmd_ascii(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                                  char *response_output_buf, uint16_t response_output_buf_len)
-{
-
-    if (args_str == NULL)
-    {
-        snprintf(response_output_buf, response_output_buf_len, "Error: Empty args_str");
-        return 1;
-    }
-
-    // TODO : Determine if we need to perform extra error checks on arg_str ie log command format etc
-
+uint8_t TCMDEXEC_gps_send_cmd_ascii(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len
+) {
     // Adding a new line character to the log command
     char gps_log_cmd[128];
     snprintf(gps_log_cmd, sizeof(gps_log_cmd), "%s\n", args_str);
@@ -41,25 +33,30 @@ uint8_t TCMDEXEC_gps_send_cmd_ascii(const char *args_str, TCMD_TelecommandChanne
     memset(GPS_rx_buffer, 0, GPS_rx_buffer_max_size); // Initialize all elements to 0
 
     // Send log command to GPS and receive response
-    const uint8_t gps_cmd_response = GPS_send_cmd_get_response(
-        gps_log_cmd, gps_log_cmd_len, GPS_rx_buffer, GPS_rx_buffer_len, GPS_rx_buffer_max_size
+    const uint8_t gps_cmd_status = GPS_send_cmd_get_response(
+        gps_log_cmd, gps_log_cmd_len, GPS_rx_buffer, GPS_rx_buffer_max_size,
+        &GPS_rx_buffer_len // Will be mutated.
     );
 
-    // Handle the gps_cmd_response: Perform the error checks
+    // Handle the gps_cmd_status: Perform the error checks
     // TODO: Potentially add GPS_validate_log_response function in here to validate response from the gps receiver
 
-    if(gps_cmd_response != 0){
+    if (gps_cmd_status != 0) {
         LOG_message(
             LOG_SYSTEM_GPS,
             LOG_SEVERITY_NORMAL,
             LOG_SINK_ALL,
-            "GPS Response Code: %d",
-            gps_cmd_response
+            "GPS_send_cmd_get_response failed -> %d",
+            gps_cmd_status
         );
-
     }
 
-    snprintf(response_output_buf, response_output_buf_len, "GPS Command: '%s' successfully transmitted", args_str);
+    snprintf(
+        response_output_buf, response_output_buf_len,
+        "GPS Response (%d bytes): %s",
+        GPS_rx_buffer_len,
+        GPS_rx_buffer
+    );
 
     return 0;
 }


### PR DESCRIPTION
This PR pulls out the GNSS-related changes from PR #298 (self checks), as that PR was getting a bit all-over-the-place.

It has been tested a bit, but could use a bit more testing too. I suggest this PR may be appropriate to merge a bit before complete testing is done with it though, as all GNSS testing in other branches should be done with this repaired code.

The main branch has a GNSS buffer overrun case, where the max size of the destination array is not respected (huge oversight). 

Fixes #313.