### PR TITLE
Telecommand to get vip of single channel from EPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Please add your name to the list below in your first Pull Request!
 * Alex O.
 * Fardin M.
 * Kevin Hoang
+* Celina Hy
 
 ## License and Libraries
 

--- a/firmware/Core/Inc/eps_drivers/eps_types_to_json.h
+++ b/firmware/Core/Inc/eps_drivers/eps_types_to_json.h
@@ -28,7 +28,7 @@ uint8_t EPS_struct_pdu_overcurrent_fault_state_TO_json(const EPS_struct_pdu_over
 uint8_t EPS_struct_pbu_abf_placed_state_TO_json(const EPS_struct_pbu_abf_placed_state_t *data, char json_output_str[], uint16_t json_output_str_size);
 
 uint8_t EPS_struct_pdu_housekeeping_data_eng_TO_json(const EPS_struct_pdu_housekeeping_data_eng_t *data, char json_output_str[], uint16_t json_output_str_size);
-uint8_t EPS_struct_single_channel_data_eng_TO_json(const EPS_struct_pdu_housekeeping_data_eng_t *data, const uint8_t eps_channel, const char *eps_channel_name, char json_output_str[], uint16_t json_output_str_size);
+uint8_t EPS_struct_single_channel_data_eng_TO_json(const EPS_struct_pdu_housekeeping_data_eng_t *data, const uint8_t eps_channel, char json_output_str[], uint16_t json_output_str_size);
 uint8_t EPS_struct_pbu_housekeeping_data_eng_TO_json(const EPS_struct_pbu_housekeeping_data_eng_t *data, char json_output_str[], uint16_t json_output_str_size);
 uint8_t EPS_struct_pcu_housekeeping_data_eng_TO_json(const EPS_struct_pcu_housekeeping_data_eng_t *data, char json_output_str[], uint16_t json_output_str_size);
 uint8_t EPS_struct_piu_housekeeping_data_eng_TO_json(const EPS_struct_piu_housekeeping_data_eng_t *data, char json_output_str[], uint16_t json_output_str_size);

--- a/firmware/Core/Inc/eps_drivers/eps_types_to_json.h
+++ b/firmware/Core/Inc/eps_drivers/eps_types_to_json.h
@@ -28,7 +28,7 @@ uint8_t EPS_struct_pdu_overcurrent_fault_state_TO_json(const EPS_struct_pdu_over
 uint8_t EPS_struct_pbu_abf_placed_state_TO_json(const EPS_struct_pbu_abf_placed_state_t *data, char json_output_str[], uint16_t json_output_str_size);
 
 uint8_t EPS_struct_pdu_housekeeping_data_eng_TO_json(const EPS_struct_pdu_housekeeping_data_eng_t *data, char json_output_str[], uint16_t json_output_str_size);
-uint8_t EPS_struct_single_channel_data_eng_TO_json(const EPS_struct_pdu_housekeeping_data_eng_t *data, const uint8_t eps_channel, char json_output_str[], uint16_t json_output_str_size);
+uint8_t EPS_struct_single_channel_data_eng_TO_json(const EPS_struct_pdu_housekeeping_data_eng_t *data, const uint8_t eps_channel, const char *eps_channel_name, char json_output_str[], uint16_t json_output_str_size);
 uint8_t EPS_struct_pbu_housekeeping_data_eng_TO_json(const EPS_struct_pbu_housekeeping_data_eng_t *data, char json_output_str[], uint16_t json_output_str_size);
 uint8_t EPS_struct_pcu_housekeeping_data_eng_TO_json(const EPS_struct_pcu_housekeeping_data_eng_t *data, char json_output_str[], uint16_t json_output_str_size);
 uint8_t EPS_struct_piu_housekeeping_data_eng_TO_json(const EPS_struct_piu_housekeeping_data_eng_t *data, char json_output_str[], uint16_t json_output_str_size);

--- a/firmware/Core/Inc/eps_drivers/eps_types_to_json.h
+++ b/firmware/Core/Inc/eps_drivers/eps_types_to_json.h
@@ -28,9 +28,9 @@ uint8_t EPS_struct_pdu_overcurrent_fault_state_TO_json(const EPS_struct_pdu_over
 uint8_t EPS_struct_pbu_abf_placed_state_TO_json(const EPS_struct_pbu_abf_placed_state_t *data, char json_output_str[], uint16_t json_output_str_size);
 
 uint8_t EPS_struct_pdu_housekeeping_data_eng_TO_json(const EPS_struct_pdu_housekeeping_data_eng_t *data, char json_output_str[], uint16_t json_output_str_size);
+uint8_t EPS_struct_single_channel_data_eng_TO_json(const EPS_struct_pdu_housekeeping_data_eng_t *data, const uint8_t eps_channel, char json_output_str[], uint16_t json_output_str_size);
 uint8_t EPS_struct_pbu_housekeeping_data_eng_TO_json(const EPS_struct_pbu_housekeeping_data_eng_t *data, char json_output_str[], uint16_t json_output_str_size);
 uint8_t EPS_struct_pcu_housekeeping_data_eng_TO_json(const EPS_struct_pcu_housekeeping_data_eng_t *data, char json_output_str[], uint16_t json_output_str_size);
 uint8_t EPS_struct_piu_housekeeping_data_eng_TO_json(const EPS_struct_piu_housekeeping_data_eng_t *data, char json_output_str[], uint16_t json_output_str_size);
-
 
 #endif // INCLUDE_GUARD__EPS_TYPES_TO_JSON_H__

--- a/firmware/Core/Inc/telecommands/eps_telecommands.h
+++ b/firmware/Core/Inc/telecommands/eps_telecommands.h
@@ -51,7 +51,7 @@ uint8_t TCMDEXEC_eps_get_pbu_abf_placed_state_json(
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
-uint8_t TCMDEXEC_eps_get_pdu_data_for_single_channel_json(
+uint8_t TCMDEXEC_eps_get_pdu_data_for_channel_json(
     const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
     char *response_output_buf, uint16_t response_output_buf_len
 );

--- a/firmware/Core/Inc/telecommands/eps_telecommands.h
+++ b/firmware/Core/Inc/telecommands/eps_telecommands.h
@@ -51,6 +51,11 @@ uint8_t TCMDEXEC_eps_get_pbu_abf_placed_state_json(
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
+uint8_t TCMDEXEC_eps_get_pdu_data_for_single_channel_json(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    char *response_output_buf, uint16_t response_output_buf_len
+);
+
 uint8_t TCMDEXEC_eps_get_pdu_housekeeping_data_eng_json(
     const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
     char *response_output_buf, uint16_t response_output_buf_len

--- a/firmware/Core/Src/eps_drivers/eps_types_to_json.c
+++ b/firmware/Core/Src/eps_drivers/eps_types_to_json.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <inttypes.h>
+#include <eps_channel_control.h>
 
 
 // TODO: Determine how long each of these are, add to docs, add checks to each function at the start.
@@ -322,44 +323,28 @@ uint8_t EPS_struct_pdu_housekeeping_data_eng_TO_json(const EPS_struct_pdu_housek
 
 
 
-uint8_t EPS_struct_single_channel_data_eng_TO_json(const EPS_struct_pdu_housekeeping_data_eng_t *data, const uint8_t eps_channel, const char *eps_channel_name, char json_output_str[], uint16_t json_output_str_size) {
+uint8_t EPS_struct_single_channel_data_eng_TO_json(const EPS_struct_pdu_housekeeping_data_eng_t *data, const uint8_t eps_channel, char json_output_str[], uint16_t json_output_str_size) {
     if (data == NULL || json_output_str == NULL || json_output_str_size < 10) {
         return 1; // Error: Invalid input
     }
-    int ret, offset = 0;
 
-    // Start the JSON string
-    offset = snprintf(json_output_str, json_output_str_size, "{");
-    
-    ret = snprintf(json_output_str + offset, json_output_str_size - offset, "\"ch_num\":%d,\"ch_name\":%s", eps_channel, eps_channel_name);
-    if (ret < 0 || ret >= (json_output_str_size - offset)) return 3;
-    offset += ret;
+    // Get the string channel name
+    const char *eps_channel_name = EPS_channel_to_str(eps_channel);
 
-    char vip_channel_json[128];
-    ret = EPS_vpid_eng_TO_json(&data->vip_each_channel[eps_channel], vip_channel_json, sizeof(vip_channel_json));
-    if (ret != 0) return 5;
+    const EPS_vpid_eng_t *channel_data = &data->vip_each_channel[eps_channel];
 
-    // Strip the trailing curly brace
-    vip_channel_json[strlen(vip_channel_json) - 1] = '\0';
+    int snprintf_ret = snprintf(
+        json_output_str, json_output_str_size,
+        "{\"ch_num\":%d,\"ch_name\":\"%s\",\"mV\":%d,\"mA\":%d,\"cW\":%d}",
+        eps_channel, eps_channel_name,channel_data->voltage_mV, channel_data->current_mA, channel_data->power_cW);
 
-    ret = snprintf(
-        json_output_str + offset,
-        json_output_str_size - offset,
-        "%s",
-        vip_channel_json + 1 // Skip the opening brace
-    );
-    if (ret < 0 || ret >= (json_output_str_size - offset)) return 3;
-    offset += ret;
-
-    // End the JSON string
-    ret = snprintf(json_output_str + offset, json_output_str_size - offset, "}");
-    if (ret < 0 || ret >= (json_output_str_size - offset)) return 3;
-    offset += ret;
-
-    // Copy to output
-    if (offset >= json_output_str_size) {
-        return 3; // Output json_output_str too small
+    if (snprintf_ret < 0) {
+        return 2; // Error: snprintf encoding error
     }
+    if (snprintf_ret >= json_output_str_size) {
+        return 3; // Error: json_output_str too short
+    }
+
     return 0;
 }
 

--- a/firmware/Core/Src/eps_drivers/eps_types_to_json.c
+++ b/firmware/Core/Src/eps_drivers/eps_types_to_json.c
@@ -321,6 +321,49 @@ uint8_t EPS_struct_pdu_housekeeping_data_eng_TO_json(const EPS_struct_pdu_housek
 }
 
 
+uint8_t EPS_struct_single_channel_data_eng_TO_json(const EPS_struct_pdu_housekeeping_data_eng_t *data, const uint8_t eps_channel, char json_output_str[], uint16_t json_output_str_size) {
+    if (data == NULL || json_output_str == NULL || json_output_str_size < 10) {
+        return 1; // Error: Invalid input
+    }
+    int ret, offset = 0;
+
+    // Start the JSON string
+    offset = snprintf(json_output_str, json_output_str_size, "{");
+    
+    ret = snprintf(json_output_str + offset, json_output_str_size - offset, "\"vip of channel %d\":[", eps_channel);
+    if (ret < 0 || ret >= (json_output_str_size - offset)) return 3;
+    offset += ret;
+
+    char vip_channel_json[128];
+    ret = EPS_vpid_eng_TO_json(&data->vip_each_channel[eps_channel], vip_channel_json, sizeof(vip_channel_json));
+    if (ret != 0) return 5;
+
+    ret = snprintf(
+        json_output_str + offset,
+        json_output_str_size - offset,
+        "%s",
+        vip_channel_json
+    );
+    if (ret < 0 || ret >= (json_output_str_size - offset)) return 3;
+    offset += ret;
+
+    ret = snprintf(json_output_str + offset, json_output_str_size - offset, "]");
+    if (ret < 0 || ret >= (json_output_str_size - offset)) return 3;
+    offset += ret;
+
+    // End the JSON string
+    ret = snprintf(json_output_str + offset, json_output_str_size - offset, "}");
+    if (ret < 0 || ret >= (json_output_str_size - offset)) return 3;
+    offset += ret;
+
+    // Copy to output
+    if (offset >= json_output_str_size) {
+        return 3; // Output json_output_str too small
+    }
+    return 0;
+}
+
+
 uint8_t EPS_struct_pbu_housekeeping_data_eng_TO_json(const EPS_struct_pbu_housekeeping_data_eng_t *data, char json_output_str[], uint16_t json_output_str_size) {
     if (data == NULL || json_output_str == NULL || json_output_str_size < 10) {
         return 1; // Error: Invalid input

--- a/firmware/Core/Src/eps_drivers/eps_types_to_json.c
+++ b/firmware/Core/Src/eps_drivers/eps_types_to_json.c
@@ -321,7 +321,8 @@ uint8_t EPS_struct_pdu_housekeeping_data_eng_TO_json(const EPS_struct_pdu_housek
 }
 
 
-uint8_t EPS_struct_single_channel_data_eng_TO_json(const EPS_struct_pdu_housekeeping_data_eng_t *data, const uint8_t eps_channel, char json_output_str[], uint16_t json_output_str_size) {
+
+uint8_t EPS_struct_single_channel_data_eng_TO_json(const EPS_struct_pdu_housekeeping_data_eng_t *data, const uint8_t eps_channel, const char *eps_channel_name, char json_output_str[], uint16_t json_output_str_size) {
     if (data == NULL || json_output_str == NULL || json_output_str_size < 10) {
         return 1; // Error: Invalid input
     }
@@ -330,7 +331,7 @@ uint8_t EPS_struct_single_channel_data_eng_TO_json(const EPS_struct_pdu_housekee
     // Start the JSON string
     offset = snprintf(json_output_str, json_output_str_size, "{");
     
-    ret = snprintf(json_output_str + offset, json_output_str_size - offset, "\"vip of channel %d\":[", eps_channel);
+    ret = snprintf(json_output_str + offset, json_output_str_size - offset, "\"ch_num\":%d,\"ch_name\":%s", eps_channel, eps_channel_name);
     if (ret < 0 || ret >= (json_output_str_size - offset)) return 3;
     offset += ret;
 
@@ -338,16 +339,15 @@ uint8_t EPS_struct_single_channel_data_eng_TO_json(const EPS_struct_pdu_housekee
     ret = EPS_vpid_eng_TO_json(&data->vip_each_channel[eps_channel], vip_channel_json, sizeof(vip_channel_json));
     if (ret != 0) return 5;
 
+    // Strip the trailing curly brace
+    vip_channel_json[strlen(vip_channel_json) - 1] = '\0';
+
     ret = snprintf(
         json_output_str + offset,
         json_output_str_size - offset,
         "%s",
-        vip_channel_json
+        vip_channel_json + 1 // Skip the opening brace
     );
-    if (ret < 0 || ret >= (json_output_str_size - offset)) return 3;
-    offset += ret;
-
-    ret = snprintf(json_output_str + offset, json_output_str_size - offset, "]");
     if (ret < 0 || ret >= (json_output_str_size - offset)) return 3;
     offset += ret;
 

--- a/firmware/Core/Src/eps_drivers/eps_types_to_json.c
+++ b/firmware/Core/Src/eps_drivers/eps_types_to_json.c
@@ -1,11 +1,11 @@
 
 #include "eps_drivers/eps_types_to_json.h"
+#include "eps_drivers/eps_channel_control.h"
 
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
 #include <inttypes.h>
-#include <eps_channel_control.h>
 
 
 // TODO: Determine how long each of these are, add to docs, add checks to each function at the start.

--- a/firmware/Core/Src/telecommands/eps_telecommands.c
+++ b/firmware/Core/Src/telecommands/eps_telecommands.c
@@ -350,6 +350,10 @@ uint8_t TCMDEXEC_eps_get_pdu_housekeeping_data_eng_json(
 /// @param args_str 
 /// - Arg 0: The channel name or number (string).
 /// @return 0 on success, >0 on failure.
+/// @note Channel name argument: A lowercase c-string of the channel name (e.g., "mpi"), or a number
+/// representing the channel number (e.g., "1" or "16").
+/// Valid string values: "vbatt_stack", "stack_5v", "stack_3v3", "camera", "uhf_antenna_deploy",
+/// "lora_module", "mpi_5v", "mpi_12v", "boom".
 uint8_t TCMDEXEC_eps_get_pdu_data_for_single_channel_json(
     const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
     char *response_output_buf, uint16_t response_output_buf_len

--- a/firmware/Core/Src/telecommands/eps_telecommands.c
+++ b/firmware/Core/Src/telecommands/eps_telecommands.c
@@ -346,7 +346,9 @@ uint8_t TCMDEXEC_eps_get_pdu_housekeeping_data_eng_json(
 }
 
 
-/// @brief Get power/current/voltage data from the EPS PDU (Power Distribution Unit), and display it as a JSON string.
+/// @brief Sets the EPS channel to be enabled (on) or disabled (off).
+/// @param args_str 
+/// - Arg 0: The channel name or number (string).
 /// @return 0 on success, >0 on failure.
 uint8_t TCMDEXEC_eps_get_pdu_data_for_single_channel_json(
     const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,

--- a/firmware/Core/Src/telecommands/eps_telecommands.c
+++ b/firmware/Core/Src/telecommands/eps_telecommands.c
@@ -368,15 +368,6 @@ uint8_t TCMDEXEC_eps_get_pdu_data_for_single_channel_json(
         return 1;
     }
 
-    // TODO: Remove this log message after testing.
-    LOG_message(
-        LOG_SYSTEM_ANTENNA_DEPLOY,
-        LOG_SEVERITY_ERROR,
-        LOG_SINK_ALL, 
-        "this is the channel name provided from params: %s",
-        channel_str
-    );
-
     // Convert the channel string to an enum value.
     const EPS_CHANNEL_enum_t eps_channel = EPS_channel_from_str(channel_str);
     if (eps_channel == EPS_CHANNEL_UNKNOWN) {
@@ -388,18 +379,6 @@ uint8_t TCMDEXEC_eps_get_pdu_data_for_single_channel_json(
 
     // Convert to a nice channel number.
     const uint8_t eps_channel_num = (uint8_t) eps_channel;
-
-    // TODO: Remove this log message after testing.
-    LOG_message(
-        LOG_SYSTEM_ANTENNA_DEPLOY,
-        LOG_SEVERITY_ERROR,
-        LOG_SINK_ALL, 
-        "eps_channel_num:%d",
-        eps_channel_num
-    );
-
-    // ------------- above is destructuing the args to get valid channel number -------------
-    // ------------- below is getting data from EPS and formatting it -------------
 
     // Define the destination of where data is written into 
     EPS_struct_pdu_housekeeping_data_eng_t data;

--- a/firmware/Core/Src/telecommands/eps_telecommands.c
+++ b/firmware/Core/Src/telecommands/eps_telecommands.c
@@ -377,8 +377,7 @@ uint8_t TCMDEXEC_eps_get_pdu_data_for_single_channel_json(
         return 4;
     }
 
-    // Convert to a nice string/channel number.
-    const char *eps_channel_name_str = EPS_channel_to_str(eps_channel);
+    // Convert to a nice channel number
     const uint8_t eps_channel_num = (uint8_t) eps_channel;
 
     // Define the destination of where data is written into 
@@ -395,8 +394,7 @@ uint8_t TCMDEXEC_eps_get_pdu_data_for_single_channel_json(
 
     // Format the data to JSON string
     const uint8_t result_json = EPS_struct_single_channel_data_eng_TO_json(
-
-        &data, eps_channel_num, eps_channel_name_str, response_output_buf, response_output_buf_len);
+        &data, eps_channel_num, response_output_buf, response_output_buf_len);
     if (result_json != 0) {
         snprintf(response_output_buf, response_output_buf_len,
             "EPS_struct_single_channel_data_eng_TO_json failed (err %d)", result_json);

--- a/firmware/Core/Src/telecommands/eps_telecommands.c
+++ b/firmware/Core/Src/telecommands/eps_telecommands.c
@@ -408,12 +408,12 @@ uint8_t TCMDEXEC_eps_get_pdu_data_for_single_channel_json(
     }
 
     // Format the data to JSON string
-    const uint8_t result_json = EPS_struct_pdu_channel_data_eng_TO_json(
+    const uint8_t result_json = EPS_struct_single_channel_data_eng_TO_json(
         &data, eps_channel_num,response_output_buf, response_output_buf_len);
 
     if (result_json != 0) {
         snprintf(response_output_buf, response_output_buf_len,
-            "EPS_struct_pdu_channel_data_eng_TO_json failed (err %d)", result_json);
+            "EPS_struct_single_channel_data_eng_TO_json failed (err %d)", result_json);
         return 2;
     }
     return 0;

--- a/firmware/Core/Src/telecommands/eps_telecommands.c
+++ b/firmware/Core/Src/telecommands/eps_telecommands.c
@@ -354,7 +354,7 @@ uint8_t TCMDEXEC_eps_get_pdu_housekeeping_data_eng_json(
 /// representing the channel number (e.g., "1" or "16").
 /// Valid string values: "vbatt_stack", "stack_5v", "stack_3v3", "camera", "uhf_antenna_deploy",
 /// "lora_module", "mpi_5v", "mpi_12v", "boom".
-uint8_t TCMDEXEC_eps_get_pdu_data_for_single_channel_json(
+uint8_t TCMDEXEC_eps_get_pdu_data_for_channel_json(
     const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {

--- a/firmware/Core/Src/telecommands/eps_telecommands.c
+++ b/firmware/Core/Src/telecommands/eps_telecommands.c
@@ -377,7 +377,8 @@ uint8_t TCMDEXEC_eps_get_pdu_data_for_single_channel_json(
         return 4;
     }
 
-    // Convert to a nice channel number.
+    // Convert to a nice string/channel number.
+    const char *eps_channel_name_str = EPS_channel_to_str(eps_channel);
     const uint8_t eps_channel_num = (uint8_t) eps_channel;
 
     // Define the destination of where data is written into 
@@ -394,8 +395,8 @@ uint8_t TCMDEXEC_eps_get_pdu_data_for_single_channel_json(
 
     // Format the data to JSON string
     const uint8_t result_json = EPS_struct_single_channel_data_eng_TO_json(
-        &data, eps_channel_num,response_output_buf, response_output_buf_len);
 
+        &data, eps_channel_num, eps_channel_name_str, response_output_buf, response_output_buf_len);
     if (result_json != 0) {
         snprintf(response_output_buf, response_output_buf_len,
             "EPS_struct_single_channel_data_eng_TO_json failed (err %d)", result_json);
@@ -403,7 +404,6 @@ uint8_t TCMDEXEC_eps_get_pdu_data_for_single_channel_json(
     }
     return 0;
 }
-
 
 
 /// @brief Get the EPS PDU (Power Distribution Unit) housekeeping data (running average), and display it as a JSON string.

--- a/firmware/Core/Src/telecommands/eps_telecommands.c
+++ b/firmware/Core/Src/telecommands/eps_telecommands.c
@@ -346,7 +346,7 @@ uint8_t TCMDEXEC_eps_get_pdu_housekeeping_data_eng_json(
 }
 
 
-/// @brief Sets the EPS channel to be enabled (on) or disabled (off).
+/// @brief Gets the Voltage, Current, and Power for a single channel on the EPS.
 /// @param args_str 
 /// - Arg 0: The channel name or number (string).
 /// @return 0 on success, >0 on failure.

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -949,8 +949,8 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {
-        .tcmd_name = "eps_get_pdu_data_for_single_channel_json",
-        .tcmd_func = TCMDEXEC_eps_get_pdu_data_for_single_channel_json,
+        .tcmd_name = "eps_get_pdu_data_for_channel_json",
+        .tcmd_func = TCMDEXEC_eps_get_pdu_data_for_channel_json,
         .number_of_args = 1,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -948,7 +948,12 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .number_of_args = 0,
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
-
+    {
+        .tcmd_name = "eps_get_pdu_data_for_single_channel_json",
+        .tcmd_func = TCMDEXEC_eps_get_pdu_data_for_single_channel_json,
+        .number_of_args = 1,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
     {
         .tcmd_name = "eps_get_pdu_housekeeping_data_eng_json",
         .tcmd_func = TCMDEXEC_eps_get_pdu_housekeeping_data_eng_json,


### PR DESCRIPTION
This PR:

- Telecommand name `eps_get_pdu_data_for_single_channel_json`. This telecommand will retrieve the VIP data for a single channel on the EPS. The function expects to receive one string arg: the channel name or number.

This issue is related to #329 

Ex:  
- CTS1+eps_get_pdu_data_for_single_channel_json(5)!
- CTS1+eps_get_pdu_data_for_single_channel_json(camera)!
- CTS1+eps_get_pdu_data_for_single_channel_json(uhf_antenna_deploy)!
- CTS1+eps_get_pdu_data_for_single_channel_json(boom)!
