### PR TITLE
Disable Non-Default EPS Channels on Boot

### DIFF
--- a/firmware/Core/Inc/system/system_bootup.h
+++ b/firmware/Core/Inc/system/system_bootup.h
@@ -1,0 +1,6 @@
+#ifndef INCLUDE_GUARD__SYSTEM_BOOTUP
+#define INCLUDE_GUARD__SYSTEM_BOOTUP
+
+void SYS_disable_systems_bootup();
+
+#endif // INCLUDE_GUARD__SYSTEM_BOOTUP

--- a/firmware/Core/Src/main.c
+++ b/firmware/Core/Src/main.c
@@ -33,7 +33,7 @@
 #include "adcs_drivers/adcs_types.h"
 #include "adcs_drivers/adcs_commands.h"
 #include "littlefs/flash_driver.h"
-
+#include "system/system_bootup.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -278,6 +278,8 @@ int main(void)
   // Always leave the Camera enable signal enabled. Easier to control it through just the EPS.
   HAL_GPIO_WritePin(PIN_CAM_EN_OUT_GPIO_Port, PIN_CAM_EN_OUT_Pin, GPIO_PIN_SET);
 
+  // Disable systems on bootup
+  SYS_disable_systems_bootup();
   /* USER CODE END 2 */
 
   /* Init scheduler */

--- a/firmware/Core/Src/system/system_bootup.c
+++ b/firmware/Core/Src/system/system_bootup.c
@@ -1,0 +1,39 @@
+#include "system/system_bootup.h"
+#include "eps_drivers/eps_channel_control.h"
+#include "boom_deploy_drivers/boom_deploy_drivers.h"
+#include "log/log.h"
+
+/// @brief Disables systems on bootup (Non-Default EPS Channels, Boom GPIO Pins)
+/// @details This function is called during the bootup process
+void SYS_disable_systems_bootup()
+{
+    // Disabling non-default channels
+
+    uint8_t fail_count = 0;
+    for (EPS_CHANNEL_enum_t channel_enum_value = EPS_CHANNEL_VBATT_STACK; channel_enum_value < EPS_ACTIVE_CHANNEL_COUNT; channel_enum_value++) {
+        if ((channel_enum_value == EPS_CHANNEL_VBATT_STACK) ||
+            (channel_enum_value == EPS_CHANNEL_5V_STACK)    ||
+            (channel_enum_value == EPS_CHANNEL_3V3_STACK)) {
+                continue;
+            }
+        const uint8_t disable_result = EPS_set_channel_enabled(channel_enum_value, 0);   
+        if (disable_result != 0) {
+            fail_count++;
+            LOG_message(LOG_SYSTEM_EPS, LOG_SEVERITY_ERROR, LOG_SINK_ALL, "Error Disabling Channel: %s. Error: %u", EPS_channel_to_str(channel_enum_value), disable_result);            
+        }
+    }
+
+    if (fail_count) {
+        // not disabling 3 channels, so not counting them
+        const uint8_t success_count = EPS_ACTIVE_CHANNEL_COUNT - 3 - fail_count;
+        LOG_message(LOG_SYSTEM_EPS, LOG_SEVERITY_ERROR, LOG_SINK_ALL, "Successfully disabled: %u channels. Failed to disable %u channels!", success_count, fail_count);
+        return;
+    }
+
+    LOG_message(LOG_SYSTEM_EPS, LOG_SEVERITY_NORMAL, LOG_SINK_ALL, "All non-default channels disabled successfully!");
+
+    // Disable GPIO Pins for BOOM
+
+    BOOM_disable_all_burns();
+    LOG_message(LOG_SYSTEM_BOOM, LOG_SEVERITY_NORMAL, LOG_SINK_ALL, "All burns disabled!"); 
+}

--- a/firmware/Core/Src/uart_handler/uart_handler.c
+++ b/firmware/Core/Src/uart_handler/uart_handler.c
@@ -1,6 +1,7 @@
 #include "uart_handler/uart_handler.h"
 #include "debug_tools/debug_uart.h"
 #include "mpi/mpi_command_handling.h"
+
 #include "main.h"
 #include "log/log.h"
 
@@ -263,6 +264,13 @@ void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart) {
 
     // Reception Error callback for EPS UART port
     if (huart->Instance == UART_eps_port_handle->Instance) {
+        const uint8_t error_code = huart->ErrorCode;
+        const uint32_t up_time_ms = HAL_GetTick();
+        // if the error code is no error or it has been less than 100 ms since start up, ignore
+        if (error_code == HAL_UART_ERROR_NONE || up_time_ms < 100 ) {
+            return;
+        }
+
         LOG_message(
             LOG_SYSTEM_EPS, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
             "HAL_UART_ErrorCallback for EPS: %lu", huart->ErrorCode


### PR DESCRIPTION
- On startup, disables all non-default channels
- Fixes bug where connecting on dev kit causes UART Error Callback for the EPS and prints junk