### PR TITLE
LFS: Fixed LFS return types to remove overflow situations

### DIFF
--- a/firmware/Core/Inc/littlefs/littlefs_helper.h
+++ b/firmware/Core/Inc/littlefs/littlefs_helper.h
@@ -31,9 +31,9 @@ int8_t LFS_unmount();
 int8_t LFS_list_directory(const char root_directory[], uint16_t offset, int16_t count);
 int8_t LFS_make_directory(const char dir_name[]);
 int8_t LFS_delete_file(const char file_name[]);
-int8_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t write_buffer_len);
-int8_t LFS_write_file_with_offset(const char file_name[], lfs_soff_t offset, uint8_t *write_buffer, uint32_t write_buffer_len);
-int8_t LFS_append_file(const char file_name[], uint8_t *write_buffer, uint32_t write_buffer_len);
+lfs_ssize_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t write_buffer_len);
+lfs_ssize_t LFS_write_file_with_offset(const char file_name[], lfs_soff_t offset, uint8_t *write_buffer, uint32_t write_buffer_len);
+lfs_ssize_t LFS_append_file(const char file_name[], uint8_t *write_buffer, uint32_t write_buffer_len);
 lfs_ssize_t LFS_read_file(const char file_name[], lfs_soff_t offset, uint8_t *read_buffer, uint32_t read_buffer_len);
 lfs_ssize_t LFS_file_size(const char file_name[]);
 

--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -272,7 +272,7 @@ int8_t LFS_delete_file(const char file_name[])
 /// @param write_buffer - Pointer to buffer holding the data to write
 /// @param write_buffer_len - Size of the data to write
 /// @return 0 on success, 1 if LFS is unmounted, negative LFS error codes on failure
-int8_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t write_buffer_len)
+lfs_ssize_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t write_buffer_len)
 {
     if (!LFS_is_lfs_mounted)
     {
@@ -318,7 +318,7 @@ int8_t LFS_write_file(const char file_name[], uint8_t *write_buffer, uint32_t wr
 /// @param write_buffer - Pointer to buffer holding the data to write
 /// @param write_buffer_len - Size of the data to write
 /// @return 0 on success, 1 if LFS is unmounted, negative LFS error codes on failure
-int8_t LFS_append_file(const char file_name[], uint8_t *write_buffer, uint32_t write_buffer_len)
+lfs_ssize_t LFS_append_file(const char file_name[], uint8_t *write_buffer, uint32_t write_buffer_len)
 {
     if (!LFS_is_lfs_mounted)
     {
@@ -363,7 +363,7 @@ int8_t LFS_append_file(const char file_name[], uint8_t *write_buffer, uint32_t w
 /// @param write_buffer - Pointer to buffer holding the data to write
 /// @param write_buffer_len - Size of the data to write
 /// @retval 0 on success, 1 if LFS is unmounted, negative LFS error codes on failure
-int8_t LFS_write_file_with_offset(const char file_name[], lfs_soff_t offset, uint8_t *write_buffer, uint32_t write_buffer_len)
+lfs_ssize_t LFS_write_file_with_offset(const char file_name[], lfs_soff_t offset, uint8_t *write_buffer, uint32_t write_buffer_len)
 {
     if (!LFS_is_lfs_mounted)
     {

--- a/firmware/Core/Src/telecommand_exec/telecommand_executor.c
+++ b/firmware/Core/Src/telecommand_exec/telecommand_executor.c
@@ -294,7 +294,7 @@ uint8_t TCMD_log_to_file(const char *filename, const char *message)
     }
 
     // FIXME(Issue #389): Should write a timestamp probably. Maybe a telecommand name too, and maybe the arg string.
-    const int8_t write_file_return = LFS_write_file(
+    const int32_t write_file_return = LFS_write_file(
         filename,
         (uint8_t *)message,
         strlen(message)

--- a/firmware/Core/Src/telecommand_exec/telecommand_executor.c
+++ b/firmware/Core/Src/telecommand_exec/telecommand_executor.c
@@ -302,7 +302,7 @@ uint8_t TCMD_log_to_file(const char *filename, const char *message)
     if (write_file_return != 0) {
         LOG_message(
             LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_ERROR, LOG_SINK_ALL,
-            "Error: TCMD_log_to_file: Failed to write to file '%s'. Error code: %d",
+            "Error: TCMD_log_to_file: Failed to write to file '%s'. Error code: %ld",
             filename,
             write_file_return
         );

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -230,7 +230,7 @@ uint8_t TCMDEXEC_fs_write_file_str(const char *args_str, TCMD_TelecommandChannel
         return 2;
     }
 
-    const int8_t result = LFS_write_file(arg_file_name, (uint8_t*) arg_file_content, strlen(arg_file_content));
+    const int32_t result = LFS_write_file(arg_file_name, (uint8_t*) arg_file_content, strlen(arg_file_content));
     if (result != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: LFS_write_file() -> %d", result);
         return 1;
@@ -290,7 +290,7 @@ uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel
     }
 
     // Use our new helper function to write the data at the specified offset
-    const int8_t result = LFS_write_file_with_offset(arg_file_name, (lfs_soff_t)file_offset, binary_data, binary_data_length);
+    const int32_t result = LFS_write_file_with_offset(arg_file_name, (lfs_soff_t)file_offset, binary_data, binary_data_length);
     if (result != 0) {
         snprintf(response_output_buf, response_output_buf_len, "LittleFS Writing Error: %d", result);
         return 4;
@@ -452,14 +452,14 @@ uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str, TCMD_TelecommandC
         return 1;
     }
 
-    const int8_t write_result = LFS_write_file(file_name, (uint8_t*) file_content, strlen(file_content));
+    const int32_t write_result = LFS_write_file(file_name, (uint8_t*) file_content, strlen(file_content));
     if (write_result != 0) {
         snprintf(response_output_buf, response_output_buf_len, "LittleFS writing error: %d", write_result);
         return 2;
     }
 
     uint8_t read_buffer[200] = {0};
-    const int8_t read_result = LFS_read_file(file_name, 0, read_buffer, sizeof(read_buffer));
+    const int32_t read_result = LFS_read_file(file_name, 0, read_buffer, sizeof(read_buffer));
     if (read_result != 0) {
         snprintf(response_output_buf, response_output_buf_len, "LittleFS reading error: %d", read_result);
         return 3;

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -232,7 +232,7 @@ uint8_t TCMDEXEC_fs_write_file_str(const char *args_str, TCMD_TelecommandChannel
 
     const int32_t result = LFS_write_file(arg_file_name, (uint8_t*) arg_file_content, strlen(arg_file_content));
     if (result != 0) {
-        snprintf(response_output_buf, response_output_buf_len, "Error: LFS_write_file() -> %d", result);
+        snprintf(response_output_buf, response_output_buf_len, "Error: LFS_write_file() -> %ld", result);
         return 1;
     }
     
@@ -292,7 +292,7 @@ uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel
     // Use our new helper function to write the data at the specified offset
     const int32_t result = LFS_write_file_with_offset(arg_file_name, (lfs_soff_t)file_offset, binary_data, binary_data_length);
     if (result != 0) {
-        snprintf(response_output_buf, response_output_buf_len, "LittleFS Writing Error: %d", result);
+        snprintf(response_output_buf, response_output_buf_len, "LittleFS Writing Error: %ld", result);
         return 4;
     }
     
@@ -454,14 +454,14 @@ uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str, TCMD_TelecommandC
 
     const int32_t write_result = LFS_write_file(file_name, (uint8_t*) file_content, strlen(file_content));
     if (write_result != 0) {
-        snprintf(response_output_buf, response_output_buf_len, "LittleFS writing error: %d", write_result);
+        snprintf(response_output_buf, response_output_buf_len, "LittleFS writing error: %ld", write_result);
         return 2;
     }
 
     uint8_t read_buffer[200] = {0};
     const int32_t read_result = LFS_read_file(file_name, 0, read_buffer, sizeof(read_buffer));
     if (read_result != 0) {
-        snprintf(response_output_buf, response_output_buf_len, "LittleFS reading error: %d", read_result);
+        snprintf(response_output_buf, response_output_buf_len, "LittleFS reading error: %ld", read_result);
         return 3;
     }
 


### PR DESCRIPTION
The changes are only made to functions that use internal LFS functions returning `lfs_ssize_t` type.

Internal LFS functions returning `int` type remain unchanged (they are `int8_t`)