### PR TITLE
fix: Prevent LFS formatting if LFS is mounted

### DIFF
--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -58,6 +58,12 @@ struct lfs_file_config LFS_file_cfg = {
 /// @return 0 on success, negative LFS error codes on failure
 int8_t LFS_format()
 {
+    if (LFS_is_lfs_mounted) {
+        LOG_message(LOG_SYSTEM_LFS, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), 
+        "FLASH Memory cannot be formatted while LFS is mounted!");
+        return 1;
+    }
+    
     int8_t format_result = lfs_format(&LFS_filesystem, &LFS_cfg);
     if (format_result < 0) {
         LOG_message(LOG_SYSTEM_LFS, LOG_SEVERITY_CRITICAL, LOG_all_sinks_except(LOG_SINK_FILE), "Error formatting FLASH memory!");

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -55,7 +55,7 @@ struct lfs_file_config LFS_file_cfg = {
 
 /// @brief Formats Memory Module so it can successfully mount LittleFS
 /// @param None
-/// @return 0 on success, negative LFS error codes on failure
+/// @return 0 on success, 1 if LFS is already mounted, negative LFS error codes on failure
 int8_t LFS_format()
 {
     if (LFS_is_lfs_mounted) {

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -493,7 +493,7 @@ lfs_ssize_t LFS_read_file(const char file_name[], lfs_soff_t offset, uint8_t *re
     if (!LFS_is_lfs_mounted)
     {
         LOG_message(LOG_SYSTEM_LFS, LOG_SEVERITY_CRITICAL, LOG_all_sinks_except(LOG_SINK_FILE), "LittleFS not mounted");
-        return 1;
+        return -12512;
     }
 
     lfs_file_t file;


### PR DESCRIPTION
I am hoping to find any potential bugs or edge cases for LFS code and then adding fixes here. 

Currently I only have 1 which stops users from formatting FLASH memory if LFS is mounted on the memory. 
This has the potential of corrupting the FLASH memory or making any proceeding operations fail.

- We can keep it like this stopping the format 
- Or, we can unmount the LFS in code and continue with format

I will continue adding fixes as soon as I find them