### PR TITLE
fix: Add power control to GNSS self-check

### DIFF
--- a/firmware/Core/Src/gps/gps_internal_drivers.c
+++ b/firmware/Core/Src/gps/gps_internal_drivers.c
@@ -14,7 +14,7 @@
 extern UART_HandleTypeDef *UART_gps_port_handle;
 
 const uint32_t GPS_RX_TIMEOUT_BEFORE_FIRST_BYTE_MS = 800;
-const uint32_t GPS_RX_TIMEOUT_BETWEEN_BYTES_MS = 800;
+const uint32_t GPS_RX_TIMEOUT_BETWEEN_BYTES_MS = 2500; // Lots of commands pause in the middle (e.g., BESTXYZA) as it contemplates its position in the universe.
 
 /// @brief Sends a log command to the GPS, and receives the response.
 /// @param cmd_buf log command string to send to the GPS.

--- a/firmware/Core/Src/uart_handler/uart_handler.c
+++ b/firmware/Core/Src/uart_handler/uart_handler.c
@@ -258,8 +258,11 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
                 // Reset to a valid index
                 UART_gps_buffer_write_idx = UART_gps_buffer_len - 1;
             }
-            UART_gps_buffer[UART_gps_buffer_write_idx++] = UART_gps_buffer_last_rx_byte;
-            UART_gps_last_write_time_ms = HAL_GetTick();
+
+            if (UART_gps_buffer_last_rx_byte != '\0') {
+                UART_gps_buffer[UART_gps_buffer_write_idx++] = UART_gps_buffer_last_rx_byte;
+                UART_gps_last_write_time_ms = HAL_GetTick();
+            }
 
             HAL_UART_Receive_IT(UART_gps_port_handle, (uint8_t*) &UART_gps_buffer_last_rx_byte, 1);
         }


### PR DESCRIPTION
Fixes #422 

Should be tested to make sure the bootup time is adequate. It's currently 500ms, but that may be too short.