### PR TITLE
ADCS: Additional bootloader bugfix

### DIFF
--- a/firmware/Core/Src/adcs_drivers/adcs_commands.c
+++ b/firmware/Core/Src/adcs_drivers/adcs_commands.c
@@ -351,9 +351,10 @@ uint8_t ADCS_get_llh_position(ADCS_llh_position_struct_t *output_struct) {
 /// @brief Instruct the ADCS to execute the ADCS_Bootloader_Clear_Errors command.
 /// @return 0 if successful, non-zero if a HAL or ADCS error occurred in transmission.
 uint8_t ADCS_bootloader_clear_errors() {
-    uint8_t data_send[1]; // 0-byte data (from manual) input into wrapper, but one-byte here to avoid warnings
-    const uint8_t cmd_status = ADCS_i2c_send_command_and_check(ADCS_COMMAND_BOOTLOADER_CLEAR_ERRORS, data_send, 0, ADCS_INCLUDE_CHECKSUM);
-    return cmd_status;
+    uint8_t data_send[1] = {ADCS_COMMAND_BOOTLOADER_CLEAR_ERRORS}; // 0-byte data (from manual) input into wrapper, but one-byte here to avoid warnings
+    const uint8_t hal_status = HAL_I2C_Master_Transmit(ADCS_i2c_HANDLE, ADCS_i2c_ADDRESS << 1, data_send, 1, ADCS_HAL_TIMEOUT);
+        // The bootloader doesn't support checksum, and this is a zero-parameter command, so HAL_I2C_Mem_Write can't be used (zero length message).
+    return hal_status;
 }
 
 /// @brief Instruct the ADCS to execute the ADCS_Set_Unix_Time_Save_Mode command.


### PR DESCRIPTION
To make sure the existing ADCS_bootloader_clear_errors command is working correctly, I've changed the implementation slightly.