### PR TITLE
feat: Store extra header info (e.g., timestamps) to `resp_fname` file

### DIFF
--- a/firmware/Core/Src/telecommand_exec/telecommand_executor.c
+++ b/firmware/Core/Src/telecommand_exec/telecommand_executor.c
@@ -215,7 +215,7 @@ static int8_t TCMD_store_resp_to_file(
         "\"tcmd\":\"%s\","
         "\"duration_ms\":%lu,"
         "\"return\":%u,"
-        "\"args\":\"%s\","
+        "\"args\":\"%s\""
         "}\n",
         timestamp_sent_str,
         timestamp_done_str,

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -14,8 +14,12 @@
 #include "telecommand_exec/telecommand_args_helpers.h"
 #include "transforms/arrays.h"
 
-uint8_t TCMDEXEC_fs_format_storage(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len) {
+uint8_t TCMDEXEC_fs_format_storage(
+    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+        char *response_output_buf, uint16_t response_output_buf_len
+) {
+    LFS_ensure_unmounted();
+
     const int8_t result = LFS_format();
     if (result != 0) {
         snprintf(response_output_buf, response_output_buf_len, "Error: LFS_format() -> %d", result);


### PR DESCRIPTION
Fixes #389