### PR TITLE
Removed TCMD_TelecommandChannel_enum_t

### DIFF
--- a/firmware/Core/Inc/telecommand_exec/telecommand_parser.h
+++ b/firmware/Core/Inc/telecommand_exec/telecommand_parser.h
@@ -29,7 +29,7 @@ uint8_t TCMD_get_suffix_tag_uint64(const char *str, const char *tag_name, uint64
 uint8_t TCMD_get_suffix_tag_hex_array(const char *str, const char *tag_name, uint8_t *value_dest);
 uint8_t TCMD_get_suffix_tag_str(const char *str, const char *tag_name, char *value_dest, uint16_t value_dest_max_len);
 
-uint8_t TCMD_parse_full_telecommand(const char tcmd_str[], TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMD_parse_full_telecommand(const char tcmd_str[],
                                     TCMD_parsed_tcmd_to_execute_t *parsed_tcmd_output);
 
 

--- a/firmware/Core/Inc/telecommand_exec/telecommand_types.h
+++ b/firmware/Core/Inc/telecommand_exec/telecommand_types.h
@@ -7,11 +7,6 @@
 #define TCMD_MAX_RESP_FNAME_LEN 64
 
 typedef enum {
-    TCMD_TelecommandChannel_DEBUG_UART,
-    TCMD_TelecommandChannel_RADIO1
-} TCMD_TelecommandChannel_enum_t;
-
-typedef enum {
     TCMD_READINESS_LEVEL_IDEA_PHASE, 
     TCMD_READINESS_LEVEL_NOT_IMPLEMENTED, 
     TCMD_READINESS_LEVEL_IN_PROGRESS, 
@@ -26,7 +21,7 @@ typedef enum {
     TCMD_READINESS_LEVEL_FOR_OPERATION
 } TCMD_readiness_level_enum_t;
 
-typedef uint8_t (*TCMD_TCMDEXEC_Function_Ptr)(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+typedef uint8_t (*TCMD_TCMDEXEC_Function_Ptr)(const char *args_str,
                                          char *response_output_buf, uint16_t response_output_buf_len);
 
 typedef struct {
@@ -50,7 +45,6 @@ typedef struct {
     /// @brief Name of file that response should be written to, empty string otherwise
     char resp_fname[TCMD_MAX_RESP_FNAME_LEN];
     /// @brief The channel on which the telecommand was received, and on which the response should be sent.
-    TCMD_TelecommandChannel_enum_t tcmd_channel;
 } TCMD_parsed_tcmd_to_execute_t;
 
 #endif // INCLUDE_GUARD__TELECOMMAND_TYPES_H

--- a/firmware/Core/Inc/telecommands/agenda_telecommands_defs.h
+++ b/firmware/Core/Inc/telecommands/agenda_telecommands_defs.h
@@ -5,16 +5,16 @@
 
 #include <stdint.h>
 
-uint8_t TCMDEXEC_agenda_delete_all(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_agenda_delete_all(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_agenda_delete_by_tssent(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_agenda_delete_by_tssent(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_agenda_fetch_jsonl(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_agenda_fetch_jsonl(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_agenda_delete_by_name(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_agenda_delete_by_name(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif // INCLUDE_GUARD__AGENDA_TELECOMMAND_DEFINITIONS_H

--- a/firmware/Core/Inc/telecommands/antenna_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/antenna_telecommand_defs.h
@@ -4,38 +4,38 @@
 #include <stdint.h>
 #include "telecommand_exec/telecommand_definitions.h"
 
-uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_reset(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len);
-
-
-uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len);
-
-uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len);
-
-uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
-                        char *response_output_buf, uint16_t response_output_buf_len);
-
-uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 
-uint8_t TCMDEXEC_ant_measure_temp(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+
+uint8_t TCMDEXEC_ant_measure_temp(const char *args_str,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args_str,
+                        char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 #endif /* INCLUDE_GUARD_ANTENNA_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Inc/telecommands/boom_deploy_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/boom_deploy_telecommand_defs.h
@@ -4,13 +4,13 @@
 #include <stdint.h>
 
 uint8_t TCMDEXEC_boom_deploy_timed(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 
 uint8_t TCMDEXEC_boom_self_check(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 

--- a/firmware/Core/Inc/telecommands/camera_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/camera_telecommand_defs.h
@@ -6,21 +6,21 @@
 
 
 uint8_t TCMDEXEC_camera_setup(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
     
 uint8_t TCMDEXEC_camera_test(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_camera_change_baud_rate(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
-uint8_t TCMDEXEC_camera_capture(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_camera_capture(const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 

--- a/firmware/Core/Inc/telecommands/comms_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/comms_telecommand_defs.h
@@ -6,25 +6,25 @@
 #include <stdint.h>
 
 uint8_t TCMDEXEC_comms_set_rf_switch_control_mode(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_comms_get_rf_switch_info(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_comms_bulk_file_downlink_start(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 uint8_t TCMDEXEC_comms_bulk_file_downlink_pause(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 uint8_t TCMDEXEC_comms_bulk_file_downlink_resume(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 

--- a/firmware/Core/Inc/telecommands/config_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/config_telecommand_defs.h
@@ -5,19 +5,19 @@
 #include "telecommand_exec/telecommand_types.h"
 
 
-uint8_t TCMDEXEC_config_set_int_var(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_config_set_int_var(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_config_set_str_var(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_config_set_str_var(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_config_get_int_var_json(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_config_get_int_var_json(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_config_get_str_var_json(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_config_get_str_var_json(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_config_get_all_vars_jsonl(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_config_get_all_vars_jsonl(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 

--- a/firmware/Core/Inc/telecommands/eps_telecommands.h
+++ b/firmware/Core/Inc/telecommands/eps_telecommands.h
@@ -6,108 +6,107 @@
 
 
 uint8_t TCMDEXEC_eps_watchdog(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_system_reset(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_no_operation(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_cancel_operation(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_switch_to_mode(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_set_channel_enabled(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_get_system_status_json(
     const char *args_str,
-    TCMD_TelecommandChannel_enum_t tcmd_channel,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_get_pdu_overcurrent_fault_state_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_get_pbu_abf_placed_state_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_get_pdu_data_for_channel_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_get_pdu_housekeeping_data_eng_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_get_pdu_housekeeping_data_run_avg_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_get_pbu_housekeeping_data_eng_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_get_pbu_housekeeping_data_run_avg_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_get_pcu_housekeeping_data_eng_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_get_pcu_housekeeping_data_run_avg_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_get_piu_housekeeping_data_eng_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_get_piu_housekeeping_data_run_avg_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_get_current_battery_percent(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_power_management_set_current_threshold(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_eps_get_enabled_channels_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 

--- a/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/flash_telecommand_defs.h
@@ -6,31 +6,31 @@
 #include "telecommand_exec/telecommand_definitions.h"
 
 /*----------------------------- TELECOMMAND DEFINITIONS ----------------------------- */
-uint8_t TCMDEXEC_flash_activate_each_cs(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_activate_each_cs(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_flash_each_is_reachable(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_each_is_reachable(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
                         
-uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_read_hex(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_write_hex(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_erase(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_flash_reset(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_reset(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_flash_read_status_register(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_read_status_register(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_flash_write_enable(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_write_enable(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
                         
 #endif /* INCLUDE_GUARD__FLASH_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Inc/telecommands/freertos_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/freertos_telecommand_defs.h
@@ -6,11 +6,11 @@
 
 #include <stdint.h>
 
-uint8_t TCMDEXEC_freetos_list_tasks_jsonl(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_freetos_list_tasks_jsonl(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 uint8_t TCMDEXEC_freertos_demo_stack_usage(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 

--- a/firmware/Core/Inc/telecommands/gnss_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/gnss_telecommand_defs.h
@@ -5,7 +5,7 @@
 
 #include <stdint.h>
 
-uint8_t TCMDEXEC_gnss_send_cmd_ascii(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_gnss_send_cmd_ascii(const char *args_str,
                                  char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif // __INCLUDE_GUARD__GNSS_TELECOMMAND_DEFS_H

--- a/firmware/Core/Inc/telecommands/i2c_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/i2c_telecommand_defs.h
@@ -5,11 +5,11 @@
 #include "telecommand_exec/telecommand_definitions.h"
 
 uint8_t TCMDEXEC_scan_i2c_bus_verbose(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len);
 
 uint8_t TCMDEXEC_scan_i2c_bus(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 

--- a/firmware/Core/Inc/telecommands/lfs_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/lfs_telecommand_defs.h
@@ -5,50 +5,50 @@
 #include <stdint.h>
 #include "telecommand_exec/telecommand_definitions.h"
 
-uint8_t TCMDEXEC_fs_format_storage(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_format_storage(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_fs_mount(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_mount(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_fs_unmount(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_unmount(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_fs_list_directory(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_list_directory(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 uint8_t TCMDEXEC_fs_list_directory_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
-uint8_t TCMDEXEC_fs_make_directory(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_make_directory(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_fs_write_file_str(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_write_file_str(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_fs_delete_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_delete_file(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
                         
-uint8_t TCMDEXEC_fs_read_file_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_read_file_hex(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_fs_read_text_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_read_text_file(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 uint8_t TCMDEXEC_fs_read_file_sha256_hash_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
-uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_fs_benchmark_write_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_benchmark_write_read(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 

--- a/firmware/Core/Inc/telecommands/log_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/log_telecommand_defs.h
@@ -5,34 +5,34 @@
 #include <stdint.h>
 #include "telecommand_exec/telecommand_definitions.h"
 
-uint8_t TCMDEXEC_log_set_sink_enabled_state(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_log_set_sink_enabled_state(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_log_set_system_file_logging_enabled_state(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_log_set_system_file_logging_enabled_state(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_log_report_sink_enabled_state(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_log_report_sink_enabled_state(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_log_report_all_sink_enabled_states(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_log_report_all_sink_enabled_states(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_log_report_system_file_logging_state(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_log_report_system_file_logging_state(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_log_report_all_system_file_logging_states(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_log_report_all_system_file_logging_states(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_log_set_sink_debugging_messages_state(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_log_set_sink_debugging_messages_state(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_log_set_system_debugging_messages_state(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_log_set_system_debugging_messages_state(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_log_set_system_severity_mask(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_log_set_system_severity_mask(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_log_report_n_latest_messages_from_memory(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_log_report_n_latest_messages_from_memory(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif /* INCLUDE_GUARD__LOG_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Inc/telecommands/mpi_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/mpi_telecommand_defs.h
@@ -5,24 +5,24 @@
 #include "telecommand_exec/telecommand_definitions.h"
 
 uint8_t TCMDEXEC_mpi_send_command_get_response_hex(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_mpi_demo_tx_to_mpi(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_mpi_demo_set_transceiver_mode(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
-uint8_t TCMDEXEC_mpi_enable_active_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, 
+uint8_t TCMDEXEC_mpi_enable_active_mode(const char *args_str, 
     char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_mpi_disable_active_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, 
+uint8_t TCMDEXEC_mpi_disable_active_mode(const char *args_str, 
     char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif /* INCLUDE_GUARD__MPI_TELECOMMAND_DEFINITIONS_H__ */

--- a/firmware/Core/Inc/telecommands/obc_systems_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/obc_systems_telecommand_defs.h
@@ -5,17 +5,17 @@
 
 
 uint8_t TCMDEXEC_obc_read_temperature_complex(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_obc_read_temperature(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_obc_adc_read_vbat_voltage(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 

--- a/firmware/Core/Inc/telecommands/stm32_internal_flash_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/stm32_internal_flash_telecommand_defs.h
@@ -3,21 +3,21 @@
 
 #include "telecommand_exec/telecommand_types.h"
 
-uint8_t TCMDEXEC_stm32_internal_flash_write(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_stm32_internal_flash_write(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_stm32_internal_flash_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_stm32_internal_flash_read(const char *args_str,
                                            char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_stm32_internal_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_stm32_internal_flash_erase(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_stm32_internal_flash_get_option_bytes(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_stm32_internal_flash_get_option_bytes(const char *args_str,
                                                        char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_stm32_internal_flash_set_active_flash_bank(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_stm32_internal_flash_set_active_flash_bank(const char *args_str,
                                                        char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_stm32_internal_flash_get_active_flash_bank(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_stm32_internal_flash_get_active_flash_bank(const char *args_str,
                                                        char *response_output_buf, uint16_t response_output_buf_len);                                                       
 #endif /* INCLUDE_GUARD_STM32_INTERNAL_FLASH_TELECOMMAND_DEFS_H */

--- a/firmware/Core/Inc/telecommands/system_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/system_telecommand_defs.h
@@ -4,28 +4,28 @@
 #include <stdint.h>
 #include "telecommand_exec/telecommand_types.h"
 
-uint8_t TCMDEXEC_hello_world(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_hello_world(const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_core_system_stats(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_core_system_stats(const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_available_telecommands(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_available_telecommands(const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_reboot(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_reboot(const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len);
 
 uint8_t TCMDEXEC_system_self_check_failures_as_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 uint8_t TCMDEXEC_system_self_check_as_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 uint8_t TCMDEXEC_obc_get_rbf_state(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 

--- a/firmware/Core/Inc/telecommands/telecommand_adcs.h
+++ b/firmware/Core/Inc/telecommands/telecommand_adcs.h
@@ -9,232 +9,232 @@
 #define ABORT_CMD_FOR_FAILED_EXTRACT(x) uint8_t result = x; if (!(result)) { return result; }
 #define CHECK_ADCS_COMMAND_SUCCESS(x) if ((x)) { return x; }
 
-uint8_t TCMDEXEC_adcs_reset(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_reset(const char *args_str,
                             char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_identification(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_identification(const char *args_str,
                                      char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_program_status(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_program_status(const char *args_str,
                                      char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_communication_status(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_communication_status(const char *args_str,
                                            char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_deploy_magnetometer(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_deploy_magnetometer(const char *args_str,
                                           char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_set_run_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_run_mode(const char *args_str,
                                    char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_clear_errors(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_clear_errors(const char *args_str,
                                    char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_attitude_control_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_attitude_control_mode(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_attitude_estimation_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_attitude_estimation_mode(const char *args_str,
                                                char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_ack(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_ack(const char *args_str,
                              char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_run_once(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_run_once(const char *args_str,
                                char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_set_magnetometer_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_magnetometer_mode(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_set_magnetorquer_output(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_magnetorquer_output(const char *args_str,
                                               char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_set_wheel_speed(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_wheel_speed(const char *args_str,
                                       char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_save_config(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_save_config(const char *args_str,
                                   char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_estimate_angular_rates(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_estimate_angular_rates(const char *args_str,
                                              char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_llh_position(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_llh_position(const char *args_str,
                                        char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_power_control(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_power_control(const char *args_str,
                                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_set_power_control(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_power_control(const char *args_str,
                                         char *response_output_buf, uint16_t response_output_buf_len);
       
-uint8_t TCMDEXEC_adcs_enter_low_power_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_enter_low_power_mode(const char *args_str,
                                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_track_sun(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_track_sun(const char *args_str,
                                               char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_set_magnetometer_config(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_magnetometer_config(const char *args_str,
                                               char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_bootloader_clear_errors(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_bootloader_clear_errors(const char *args_str,
                                               char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_set_unix_time_save_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_unix_time_save_mode(const char *args_str,
                                               char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_unix_time_save_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_unix_time_save_mode(const char *args_str,
                                               char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_set_sgp4_orbit_params(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_sgp4_orbit_params(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_sgp4_orbit_params(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_sgp4_orbit_params(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_save_orbit_params(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_save_orbit_params(const char *args_str,
                                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_rate_sensor_rates(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_rate_sensor_rates(const char *args_str,
                                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_wheel_speed(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_wheel_speed(const char *args_str,
                                       char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_magnetorquer_command(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_magnetorquer_command(const char *args_str,
                                                char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_raw_magnetometer_values(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_raw_magnetometer_values(const char *args_str,
                                                   char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_fine_angular_rates(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_fine_angular_rates(const char *args_str,
                                          char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_estimate_fine_angular_rates(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_estimate_fine_angular_rates(const char *args_str,
                                                   char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_magnetometer_config(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_magnetometer_config(const char *args_str,
                                               char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_commanded_attitude_angles(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_commanded_attitude_angles(const char *args_str,
                                                     char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_set_commanded_attitude_angles(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_commanded_attitude_angles(const char *args_str,
                                                     char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_set_estimation_params(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_estimation_params(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_estimation_params(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_estimation_params(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_set_augmented_sgp4_params(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_augmented_sgp4_params(const char *args_str,
                                        char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_augmented_sgp4_params(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_augmented_sgp4_params(const char *args_str,
                                        char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_set_tracking_controller_target_reference(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_tracking_controller_target_reference(const char *args_str,
                                                                 char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_tracking_controller_target_reference(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_tracking_controller_target_reference(const char *args_str,
                                                                 char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_set_rate_gyro_config(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_rate_gyro_config(const char *args_str,
                                            char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_rate_gyro_config(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_rate_gyro_config(const char *args_str,
                                            char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_estimated_attitude_angles(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_estimated_attitude_angles(const char *args_str,
                                                 char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_magnetic_field_vector(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_magnetic_field_vector(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_fine_sun_vector(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_fine_sun_vector(const char *args_str,
                                       char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_nadir_vector(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_nadir_vector(const char *args_str,
                                    char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_commanded_wheel_speed(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_commanded_wheel_speed(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_igrf_magnetic_field_vector(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_igrf_magnetic_field_vector(const char *args_str,
                                                  char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_quaternion_error_vector(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_quaternion_error_vector(const char *args_str,
                                               char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_estimated_gyro_bias(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_estimated_gyro_bias(const char *args_str,
                                           char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_estimation_innovation_vector(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_estimation_innovation_vector(const char *args_str,
                                                    char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_raw_cam1_sensor(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_raw_cam1_sensor(const char *args_str,
                                       char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_raw_cam2_sensor(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_raw_cam2_sensor(const char *args_str,
                                       char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_raw_coarse_sun_sensor_1_to_6(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_raw_coarse_sun_sensor_1_to_6(const char *args_str,
                                      char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_raw_coarse_sun_sensor_7_to_10(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_raw_coarse_sun_sensor_7_to_10(const char *args_str,
                                       char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_cubecontrol_current(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_cubecontrol_current(const char *args_str,
                                           char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_measurements(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_measurements(const char *args_str,
                                    char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_generic_command(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_generic_command(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_generic_telemetry_request(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_generic_telemetry_request(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_download_sd_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_download_sd_file(const char *args_str,
             char *response_output_buf, uint16_t response_output_buf_len);
             
-uint8_t TCMDEXEC_adcs_acp_execution_state(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_acp_execution_state(const char *args_str,
                                    char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_current_state_1(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_current_state_1(const char *args_str,
                                    char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_save_image_to_sd(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_save_image_to_sd(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_request_commissioning_telemetry(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_request_commissioning_telemetry(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_synchronize_unix_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_synchronize_unix_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_current_unix_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_current_unix_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_set_sd_log_config(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_sd_log_config(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_get_sd_log_config(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_sd_log_config(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_format_sd(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_format_sd(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_download_index_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_download_index_file(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
                          
-uint8_t TCMDEXEC_adcs_set_commissioning_modes(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_commissioning_modes(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_erase_sd_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_erase_sd_file(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_adcs_exit_bootloader(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_exit_bootloader(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif // INCLUDE_GUARD__TELECOMMAND_adcs_H

--- a/firmware/Core/Inc/telecommands/testing_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/testing_telecommand_defs.h
@@ -5,17 +5,17 @@
 #include "telecommand_exec/telecommand_types.h"
 #include <stdint.h>
 
-uint8_t TCMDEXEC_echo_back_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_echo_back_args(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_echo_back_uint32_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_echo_back_uint32_args(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_run_all_unit_tests(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_run_all_unit_tests(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 uint8_t TCMDEXEC_demo_blocking_delay(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 

--- a/firmware/Core/Inc/telecommands/timekeeping_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/timekeeping_telecommand_defs.h
@@ -5,19 +5,19 @@
 #include <stdint.h>
 #include "telecommand_exec/telecommand_definitions.h"
 
-uint8_t TCMDEXEC_get_system_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_get_system_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_set_system_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_set_system_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_correct_system_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_correct_system_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_set_eps_time_based_on_obc_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_set_eps_time_based_on_obc_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_set_obc_time_based_on_eps_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_set_obc_time_based_on_eps_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif /* INCLUDE_GUARD__FLASH_TELECOMMAND_DEFS_H__ */

--- a/firmware/Core/Inc/telecommands/uart_error_tracking_telecommands.h
+++ b/firmware/Core/Inc/telecommands/uart_error_tracking_telecommands.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include "telecommand_exec/telecommand_definitions.h"
 
-uint8_t TCMDEXEC_uart_get_errors_json(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_uart_get_errors_json(const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 

--- a/firmware/Core/Inc/telecommands/uart_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/uart_telecommand_defs.h
@@ -4,20 +4,18 @@
 #include "telecommand_exec/telecommand_definitions.h"
 
 uint8_t TCMDEXEC_uart_send_hex_get_response_hex(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_uart_get_last_rx_times_json(
     const char *args_str,
-    TCMD_TelecommandChannel_enum_t tcmd_channel,
     char *response_output_buf,
     uint16_t response_output_buf_len
 );
 
 uint8_t TCMDEXEC_uart_set_baud_rate(
     const char *args_str,
-    TCMD_TelecommandChannel_enum_t tcmd_channel,
     char *response_output_buf,
     uint16_t response_output_buf_len
 );

--- a/firmware/Core/Src/rtos_tasks/rtos_tasks_rx_telecommands.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_tasks_rx_telecommands.c
@@ -129,7 +129,7 @@ static TCMD_check_result_enum_t check_for_and_handle_new_uart_tcmds() {
     // Parse the telecommand
     TCMD_parsed_tcmd_to_execute_t parsed_tcmd;
     uint8_t parse_result = TCMD_parse_full_telecommand(
-        latest_tcmd, TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd
+        latest_tcmd, &parsed_tcmd
     );
     if (parse_result != 0) {
         LOG_message(
@@ -266,7 +266,7 @@ static TCMD_check_result_enum_t check_for_and_handle_new_ax100_kiss_tcmd(
     // Parse the telecommand
     TCMD_parsed_tcmd_to_execute_t parsed_tcmd;
     uint8_t parse_result = TCMD_parse_full_telecommand(
-        latest_tcmd, TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd
+        latest_tcmd, &parsed_tcmd
     );
     if (parse_result != 0) {
         LOG_message(

--- a/firmware/Core/Src/telecommand_exec/telecommand_executor.c
+++ b/firmware/Core/Src/telecommand_exec/telecommand_executor.c
@@ -33,18 +33,6 @@ TCMD_parsed_tcmd_to_execute_t TCMD_agenda[TCMD_AGENDA_SIZE];
 ///         (i.e., filled with a not-yet-executed command).
 uint8_t TCMD_agenda_is_valid[TCMD_AGENDA_SIZE] = {0};
 
-/// @brief Converts a TCMD_TelecommandChannel_enum_t to a string representation.
-/// @param channel Input TCMD_TelecommandChannel_enum_t
-/// @return A pointer to a C-string representing the TCMD_TelecommandChannel_enum_t.
-const char* telecommand_channel_enum_to_str(TCMD_TelecommandChannel_enum_t channel) {
-    switch (channel) {
-        case TCMD_TelecommandChannel_DEBUG_UART     :return "DEBUG_UART";
-        case TCMD_TelecommandChannel_RADIO1         :return "RADIO1";
-        default                                     :return "UNKNOWN_CHANNEL";
-    }
-}
-
-
 
 /// @brief Adds a telecommand to the agenda (schedule/queue) of telecommands to execute.
 /// @param parsed_tcmd The parsed telecommand to add to the agenda.
@@ -84,7 +72,6 @@ uint8_t TCMD_add_tcmd_to_agenda(const TCMD_parsed_tcmd_to_execute_t *parsed_tcmd
 
         // Copy the parsed telecommand into the agenda.
         TCMD_agenda[slot_num].tcmd_idx = parsed_tcmd->tcmd_idx;
-        TCMD_agenda[slot_num].tcmd_channel = parsed_tcmd->tcmd_channel;
         TCMD_agenda[slot_num].timestamp_sent = parsed_tcmd->timestamp_sent;
         TCMD_agenda[slot_num].timestamp_to_execute = parsed_tcmd->timestamp_to_execute;
 
@@ -293,7 +280,6 @@ static uint8_t TCMD_execute_parsed_telecommand_now(
     const uint16_t tcmd_idx,
     const char args_str_no_parens[],
     const uint64_t timestamp_sent,
-    TCMD_TelecommandChannel_enum_t tcmd_channel,
     const char * tcmd_resp_fname,
     char *response_output_buf, uint16_t response_output_buf_size
 ) {
@@ -319,7 +305,6 @@ static uint8_t TCMD_execute_parsed_telecommand_now(
     const uint32_t uptime_before_tcmd_exec_ms = HAL_GetTick();
     const uint8_t tcmd_result = tcmd_def.tcmd_func(
         args_str_no_parens,
-        tcmd_channel,
         response_output_buf,
         response_output_buf_size);
     const uint32_t uptime_after_tcmd_exec_ms = HAL_GetTick();
@@ -411,7 +396,6 @@ uint8_t TCMD_execute_telecommand_in_agenda(const uint16_t tcmd_agenda_slot_num,
         TCMD_agenda[tcmd_agenda_slot_num].tcmd_idx,
         TCMD_agenda[tcmd_agenda_slot_num].args_str_no_parens,
         TCMD_agenda[tcmd_agenda_slot_num].timestamp_sent,
-        TCMD_agenda[tcmd_agenda_slot_num].tcmd_channel,
         TCMD_agenda[tcmd_agenda_slot_num].resp_fname,
         response_output_buf,
         response_output_buf_size
@@ -515,9 +499,8 @@ uint8_t TCMD_agenda_fetch() {
 
             LOG_message(
                 LOG_SYSTEM_TELECOMMAND, LOG_SEVERITY_NORMAL, LOG_SINK_ALL, 
-                "{\"slot_num\":\"%u\",\"telecommand_channel\":\"%s\",\"timestamp_sent\":%s,\"timestamp_to_execute\":%s}\n",
+                "{\"slot_num\":\"%u\",\"timestamp_sent\":%s,\"timestamp_to_execute\":%s}\n",
                 slot_num,
-                telecommand_channel_enum_to_str(TCMD_agenda[slot_num].tcmd_channel),
                 tssent_str,
                 tsexec_str
             );

--- a/firmware/Core/Src/telecommand_exec/telecommand_parser.c
+++ b/firmware/Core/Src/telecommand_exec/telecommand_parser.c
@@ -284,7 +284,7 @@ uint8_t TCMD_get_suffix_tag_str(const char *str, const char *tag_name, char *val
 ///     Not modified if an error occurs.
 /// @return 0 on success, >0 on error.
 uint8_t TCMD_parse_full_telecommand(
-    const char tcmd_str[], TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char tcmd_str[],
     TCMD_parsed_tcmd_to_execute_t *parsed_tcmd_output
 ) {
     size_t tcmd_str_len = strlen(tcmd_str);
@@ -468,7 +468,6 @@ uint8_t TCMD_parse_full_telecommand(
     memcpy(parsed_tcmd_output->args_str_no_parens, args_str_no_parens, arg_len + 1);
     parsed_tcmd_output->timestamp_sent = timestamp_sent;
     parsed_tcmd_output->timestamp_to_execute = timestamp_to_execute;
-    parsed_tcmd_output->tcmd_channel = tcmd_channel;
     memcpy(parsed_tcmd_output->resp_fname, tcmd_suffix_resp_fname, TCMD_MAX_RESP_FNAME_LEN);
 
     return 0;

--- a/firmware/Core/Src/telecommands/agenda_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/agenda_telecommand_defs.c
@@ -11,12 +11,11 @@
 
 /// @brief Telecommand: Delete all agendas
 /// @param args_str No arguments needed
-/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0 on success
 uint8_t TCMDEXEC_agenda_delete_all(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     snprintf(response_output_buf, response_output_buf_len, "Cleared agenda.");
@@ -28,11 +27,10 @@ uint8_t TCMDEXEC_agenda_delete_all(
 /// @brief Telecommand: Delete agenda entry by tssent timestamp
 /// @param args_str
 /// - Arg 0: Timestamp sent (uint64_t) - The tssent timestamp of the agenda entry to delete.
-/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_agenda_delete_by_tssent(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_agenda_delete_by_tssent(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     
     uint64_t tssent = 0;
@@ -71,11 +69,10 @@ uint8_t TCMDEXEC_agenda_delete_by_tssent(const char *args_str, TCMD_TelecommandC
 
 /// @brief Telecommand: Fetch all pending agenda items, and log them each as JSONL
 /// @param args_str No arguments needed
-/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0 on success, 1 if there are no active agendas.
-uint8_t TCMDEXEC_agenda_fetch_jsonl(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_agenda_fetch_jsonl(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
      
     const uint8_t result = TCMD_agenda_fetch();
@@ -86,11 +83,10 @@ uint8_t TCMDEXEC_agenda_fetch_jsonl(const char *args_str, TCMD_TelecommandChanne
 /// @brief Telecommand: Delete all agenda entries with a telecommand name
 /// @param args_str
 /// - Arg 0: telecommand name (string) - The name of the telecommand function in the agenda to delete. (e.g, hello_world)
-/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0 on success, > 0 on error
-uint8_t TCMDEXEC_agenda_delete_by_name(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_agenda_delete_by_name(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     
     const uint8_t result = TCMD_agenda_delete_by_name(args_str);

--- a/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/antenna_telecommand_defs.c
@@ -15,7 +15,7 @@
 /// @param args_str
 /// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// @return 0 on success, > 0 otherwise
-uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_reset(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) 
 {
     char i2c_bus_str [2];
@@ -52,7 +52,7 @@ uint8_t TCMDEXEC_ant_reset(const char *args_str, TCMD_TelecommandChannel_enum_t 
 /// @param args_str 
 /// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
@@ -89,7 +89,7 @@ uint8_t TCMDEXEC_ant_arm_antenna_system(const char *args_str, TCMD_TelecommandCh
 /// @param args_str 
 /// - Arg 0: specifies which mcu on the antenna deployment system to disarm, and which i2c bus to use 
 /// @return 0 on success, 0 > otherwise
-uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
@@ -128,7 +128,7 @@ uint8_t TCMDEXEC_ant_disarm_antenna_system(const char *args_str, TCMD_Telecomman
 /// - Arg 1: antenna number. between 1-4
 /// - Arg 2: Activation time in seconds
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
@@ -203,7 +203,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna(const char *args_str, TCMD_TelecommandChanne
 /// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// - Arg 1: Activation time in seconds
 /// @return returns 0 on success, > 0 otherwise
-uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) 
 {
     char i2c_bus_str [2];
@@ -253,7 +253,7 @@ uint8_t TCMDEXEC_ant_start_automated_antenna_deployment(const char *args_str, TC
 /// - Arg 1: antenna number. between 1-4
 /// - Arg 2: Activation time in seconds
 /// @return 0 on successful communication, >0 on communications error 
-uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
@@ -328,7 +328,7 @@ uint8_t TCMDEXEC_ant_deploy_antenna_with_override(const char *args_str, TCMD_Tel
 /// @param args_str 
 /// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// @return 0 on successful communication, > 0 on communications error
-uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
@@ -366,7 +366,7 @@ uint8_t TCMDEXEC_ant_cancel_deployment_system_activation(const char *args_str, T
 /// @param args_str 
 /// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// @return 0 on successful communication, > 0 on communications error
-uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
@@ -448,7 +448,7 @@ uint8_t TCMDEXEC_ant_report_deployment_status(const char *args_str, TCMD_Telecom
 /// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// - Arg 1: the antenna to check, between 1-4 
 /// @return 0 on successful communication, > 0 on communications error
-uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
@@ -512,7 +512,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_count(const char *args
 /// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// - Arg 1: the antenna to check, between 1-4 
 /// @return 0 on successful communication, > 0 on communications error
-uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {
@@ -574,7 +574,7 @@ uint8_t TCMDEXEC_ant_report_antenna_deployment_activation_time(const char *args_
 /// @param args_str
 /// - Arg 0: specifies which mcu on the antenna deployment system to transmit to, and which i2c bus to use. Pass either "A" or "B"
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_ant_measure_temp(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_ant_measure_temp(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char i2c_bus_str [2];
     if(TCMD_extract_string_arg(args_str, 0, i2c_bus_str, 2) != 0 ) {

--- a/firmware/Core/Src/telecommands/boom_deploy_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/boom_deploy_telecommand_defs.c
@@ -28,7 +28,7 @@
 /// @note If you need longer than the max duration, you can of course call this function
 /// multiple times back-to-back, relying on the heat capacity of the resistors to stay hot.
 uint8_t TCMDEXEC_boom_deploy_timed(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     uint64_t channel_u64;
@@ -168,7 +168,7 @@ static void boom_self_check_cleanup() {
 /// @return 0 on success, >0 on error.
 /// @note If this function glitches (which it shouldn't/doesn't), it has the potential to deploy the boom.
 uint8_t TCMDEXEC_boom_self_check(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     const uint16_t boom_on_duration_ms = 1000;

--- a/firmware/Core/Src/telecommands/camera_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/camera_telecommand_defs.c
@@ -15,7 +15,7 @@
 /// @param response_output_buf_len Max length of the buffer
 /// @return 0 if successful, >0 if an error occurred
 uint8_t TCMDEXEC_camera_setup(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     const uint8_t setup_status = CAM_setup();
@@ -40,7 +40,7 @@ uint8_t TCMDEXEC_camera_setup(
 /// @param response_output_buf_len Max length of the buffer
 /// @return 0 if successful, >0 if an error occurred
 uint8_t TCMDEXEC_camera_test(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len)
 {
     uint8_t test_return = CAM_test();
@@ -64,7 +64,7 @@ uint8_t TCMDEXEC_camera_test(
 /// - Arg 1: Baudrate to change to (bits per second). 10 options from 1200 to 921600.
 /// @return 0 if successful, >0 if an error occurred
 uint8_t TCMDEXEC_camera_change_baud_rate(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len)
 {
     const uint32_t new_baud_rate = atoi(args_str);
@@ -96,7 +96,7 @@ uint8_t TCMDEXEC_camera_change_baud_rate(
 /// @param response_output_buf Buffer to write the response to
 /// @param response_output_buf_len Max length of the buffer
 /// @return 0 if successful, >0 if an error occurred
-uint8_t TCMDEXEC_camera_capture(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_camera_capture(const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len)
 {
     // Extract arg 0 - filename

--- a/firmware/Core/Src/telecommands/comms_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/comms_telecommand_defs.c
@@ -13,7 +13,7 @@
 /// - Arg 0: Enum: "toggle_before_beacon" (default), "ant1", "ant2", "adcs", "adcs_flipped". Case-insensitive.
 /// @return 0 on success, 1 on error.
 uint8_t TCMDEXEC_comms_set_rf_switch_control_mode(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     // Parse the arguments.
@@ -63,7 +63,7 @@ uint8_t TCMDEXEC_comms_set_rf_switch_control_mode(
 /// @param args_str No args.
 /// @return 
 uint8_t TCMDEXEC_comms_get_rf_switch_info(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     const uint8_t adcs_antenna_num = COMMS_find_optimal_antenna_using_adcs();
@@ -98,7 +98,7 @@ uint8_t TCMDEXEC_comms_get_rf_switch_info(
 /// @note This function is safe to call at any point (including mid-downlink, or mid-pause).
 ///       It will close the previous file and start a new downlink.
 uint8_t TCMDEXEC_comms_bulk_file_downlink_start(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     const uint8_t args_str_len = strlen(args_str);
@@ -180,7 +180,7 @@ uint8_t TCMDEXEC_comms_bulk_file_downlink_start(
 /// @brief Telecommand: Pause bulk file downlink
 /// @param args_str (unused)
 uint8_t TCMDEXEC_comms_bulk_file_downlink_pause(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     const uint8_t result = COMMS_bulk_file_downlink_pause();
@@ -202,7 +202,7 @@ uint8_t TCMDEXEC_comms_bulk_file_downlink_pause(
 
 
 uint8_t TCMDEXEC_comms_bulk_file_downlink_resume(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     const uint8_t result = COMMS_bulk_file_downlink_resume();

--- a/firmware/Core/Src/telecommands/config_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/config_telecommand_defs.c
@@ -15,7 +15,7 @@
 /// @param response_output_buf Buffer to write the response to
 /// @param response_output_buf_len Max length of the buffer
 /// @return 0 if successful, >0 if an error occurred
-uint8_t TCMDEXEC_config_set_int_var(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_config_set_int_var(const char *args_str,
                                          char *response_output_buf, uint16_t response_output_buf_len)
 {
     const int args_str_len = strlen(args_str);
@@ -52,7 +52,7 @@ uint8_t TCMDEXEC_config_set_int_var(const char *args_str, TCMD_TelecommandChanne
 /// - Arg 0: variable name
 /// - Arg 1: new value
 /// @return 0 if successful, >0 if an error occurred
-uint8_t TCMDEXEC_config_set_str_var(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_config_set_str_var(const char *args_str,
                                          char *response_output_buf, uint16_t response_output_buf_len)
 
 {
@@ -91,7 +91,7 @@ uint8_t TCMDEXEC_config_set_str_var(const char *args_str, TCMD_TelecommandChanne
 /// @param args_str
 /// - Arg 0: variable name
 /// @return 0 if successful, >0 if an error occurred
-uint8_t TCMDEXEC_config_get_int_var_json(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_config_get_int_var_json(const char *args_str,
                                                     char *response_output_buf, uint16_t response_output_buf_len)
 {
     const uint16_t res = CONFIG_int_var_to_json(args_str, response_output_buf, response_output_buf_len);
@@ -109,7 +109,7 @@ uint8_t TCMDEXEC_config_get_int_var_json(const char *args_str, TCMD_TelecommandC
 /// - Arg 0: variable name
 /// @return 0 if successful, >0 if an error occurred
 uint8_t TCMDEXEC_config_get_str_var_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     const uint16_t res = CONFIG_str_var_to_json(args_str, response_output_buf, response_output_buf_len);
@@ -126,7 +126,7 @@ uint8_t TCMDEXEC_config_get_str_var_json(
 /// @param args_str No arguments.
 /// @return 0 if successful, >0 if an error occurred
 uint8_t TCMDEXEC_config_get_all_vars_jsonl(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     char json_str[CONFIG_MAX_JSON_STRING_LENGTH];

--- a/firmware/Core/Src/telecommands/eps_telecommands.c
+++ b/firmware/Core/Src/telecommands/eps_telecommands.c
@@ -16,7 +16,7 @@
 /// @param args_str No arguments.
 /// @return 0 on success, 1 on failure.
 uint8_t TCMDEXEC_eps_watchdog(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     const uint8_t result = EPS_CMD_watchdog();
@@ -36,7 +36,7 @@ uint8_t TCMDEXEC_eps_watchdog(
 /// @param args_str No arguments.
 /// @return 0 on success, 1 on failure.
 uint8_t TCMDEXEC_eps_system_reset(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     const uint8_t result = EPS_CMD_system_reset();
@@ -56,7 +56,7 @@ uint8_t TCMDEXEC_eps_system_reset(
 /// @param args_str No arguments.
 /// @return 0 on success, 1 on failure.
 uint8_t TCMDEXEC_eps_no_operation(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) { 
     const uint8_t result = EPS_CMD_no_operation();
@@ -78,7 +78,7 @@ uint8_t TCMDEXEC_eps_no_operation(
 /// @note This command likely isn't useful, as telecommands cannot be trigger simultaneously, and
 ///     thus another command to the EPS cannot really be cancelled from here.
 uint8_t TCMDEXEC_eps_cancel_operation(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     const uint8_t result = EPS_CMD_cancel_operation();
@@ -100,7 +100,7 @@ uint8_t TCMDEXEC_eps_cancel_operation(
 /// @return 0 on success, 1 on failure.
 /// @note See EPS Software ICD, Page 12, Section 3 (Functional Description) for state/mode definitions.
 uint8_t TCMDEXEC_eps_switch_to_mode(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     uint8_t result = 42;
@@ -143,7 +143,7 @@ uint8_t TCMDEXEC_eps_switch_to_mode(
 /// Valid string values: "vbatt_stack", "stack_5v", "stack_3v3", "camera", "uhf_antenna_deploy",
 /// "gnss", "mpi_5v", "mpi_12v", "boom".
 uint8_t TCMDEXEC_eps_set_channel_enabled(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     // Extract Arg 0: The channel name/number.
@@ -234,7 +234,7 @@ uint8_t TCMDEXEC_eps_set_channel_enabled(
 /// @brief Get the EPS system status, and display it as a JSON string.
 /// @return 0 on success, >0 on failure.
 uint8_t TCMDEXEC_eps_get_system_status_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     
@@ -263,7 +263,7 @@ uint8_t TCMDEXEC_eps_get_system_status_json(
 /// @brief Get the EPS PDU (Power Distribution Unit) overcurrent fault status, and display it as a JSON string.
 /// @return 0 on success, >0 on failure.
 uint8_t TCMDEXEC_eps_get_pdu_overcurrent_fault_state_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     
@@ -291,7 +291,7 @@ uint8_t TCMDEXEC_eps_get_pdu_overcurrent_fault_state_json(
 /// @brief Get the EPS PBU (Power Battery Unit) ABF placed status, and display it as a JSON string.
 /// @return 0 on success, >0 on failure.
 uint8_t TCMDEXEC_eps_get_pbu_abf_placed_state_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     
@@ -321,7 +321,7 @@ uint8_t TCMDEXEC_eps_get_pbu_abf_placed_state_json(
 /// @brief Get the EPS PDU (Power Distribution Unit) housekeeping data, and display it as a JSON string.
 /// @return 0 on success, >0 on failure.
 uint8_t TCMDEXEC_eps_get_pdu_housekeeping_data_eng_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     
@@ -355,7 +355,7 @@ uint8_t TCMDEXEC_eps_get_pdu_housekeeping_data_eng_json(
 /// Valid string values: "vbatt_stack", "stack_5v", "stack_3v3", "camera", "uhf_antenna_deploy",
 /// "gnss", "mpi_5v", "mpi_12v", "boom".
 uint8_t TCMDEXEC_eps_get_pdu_data_for_channel_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     // Extract Arg 0: The channel name/number.
@@ -407,7 +407,7 @@ uint8_t TCMDEXEC_eps_get_pdu_data_for_channel_json(
 /// @brief Get the EPS PDU (Power Distribution Unit) housekeeping data (running average), and display it as a JSON string.
 /// @return 0 on success, >0 on failure.
 uint8_t TCMDEXEC_eps_get_pdu_housekeeping_data_run_avg_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     
@@ -436,7 +436,7 @@ uint8_t TCMDEXEC_eps_get_pdu_housekeeping_data_run_avg_json(
 /// @brief Get the EPS PBU (Power Battery Unit) housekeeping data, and display it as a JSON string.
 /// @return 0 on success, >0 on failure.
 uint8_t TCMDEXEC_eps_get_pbu_housekeeping_data_eng_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     
@@ -465,7 +465,7 @@ uint8_t TCMDEXEC_eps_get_pbu_housekeeping_data_eng_json(
 /// @brief Get the EPS PBU (Power Battery Unit) housekeeping data (running average), and display it as a JSON string.
 /// @return 0 on success, >0 on failure.
 uint8_t TCMDEXEC_eps_get_pbu_housekeeping_data_run_avg_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     
@@ -494,7 +494,7 @@ uint8_t TCMDEXEC_eps_get_pbu_housekeeping_data_run_avg_json(
 /// @brief Get the EPS PCU (Power Conditioning Unit, solar panel MPPT) housekeeping data, and display it as a JSON string.
 /// @return 0 on success, >0 on failure.
 uint8_t TCMDEXEC_eps_get_pcu_housekeeping_data_eng_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     
@@ -523,7 +523,7 @@ uint8_t TCMDEXEC_eps_get_pcu_housekeeping_data_eng_json(
 /// @brief Get the EPS PCU (Power Conditioning Unit, solar panel MPPT) housekeeping data (running average), and display it as a JSON string.
 /// @return 0 on success, >0 on failure.
 uint8_t TCMDEXEC_eps_get_pcu_housekeeping_data_run_avg_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     
@@ -551,7 +551,7 @@ uint8_t TCMDEXEC_eps_get_pcu_housekeeping_data_run_avg_json(
 /// @brief Gets the EPS PIU (Power Integrated Unit, info about all systems) housekeeping data, and returns it as a JSON string.
 /// @return 0 on success, >0 on failure.
 uint8_t TCMDEXEC_eps_get_piu_housekeeping_data_eng_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     
@@ -580,7 +580,7 @@ uint8_t TCMDEXEC_eps_get_piu_housekeeping_data_eng_json(
 /// @brief Get the EPS PIU (Power Integrated Unit, info about all systems) housekeeping data (running average), and display it as a JSON string.
 /// @return 0 on success, >0 on failure.
 uint8_t TCMDEXEC_eps_get_piu_housekeeping_data_run_avg_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     
@@ -606,7 +606,7 @@ uint8_t TCMDEXEC_eps_get_piu_housekeeping_data_run_avg_json(
 
 /// @brief Get current battery voltage percent from PBU
 uint8_t TCMDEXEC_eps_get_current_battery_percent(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len) {
 
     EPS_struct_pbu_housekeeping_data_eng_t data;
@@ -628,7 +628,7 @@ uint8_t TCMDEXEC_eps_get_current_battery_percent(
 }
 
 uint8_t TCMDEXEC_eps_get_enabled_channels_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len) {
 
     EPS_struct_pdu_housekeeping_data_eng_t status;
@@ -655,7 +655,7 @@ uint8_t TCMDEXEC_eps_get_enabled_channels_json(
 /// @note Valid string values (Arg 0): "vbatt_stack", "stack_5v", "stack_3v3", "camera",
 /// "uhf_antenna_deploy", "gnss", "mpi_5v", "mpi_12v", "boom".
 uint8_t TCMDEXEC_eps_power_management_set_current_threshold(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     // Extract Arg 0: The channel name/number.

--- a/firmware/Core/Src/telecommands/flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/flash_telecommand_defs.c
@@ -17,7 +17,7 @@ uint8_t bytes_to_write[FLASH_MAX_BYTES_PER_PAGE];
 /// @brief Telecommand: Read bytes as hex from a flash address
 /// @param args_str No args.
 /// @return 0 always
-uint8_t TCMDEXEC_flash_activate_each_cs(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_activate_each_cs(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     const uint16_t delay_time_ms = 500;
 
@@ -47,7 +47,7 @@ uint8_t TCMDEXEC_flash_activate_each_cs(const char *args_str, TCMD_TelecommandCh
 /// @brief Telecommand: Read bytes as hex from a flash address
 /// @param args_str No args.
 /// @return 0 always
-uint8_t TCMDEXEC_flash_each_is_reachable(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_each_is_reachable(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint8_t fail_count = 0;
 
@@ -100,7 +100,7 @@ uint8_t TCMDEXEC_flash_each_is_reachable(const char *args_str, TCMD_TelecommandC
 /// - Arg 1: Page number as uint
 /// - Arg 2: Number of bytes to read as uint
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_read_hex(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t chip_num_u64, page_num_u64, num_bytes_u64;
 
@@ -179,7 +179,7 @@ uint8_t TCMDEXEC_flash_read_hex(const char *args_str, TCMD_TelecommandChannel_en
 /// - Arg 1: Page number as uint
 /// - Arg 2: Hex string of bytes to write (any case, allows space/underscore separators)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_write_hex(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint16_t num_bytes;
     uint64_t chip_num_u64, page_num_u64;
@@ -239,7 +239,7 @@ uint8_t TCMDEXEC_flash_write_hex(const char *args_str, TCMD_TelecommandChannel_e
 /// - Arg 0: Chip Number (CS number) as uint
 /// - Arg 1: Page number as uint
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_erase(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t chip_num_u64, page_num_u64;
 
@@ -297,7 +297,7 @@ uint8_t TCMDEXEC_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_
 /// - Arg 1: Test Data Address as uint
 /// - Arg 2: Test Data Length as uint
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t chip_num, test_data_address, test_data_length;
 
@@ -330,7 +330,7 @@ uint8_t TCMDEXEC_flash_benchmark_erase_write_read(const char *args_str, TCMD_Tel
 /// @param args_str 
 /// - Arg 0: Chip Number (CS number) as uint
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_flash_reset(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_reset(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t chip_num_u64;
 
@@ -374,7 +374,7 @@ uint8_t TCMDEXEC_flash_reset(const char *args_str, TCMD_TelecommandChannel_enum_
 /// @param args_str
 /// - Arg 0: Chip Number (CS number) as uint
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_flash_read_status_register(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_read_status_register(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t chip_num_u64;
 
@@ -419,7 +419,7 @@ uint8_t TCMDEXEC_flash_read_status_register(const char *args_str, TCMD_Telecomma
 /// @param args_str
 /// - Arg 0: Chip Number (CS number) as uint
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_flash_write_enable(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_flash_write_enable(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t chip_num_u64;
 

--- a/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
@@ -36,11 +36,10 @@ const char* freertos_eTaskState_to_str(eTaskState state) {
 
 /// @brief Telecommand that return metadata regarding Tasks from FreeRTOS
 /// @param args_str No arguments expected
-/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0 if successful, >0 if an error occurred (but hello_world can't return an error)
-uint8_t TCMDEXEC_freetos_list_tasks_jsonl(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_freetos_list_tasks_jsonl(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     const UBaseType_t number_of_tasks = uxTaskGetNumberOfTasks();
     uint32_t total_run_time;
@@ -82,7 +81,7 @@ uint8_t TCMDEXEC_freetos_list_tasks_jsonl(const char *args_str, TCMD_Telecommand
 /// - Arg 0: num_bytes (uint64_t) - The number of elements to allocate in the VLA. <=1_000_000.
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_freertos_demo_stack_usage(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     uint64_t num_bytes;

--- a/firmware/Core/Src/telecommands/gnss_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/gnss_telecommand_defs.c
@@ -13,12 +13,11 @@
 /// @brief Telecommand: Transmit a log command to the GNSS receiver through UART
 /// @param args_str
 /// - Arg 0: Log command to be sent to GNSS eg "log bestxyza once" (string)
-/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0 on success, > 0 error
 uint8_t TCMDEXEC_gnss_send_cmd_ascii(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     // Adding a new line character to the log command

--- a/firmware/Core/Src/telecommands/i2c_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/i2c_telecommand_defs.c
@@ -12,7 +12,7 @@ const uint32_t I2C_scan_timeout_ms = 5;
 /// - Arg 0: I2C bus to scan (1-4)
 /// @return 0 if successful, 1 if error.
 uint8_t TCMDEXEC_scan_i2c_bus_verbose(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     I2C_HandleTypeDef* hi2c;
@@ -101,7 +101,7 @@ uint8_t TCMDEXEC_scan_i2c_bus_verbose(
 /// - Arg 0: I2C bus to scan (1-4)
 /// @return 0 if successful, 1 if error.
 uint8_t TCMDEXEC_scan_i2c_bus(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     I2C_HandleTypeDef* hi2c;

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -15,7 +15,7 @@
 #include "transforms/arrays.h"
 
 uint8_t TCMDEXEC_fs_format_storage(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
         char *response_output_buf, uint16_t response_output_buf_len
 ) {
     LFS_ensure_unmounted();
@@ -30,7 +30,7 @@ uint8_t TCMDEXEC_fs_format_storage(
     return 0;
 }
 
-uint8_t TCMDEXEC_fs_mount(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_mount(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     const int8_t result = LFS_mount();
     if (result != 0) {
@@ -42,7 +42,7 @@ uint8_t TCMDEXEC_fs_mount(const char *args_str, TCMD_TelecommandChannel_enum_t t
     return 0;
 }
 
-uint8_t TCMDEXEC_fs_unmount(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_unmount(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     const int8_t result = LFS_unmount();
     if (result != 0) {
@@ -59,7 +59,7 @@ uint8_t TCMDEXEC_fs_unmount(const char *args_str, TCMD_TelecommandChannel_enum_t
 /// - Arg 0: Root Directory path as string
 /// - Arg 1: (Offset) Number of entries to skip at the beginning
 /// - Arg 2: (Count) Number entries to display
-uint8_t TCMDEXEC_fs_list_directory(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_list_directory(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
 
     char arg_root_directory_path[LFS_MAX_PATH_LENGTH];
@@ -122,7 +122,7 @@ uint8_t TCMDEXEC_fs_list_directory(const char *args_str, TCMD_TelecommandChannel
 /// - Arg 2: (Count) Number entries to display
 /// @note In the resulting JSON, the JSON value of directories is "null".
 uint8_t TCMDEXEC_fs_list_directory_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     char arg_root_directory_path[LFS_MAX_PATH_LENGTH];
@@ -182,7 +182,7 @@ uint8_t TCMDEXEC_fs_list_directory_json(
 /// @brief Telecommand: Create a directory
 /// @param args_str
 /// - Arg 0: Directory Name as string (e.g., "/dir1", "/dir1/subdir1")
-uint8_t TCMDEXEC_fs_make_directory(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_make_directory(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len
 ) {
     char arg_root_directory_path[LFS_MAX_PATH_LENGTH];
@@ -211,7 +211,7 @@ uint8_t TCMDEXEC_fs_make_directory(const char *args_str, TCMD_TelecommandChannel
 /// @param args_str
 /// - Arg 0: File path as string
 /// - Arg 1: String to write to file (up to 512 bytes)
-uint8_t TCMDEXEC_fs_write_file_str(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_write_file_str(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
 
     char arg_file_name[LFS_MAX_PATH_LENGTH];
@@ -252,7 +252,7 @@ uint8_t TCMDEXEC_fs_write_file_str(const char *args_str, TCMD_TelecommandChannel
 /// - Arg 1: Offset within the file to start writing (uint64)
 /// - Arg 2: Hex string to write to file (e.g., "DEADBEEF" or "DE AD BE EF")
 /// @note The maximum number of bytes that can be written is 105 bytes
-uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char arg_file_name[LFS_MAX_PATH_LENGTH];
     const uint8_t parse_file_name_result = TCMD_extract_string_arg(args_str, 0, arg_file_name, sizeof(arg_file_name));
@@ -312,7 +312,7 @@ uint8_t TCMDEXEC_fs_write_file_hex(const char *args_str, TCMD_TelecommandChannel
 /// @param args_str
 /// - Arg 0: File name to be deleted
 /// @note Do not add quotations around the argument, write as is.
-uint8_t TCMDEXEC_fs_delete_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_delete_file(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     char arg_file_name[LFS_MAX_PATH_LENGTH];
     const uint8_t parse_file_name_result = TCMD_extract_string_arg(args_str, 0, arg_file_name, sizeof(arg_file_name));
@@ -388,7 +388,7 @@ static uint8_t parse_arg_str_for_file_offset_length(
 /// - Arg 2: Length to read (bytes). 0 to read max.
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_fs_read_file_hex(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     char arg_file_name[LFS_MAX_PATH_LENGTH];
@@ -433,7 +433,7 @@ uint8_t TCMDEXEC_fs_read_file_hex(
 /// - Arg 2: Length to read (bytes). 0 to read max.
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_fs_read_text_file(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     char arg_file_name[LFS_MAX_PATH_LENGTH];
@@ -477,7 +477,7 @@ uint8_t TCMDEXEC_fs_read_text_file(
 /// - Arg 2: Length to read (bytes). 0 to read max.
 /// @return 0 on success, >0 on error
 uint8_t TCMDEXEC_fs_read_file_sha256_hash_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     char arg_file_name[LFS_MAX_PATH_LENGTH];
@@ -534,7 +534,7 @@ uint8_t TCMDEXEC_fs_read_file_sha256_hash_json(
 }
 
 
-uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
 
     char file_name[] = "demo_test.txt";
@@ -577,7 +577,7 @@ uint8_t TCMDEXEC_fs_demo_write_then_read(const char *args_str, TCMD_TelecommandC
 /// - Arg 1: Write chunk count
 /// @return 0 on success, 1 if error parsing args, 2 if benchmark failed
 /// @note The maximum write chunk size is 127 bytes, apparently; need to investigate why so small.
-uint8_t TCMDEXEC_fs_benchmark_write_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_fs_benchmark_write_read(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     
     uint64_t arg_write_chunk_size, arg_write_chunk_count;

--- a/firmware/Core/Src/telecommands/log_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/log_telecommand_defs.c
@@ -19,7 +19,7 @@
 ///    LOG_SINK_FILE = 2 
 ///    LOG_SINK_UMBILICAL_UART = 4
 uint8_t TCMDEXEC_log_set_sink_enabled_state(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     uint64_t sink;
@@ -68,7 +68,7 @@ uint8_t TCMDEXEC_log_set_sink_enabled_state(
 ///    LOG_SYSTEM_TELECOMMAND = 4096
 ///    LOG_SYSTEM_UNIT_TEST = 8192
 uint8_t TCMDEXEC_log_set_system_file_logging_enabled_state(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     uint64_t system;
@@ -101,7 +101,7 @@ uint8_t TCMDEXEC_log_set_system_file_logging_enabled_state(
 /// @param args_str
 /// - Arg 0: Sink enum
 uint8_t TCMDEXEC_log_report_sink_enabled_state(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     uint64_t sink;
@@ -122,7 +122,7 @@ uint8_t TCMDEXEC_log_report_sink_enabled_state(
 
 /// @brief Telecommand: Report all LOG sink enable states
 uint8_t TCMDEXEC_log_report_all_sink_enabled_states(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     // Response is logged by log system
@@ -138,7 +138,7 @@ uint8_t TCMDEXEC_log_report_all_sink_enabled_states(
 /// @param args_str
 /// - Arg 0: Subsystem enum
 uint8_t TCMDEXEC_log_report_system_file_logging_state(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     uint64_t system;
@@ -159,7 +159,7 @@ uint8_t TCMDEXEC_log_report_system_file_logging_state(
 
 /// @brief Telecommand: Report all LOG subsystem file logging states
 uint8_t TCMDEXEC_log_report_all_system_file_logging_states(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     // Response is logged by log system.
@@ -176,7 +176,7 @@ uint8_t TCMDEXEC_log_report_all_system_file_logging_states(
 /// - Arg 0: Sink enum
 /// - Arg 1: State 0: disable debug messages, 1: enable debug messages
 uint8_t TCMDEXEC_log_set_sink_debugging_messages_state(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     uint64_t sink = 0;
@@ -210,7 +210,7 @@ uint8_t TCMDEXEC_log_set_sink_debugging_messages_state(
 /// - Arg 0: Subsystem enum
 /// - Arg 1: State 0: disable debug messages, 1: enable debug messages
 uint8_t TCMDEXEC_log_set_system_debugging_messages_state(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     uint64_t system = 0;
@@ -268,7 +268,7 @@ uint8_t TCMDEXEC_log_set_system_debugging_messages_state(
 ///    LOG_SEVERITY_CRITICAL = 16
 ///
 uint8_t TCMDEXEC_log_set_system_severity_mask(
-        const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, 
+        const char *args_str, 
         char *response_output_buf, uint16_t response_output_buf_len
 ) {
     uint64_t system = 0;
@@ -302,7 +302,7 @@ uint8_t TCMDEXEC_log_set_system_severity_mask(
 /// @param args_str
 /// - Arg 0: Number of latest log messages to report
 uint8_t TCMDEXEC_log_report_n_latest_messages_from_memory(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     uint64_t requested_number_of_entries = 0;

--- a/firmware/Core/Src/telecommands/mpi_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/mpi_telecommand_defs.c
@@ -19,12 +19,11 @@
 /// @brief Send a configuration command & params (IF ANY) to the MPI encoded in hex
 /// @param args_str 
 /// - Arg 0: Hex-encoded string representing the configuration command + arguments (IF ANY) to send to the MPI, INCLUDING 'TC' (0x54 0x43)
-/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0: Success, >0 error code
 uint8_t TCMDEXEC_mpi_send_command_get_response_hex(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {    
     // Parse hex-encoded string to bytes
@@ -90,11 +89,10 @@ uint8_t TCMDEXEC_mpi_send_command_get_response_hex(
 /// @brief Enables systems to start receiving data actively from MPI and storing using LFS.
 /// @param args_str
 /// - Arg 0: File name as a string
-/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0: Success, >0: Failure
-uint8_t TCMDEXEC_mpi_enable_active_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, char *response_output_buf, uint16_t response_output_buf_len) {
+uint8_t TCMDEXEC_mpi_enable_active_mode(const char *args_str, char *response_output_buf, uint16_t response_output_buf_len) {
     // Get the file name from the telecommand argument
     char arg_file_name[LFS_MAX_PATH_LENGTH];
     const uint8_t parse_file_name_result = TCMD_extract_string_arg(args_str, 0, arg_file_name, sizeof(arg_file_name));
@@ -119,11 +117,10 @@ uint8_t TCMDEXEC_mpi_enable_active_mode(const char *args_str, TCMD_TelecommandCh
 
 /// @brief Sets the state to not send or receive data from MPI.
 /// @param args_str No args.
-/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0: Success, >0: Failure
-uint8_t TCMDEXEC_mpi_disable_active_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, char *response_output_buf, uint16_t response_output_buf_len) {
+uint8_t TCMDEXEC_mpi_disable_active_mode(const char *args_str, char *response_output_buf, uint16_t response_output_buf_len) {
     const uint8_t disable_result = MPI_disable_active_mode();
 
     if (disable_result != 0) {
@@ -139,12 +136,11 @@ uint8_t TCMDEXEC_mpi_disable_active_mode(const char *args_str, TCMD_TelecommandC
 
 /// @brief Sends a message over UART to the MPI.
 /// @param args_str No args.
-/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0: Success, >0: Failure
 uint8_t TCMDEXEC_mpi_demo_tx_to_mpi(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     // First, set transceiver state.
@@ -184,12 +180,11 @@ uint8_t TCMDEXEC_mpi_demo_tx_to_mpi(
 /// @brief Sends a message over UART to the MPI.
 /// @param args_str
 /// - Arg 0: The target mode - "MISO" (from MPI), "MOSI" (to MPI), "DUPLEX", or anything else disables it
-/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0: Success, >0: Failure
 uint8_t TCMDEXEC_mpi_demo_set_transceiver_mode(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     if (strcasecmp(args_str, "MISO") == 0) {

--- a/firmware/Core/Src/telecommands/obc_systems_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/obc_systems_telecommand_defs.c
@@ -15,7 +15,7 @@
 /// @return 0 if successful, 1 if error.
 /// @note There are better ways to get the temperature.
 uint8_t TCMDEXEC_obc_read_temperature_complex(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     int32_t temperature;
@@ -73,7 +73,7 @@ uint8_t TCMDEXEC_obc_read_temperature_complex(
 /// @return 0 if successful, >0 if error.
 /// @note Temperature range is -55 to 125 degrees celsius with +/- 3 degrees celsius accuracy over the whole range.
 uint8_t TCMDEXEC_obc_read_temperature(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     const int32_t temp_cC = OBC_TEMP_SENSOR_get_temperature_cC();
@@ -99,7 +99,7 @@ uint8_t TCMDEXEC_obc_read_temperature(
 /// @param args_str No arguments.
 /// @return 
 uint8_t TCMDEXEC_obc_adc_read_vbat_voltage(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     // Read the voltage from the ADC.

--- a/firmware/Core/Src/telecommands/stm32_internal_flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/stm32_internal_flash_telecommand_defs.c
@@ -13,7 +13,7 @@
 /// @note This telecommand is only for testing purposes, it is purposfully not fully fleshed out
 /// as there is no intention on using this. Update as needed
 //// @return 0 on success, > 0 on error
-uint8_t TCMDEXEC_stm32_internal_flash_write(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, char *response_output_buf, uint16_t response_output_buf_len)
+uint8_t TCMDEXEC_stm32_internal_flash_write(const char *args_str, char *response_output_buf, uint16_t response_output_buf_len)
 {
     uint8_t write_hex_buffer[PAGESIZE] = {0};
     uint16_t write_hex_buffer_len = 0;
@@ -47,7 +47,7 @@ uint8_t TCMDEXEC_stm32_internal_flash_write(const char *args_str, TCMD_Telecomma
 /// - Arg 0: The address to start reading from
 /// - Arg 1: The number of bytes to read as a uint64_t
 //// @return 0 on success, > 0 on error
-uint8_t TCMDEXEC_stm32_internal_flash_read(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, char *response_output_buf, uint16_t response_output_buf_len)
+uint8_t TCMDEXEC_stm32_internal_flash_read(const char *args_str, char *response_output_buf, uint16_t response_output_buf_len)
 {
 
     uint64_t address = 0;
@@ -87,7 +87,7 @@ uint8_t TCMDEXEC_stm32_internal_flash_read(const char *args_str, TCMD_Telecomman
 /// - Arg 0: The starting page to erase as a uint64_t
 /// - Arg 1: The number of pages to erase as a uint64_t
 //// @return 0 on success, > 0 on error
-uint8_t TCMDEXEC_stm32_internal_flash_erase(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, char *response_output_buf, uint16_t response_output_buf_len)
+uint8_t TCMDEXEC_stm32_internal_flash_erase(const char *args_str, char *response_output_buf, uint16_t response_output_buf_len)
 {
     uint64_t start_page_erase = 0;
 
@@ -119,7 +119,7 @@ uint8_t TCMDEXEC_stm32_internal_flash_erase(const char *args_str, TCMD_Telecomma
 /// @brief Get the option bytes configuration from the stm32 internal flash memory
 /// @param args_str No args
 /// @return 0 on success, > 0 on error
-uint8_t TCMDEXEC_stm32_internal_flash_get_option_bytes(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, char *response_output_buf, uint16_t response_output_buf_len)
+uint8_t TCMDEXEC_stm32_internal_flash_get_option_bytes(const char *args_str, char *response_output_buf, uint16_t response_output_buf_len)
 {
     FLASH_OBProgramInitTypeDef option_bytes;
     const uint8_t res = STM32_internal_flash_get_option_bytes(&option_bytes);
@@ -154,7 +154,7 @@ uint8_t TCMDEXEC_stm32_internal_flash_get_option_bytes(const char *args_str, TCM
 /// - Arg 0: A 1 or 2. 1 to switch to the application present in Flash Bank 1, 2 to switch to the application present in Flash Bank 2
 /// @param response_output_buf Prints error if it occurs
 /// @return 0 on success, > 0 otherwise
-uint8_t TCMDEXEC_stm32_internal_flash_set_active_flash_bank(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, char *response_output_buf, uint16_t response_output_buf_len)
+uint8_t TCMDEXEC_stm32_internal_flash_set_active_flash_bank(const char *args_str, char *response_output_buf, uint16_t response_output_buf_len)
 {
     uint64_t desired_active_flash_bank = 0;
     const uint8_t arg_res = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &desired_active_flash_bank);
@@ -175,7 +175,7 @@ uint8_t TCMDEXEC_stm32_internal_flash_set_active_flash_bank(const char *args_str
 
 /// @brief Prints the active flash bank where the firmware boots from
 /// @param response_output_buf Prints the active bank
-uint8_t TCMDEXEC_stm32_internal_flash_get_active_flash_bank(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, char *response_output_buf, uint16_t response_output_buf_len)
+uint8_t TCMDEXEC_stm32_internal_flash_get_active_flash_bank(const char *args_str, char *response_output_buf, uint16_t response_output_buf_len)
 {
     const uint8_t stm32_internal_active_flash_bank = STM32_internal_flash_get_active_flash_bank();
 

--- a/firmware/Core/Src/telecommands/system_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/system_telecommand_defs.c
@@ -19,12 +19,11 @@
 
 /// @brief A simple telecommand that responds with "Hello, world!" (log message and TCMD response)
 /// @param args_str No arguments expected
-/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0 if successful, >0 if an error occurred (but hello_world can't return an error)
 uint8_t TCMDEXEC_hello_world(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     LOG_message(
@@ -39,7 +38,7 @@ uint8_t TCMDEXEC_hello_world(
 }
 
 uint8_t TCMDEXEC_core_system_stats(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     // TODO: Add temperatures (EPS, OBC, antenna, etc.)
@@ -94,7 +93,7 @@ uint8_t TCMDEXEC_core_system_stats(
 }
 
 uint8_t TCMDEXEC_available_telecommands(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     char *p = response_output_buf;
@@ -128,7 +127,7 @@ uint8_t TCMDEXEC_available_telecommands(
 
 
 uint8_t TCMDEXEC_reboot(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     LFS_ensure_unmounted();
@@ -151,7 +150,7 @@ uint8_t TCMDEXEC_reboot(
 /// @return 0 regardless; see the response_output_buf for the results of the self-check.
 /// @note Output is a JSON list of the failing checks (as strings). Returns 0 regardless.
 uint8_t TCMDEXEC_system_self_check_failures_as_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     CTS1_system_self_check_result_struct_t self_check_result;
@@ -169,7 +168,7 @@ uint8_t TCMDEXEC_system_self_check_failures_as_json(
 /// @return 0 regardless; see the response_output_buf for the results of the self-check.
 /// @note Output is a JSON list of the failing checks (as strings). Returns 0 regardless.
 uint8_t TCMDEXEC_system_self_check_as_json(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     CTS1_system_self_check_result_struct_t self_check_result;
@@ -182,7 +181,7 @@ uint8_t TCMDEXEC_system_self_check_as_json(
 }
 
 uint8_t TCMDEXEC_obc_get_rbf_state(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     const OBC_rbf_state_enum_t rbf_state = OBC_get_rbf_state();

--- a/firmware/Core/Src/telecommands/telecommand_adcs.c
+++ b/firmware/Core/Src/telecommands/telecommand_adcs.c
@@ -24,7 +24,7 @@
 ///     - Arg 1: hex array of data bytes of length up to 504 (longest command is almost ADCS Configuration (ID 26/204) at 504 bytes)
 /// @note All hex bytes must be two-digit (e.g. 00 instead of 0); for zero-parameter commands, use 00
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_generic_command(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_generic_command(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     
     // parse command ID argument: first into uint64_t, then convert to correct form for input
@@ -70,7 +70,7 @@ uint8_t TCMDEXEC_adcs_generic_command(const char *args_str, TCMD_TelecommandChan
 ///     - Arg 0: ID of the telemetry request to send (see Firmware Reference Manual)
 ///     - Arg 1: number of data bytes expected to receive from the ADCS (also see Firmware Reference Manual, up to 504)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_generic_telemetry_request(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_generic_telemetry_request(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
 
     // parse telemetry request ID argument: first into uint64_t
@@ -152,7 +152,7 @@ uint8_t TCMDEXEC_adcs_generic_telemetry_request(const char *args_str, TCMD_Telec
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_ack(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_ack(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_cmd_ack_struct_t ack;
     const uint8_t status = ADCS_cmd_ack(&ack);
@@ -181,7 +181,7 @@ uint8_t TCMDEXEC_adcs_ack(const char *args_str, TCMD_TelecommandChannel_enum_t t
 ///     - Arg 1: wheel speed y value
 ///     - Arg 2: wheel speed z value
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_set_wheel_speed(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_wheel_speed(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     // parse arguments: first into int64_t, then convert to correct form for input
     const uint8_t num_args = 3;
@@ -206,7 +206,7 @@ uint8_t TCMDEXEC_adcs_set_wheel_speed(const char *args_str, TCMD_TelecommandChan
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_reset(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_reset(const char *args_str,
                             char *response_output_buf, uint16_t response_output_buf_len) {
     const uint8_t status = ADCS_reset(); 
     return status;
@@ -216,7 +216,7 @@ uint8_t TCMDEXEC_adcs_reset(const char *args_str, TCMD_TelecommandChannel_enum_t
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_identification(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_identification(const char *args_str,
                                      char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_id_struct_t packed_struct;
     const uint8_t status = ADCS_get_identification(&packed_struct); 
@@ -243,7 +243,7 @@ uint8_t TCMDEXEC_adcs_identification(const char *args_str, TCMD_TelecommandChann
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_program_status(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_program_status(const char *args_str,
                                      char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_boot_running_status_struct_t packed_struct;
     const uint8_t status = ADCS_get_program_status(&packed_struct); 
@@ -270,7 +270,7 @@ uint8_t TCMDEXEC_adcs_program_status(const char *args_str, TCMD_TelecommandChann
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_communication_status(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_communication_status(const char *args_str,
                                            char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_comms_status_struct_t packed_struct;
     const uint8_t status = ADCS_get_communication_status(&packed_struct); 
@@ -297,7 +297,7 @@ uint8_t TCMDEXEC_adcs_communication_status(const char *args_str, TCMD_Telecomman
 /// @param args_str 
 ///     - Arg 0: timeout for deployment [seconds]
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_deploy_magnetometer(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_deploy_magnetometer(const char *args_str,
                                           char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t timeout;
     uint8_t extract_status = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &timeout);
@@ -314,7 +314,7 @@ uint8_t TCMDEXEC_adcs_deploy_magnetometer(const char *args_str, TCMD_Telecommand
 /// @param args_str 
 ///     - Arg 0: run mode to set; can be can be off (0), enabled (1), triggered (2), or simulation (3)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_set_run_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_run_mode(const char *args_str,
                                    char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t run_mode;
     uint8_t extract_status = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &run_mode);
@@ -331,7 +331,7 @@ uint8_t TCMDEXEC_adcs_set_run_mode(const char *args_str, TCMD_TelecommandChannel
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_clear_errors(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_clear_errors(const char *args_str,
                                    char *response_output_buf, uint16_t response_output_buf_len) {
     const uint8_t status = ADCS_clear_errors();
     return status;
@@ -342,7 +342,7 @@ uint8_t TCMDEXEC_adcs_clear_errors(const char *args_str, TCMD_TelecommandChannel
 ///     - Arg 0: Control mode to set (Table 77 in Firmware Manual)
 ///     - Arg 1: Timeout to set control mode
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_attitude_control_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_attitude_control_mode(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len) {
     // parse arguments into uint64_t
     const uint8_t num_args = 2;
@@ -364,7 +364,7 @@ uint8_t TCMDEXEC_adcs_attitude_control_mode(const char *args_str, TCMD_Telecomma
 /// @param args_str 
 ///     - Arg 0: Attitude estimation mode to set (Table 79 in Firmware Manual)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_attitude_estimation_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_attitude_estimation_mode(const char *args_str,
                                                char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t estimation_mode;
     uint8_t extract_status = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &estimation_mode);
@@ -381,7 +381,7 @@ uint8_t TCMDEXEC_adcs_attitude_estimation_mode(const char *args_str, TCMD_Teleco
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_run_once(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_run_once(const char *args_str,
                                char *response_output_buf, uint16_t response_output_buf_len) {
     const uint8_t status = ADCS_run_once();
     return status;
@@ -391,7 +391,7 @@ uint8_t TCMDEXEC_adcs_run_once(const char *args_str, TCMD_TelecommandChannel_enu
 /// @param args_str 
 ///     - Arg 0: magnetometer mode to set
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_set_magnetometer_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_magnetometer_mode(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t mode;
     uint8_t extract_status = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &mode);
@@ -410,7 +410,7 @@ uint8_t TCMDEXEC_adcs_set_magnetometer_mode(const char *args_str, TCMD_Telecomma
 ///     - Arg 1: magnetorquer y duty cycle (double)
 ///     - Arg 2: magnetorquer z duty cycle (double)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_set_magnetorquer_output(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_magnetorquer_output(const char *args_str,
                                               char *response_output_buf, uint16_t response_output_buf_len) {
      // parse arguments into doubles
     const uint8_t num_args = 3;
@@ -432,7 +432,7 @@ uint8_t TCMDEXEC_adcs_set_magnetorquer_output(const char *args_str, TCMD_Telecom
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_save_config(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_save_config(const char *args_str,
                                   char *response_output_buf, uint16_t response_output_buf_len) {
     const uint8_t status = ADCS_save_config();
     return status;
@@ -442,7 +442,7 @@ uint8_t TCMDEXEC_adcs_save_config(const char *args_str, TCMD_TelecommandChannel_
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_estimate_angular_rates(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_estimate_angular_rates(const char *args_str,
                                              char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_angular_rates_struct_t packed_struct;
     const uint8_t status = ADCS_get_estimate_angular_rates(&packed_struct);
@@ -469,7 +469,7 @@ uint8_t TCMDEXEC_adcs_estimate_angular_rates(const char *args_str, TCMD_Telecomm
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_llh_position(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_llh_position(const char *args_str,
                                        char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_llh_position_struct_t packed_struct;
     const uint8_t status = ADCS_get_llh_position(&packed_struct);
@@ -496,7 +496,7 @@ uint8_t TCMDEXEC_adcs_get_llh_position(const char *args_str, TCMD_TelecommandCha
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_power_control(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_power_control(const char *args_str,
                                         char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_power_control_struct_t packed_struct;
     const uint8_t status = ADCS_get_power_control(&packed_struct);
@@ -532,7 +532,7 @@ uint8_t TCMDEXEC_adcs_get_power_control(const char *args_str, TCMD_TelecommandCh
 ///     - Arg 8: Motor power control mode
 ///     - Arg 9: GPS power control mode
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_set_power_control(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_power_control(const char *args_str,
                                         char *response_output_buf, uint16_t response_output_buf_len) {
 
     // parse arguments: first into uint64_t, then convert to correct form for input
@@ -557,7 +557,7 @@ uint8_t TCMDEXEC_adcs_set_power_control(const char *args_str, TCMD_TelecommandCh
 /// @param args_str 
 ///     - Arg 0: Enable stable attitude mode. 1 to keep the attitude of the satellite stable (costs average 250 mW, maximum 1 W extra), 0 to disable control entirely (satellite will slowly start to tumble).
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_enter_low_power_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_enter_low_power_mode(const char *args_str,
                                         char *response_output_buf, uint16_t response_output_buf_len) {
     
     uint64_t mode;
@@ -598,7 +598,7 @@ uint8_t TCMDEXEC_adcs_enter_low_power_mode(const char *args_str, TCMD_Telecomman
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_track_sun(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_track_sun(const char *args_str,
                                   char *response_output_buf, uint16_t response_output_buf_len) {
 
     ADCS_current_state_1_struct_t current_state;
@@ -671,7 +671,7 @@ uint8_t TCMDEXEC_adcs_track_sun(const char *args_str, TCMD_TelecommandChannel_en
 ///     - Arg 13: Value (3, 1) of the magnetometer sensitivity matrix (double)
 ///     - Arg 14: Value (3, 2) of the magnetometer sensitivity matrix (double)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_set_magnetometer_config(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_magnetometer_config(const char *args_str,
                                               char *response_output_buf, uint16_t response_output_buf_len) {
 
     // parse arguments into doubles
@@ -694,7 +694,7 @@ uint8_t TCMDEXEC_adcs_set_magnetometer_config(const char *args_str, TCMD_Telecom
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_bootloader_clear_errors(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_bootloader_clear_errors(const char *args_str,
                                               char *response_output_buf, uint16_t response_output_buf_len) {
     const uint8_t status = ADCS_bootloader_clear_errors(); 
     return status;
@@ -707,7 +707,7 @@ uint8_t TCMDEXEC_adcs_bootloader_clear_errors(const char *args_str, TCMD_Telecom
 ///     - Arg 2: whether to save the current Unix time periodically (bool passed as int; 1 = save periodically, 0 = don't)
 ///     - Arg 3: the period of saving the current Unix time (in seconds)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_set_unix_time_save_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_unix_time_save_mode(const char *args_str,
                                               char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t bools[3];
     uint64_t uint_arg;
@@ -735,7 +735,7 @@ uint8_t TCMDEXEC_adcs_set_unix_time_save_mode(const char *args_str, TCMD_Telecom
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_unix_time_save_mode(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_unix_time_save_mode(const char *args_str,
                                               char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_set_unix_time_save_mode_struct_t packed_struct;
     const uint8_t status = ADCS_get_unix_time_save_mode(&packed_struct);
@@ -769,7 +769,7 @@ uint8_t TCMDEXEC_adcs_get_unix_time_save_mode(const char *args_str, TCMD_Telecom
 ///     - Arg 6: mean anomaly (degrees) (double)
 ///     - Arg 7: epoch (integer component is year, decimal component is day) (double)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_set_sgp4_orbit_params(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_sgp4_orbit_params(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len) {
     // parse arguments into doubles
     const uint8_t num_args = 8;
@@ -791,7 +791,7 @@ uint8_t TCMDEXEC_adcs_set_sgp4_orbit_params(const char *args_str, TCMD_Telecomma
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_sgp4_orbit_params(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_sgp4_orbit_params(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_orbit_params_struct_t packed_struct;
     const uint8_t status = ADCS_get_sgp4_orbit_params(&packed_struct);
@@ -818,7 +818,7 @@ uint8_t TCMDEXEC_adcs_get_sgp4_orbit_params(const char *args_str, TCMD_Telecomma
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_save_orbit_params(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_save_orbit_params(const char *args_str,
                                         char *response_output_buf, uint16_t response_output_buf_len) {
     const uint8_t status = ADCS_save_orbit_params();
     return status;
@@ -828,7 +828,7 @@ uint8_t TCMDEXEC_adcs_save_orbit_params(const char *args_str, TCMD_TelecommandCh
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_rate_sensor_rates(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_rate_sensor_rates(const char *args_str,
                                         char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_rated_sensor_rates_struct_t packed_struct;
     const uint8_t status = ADCS_get_rate_sensor_rates(&packed_struct);
@@ -855,7 +855,7 @@ uint8_t TCMDEXEC_adcs_rate_sensor_rates(const char *args_str, TCMD_TelecommandCh
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_wheel_speed(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_wheel_speed(const char *args_str,
                                       char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_wheel_speed_struct_t packed_struct;
     const uint8_t status = ADCS_get_wheel_speed(&packed_struct);
@@ -882,7 +882,7 @@ uint8_t TCMDEXEC_adcs_get_wheel_speed(const char *args_str, TCMD_TelecommandChan
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_magnetorquer_command(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_magnetorquer_command(const char *args_str,
                                                char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_magnetorquer_command_struct_t packed_struct;
     const uint8_t status = ADCS_get_magnetorquer_command(&packed_struct);
@@ -909,7 +909,7 @@ uint8_t TCMDEXEC_adcs_get_magnetorquer_command(const char *args_str, TCMD_Teleco
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_raw_magnetometer_values(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_raw_magnetometer_values(const char *args_str,
                                                   char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_raw_magnetometer_values_struct_t packed_struct;
     const uint8_t status = ADCS_get_raw_magnetometer_values(&packed_struct);
@@ -936,7 +936,7 @@ uint8_t TCMDEXEC_adcs_get_raw_magnetometer_values(const char *args_str, TCMD_Tel
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_estimate_fine_angular_rates(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_estimate_fine_angular_rates(const char *args_str,
                                                   char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_fine_angular_rates_struct_t packed_struct;
     const uint8_t status = ADCS_get_estimate_fine_angular_rates(&packed_struct); 
@@ -963,7 +963,7 @@ uint8_t TCMDEXEC_adcs_estimate_fine_angular_rates(const char *args_str, TCMD_Tel
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_magnetometer_config(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_magnetometer_config(const char *args_str,
                                               char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_magnetometer_config_struct_t packed_struct;
     const uint8_t status = ADCS_get_magnetometer_config(&packed_struct);
@@ -990,7 +990,7 @@ uint8_t TCMDEXEC_adcs_get_magnetometer_config(const char *args_str, TCMD_Telecom
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_commanded_attitude_angles(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_commanded_attitude_angles(const char *args_str,
                                                     char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_commanded_angles_struct_t packed_struct;
     const uint8_t status = ADCS_get_commanded_attitude_angles(&packed_struct);
@@ -1019,7 +1019,7 @@ uint8_t TCMDEXEC_adcs_get_commanded_attitude_angles(const char *args_str, TCMD_T
 ///     - Arg 1: y attitude angle (double)
 ///     - Arg 2: z attitude angle (double)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_set_commanded_attitude_angles(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_commanded_attitude_angles(const char *args_str,
                                                     char *response_output_buf, uint16_t response_output_buf_len) {
     // parse arguments into doubles
     const uint8_t num_args = 3;
@@ -1057,7 +1057,7 @@ uint8_t TCMDEXEC_adcs_set_commanded_attitude_angles(const char *args_str, TCMD_T
 ///     - Arg 15: automatic_estimation_transition_due_to_rate_sensor_errors (bool; enable/disable automatic transition from MEMS rate estimation mode to RKF in case of rate sensor error)
 ///     - Arg 16: error_counter_reset_period_min (uint8; period after which a node's power cycle reset counter is cleared if no errors occurred)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_set_estimation_params(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_estimation_params(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len) {
     // the first seven are floats (0-6)
     // the next six are bools (0-5)
@@ -1116,7 +1116,7 @@ uint8_t TCMDEXEC_adcs_set_estimation_params(const char *args_str, TCMD_Telecomma
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_estimation_params(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_estimation_params(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_estimation_params_struct_t packed_struct;
     const uint8_t status = ADCS_get_estimation_params(&packed_struct);
@@ -1159,7 +1159,7 @@ uint8_t TCMDEXEC_adcs_get_estimation_params(const char *args_str, TCMD_Telecomma
 ///     - Arg 15: max_lag (maximum lagged timestamp measurements to incorporate) (double)
 ///     - Arg 16: min_samples (Minimum samples to use to get Augmented_SGP4)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_set_augmented_sgp4_params(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_augmented_sgp4_params(const char *args_str,
                                        char *response_output_buf, uint16_t response_output_buf_len) {
     // seven doubles, then enum, then two doubles, uint8, two doubles, uint8, two doubles, uint16
     //  0-6             7           8-9             10      11-12       13      14-15       16
@@ -1213,7 +1213,7 @@ uint8_t TCMDEXEC_adcs_set_augmented_sgp4_params(const char *args_str, TCMD_Telec
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_augmented_sgp4_params(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_augmented_sgp4_params(const char *args_str,
                                        char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_augmented_sgp4_params_struct_t packed_struct;
     const uint8_t status = ADCS_get_augmented_sgp4_params(&packed_struct);
@@ -1242,7 +1242,7 @@ uint8_t TCMDEXEC_adcs_get_augmented_sgp4_params(const char *args_str, TCMD_Telec
 ///     - Arg 1: latitude (double)
 ///     - Arg 2: altitude (double)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_set_tracking_controller_target_reference(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_tracking_controller_target_reference(const char *args_str,
                                                                 char *response_output_buf, uint16_t response_output_buf_len) {
     // parse arguments into doubles
     const uint8_t num_args = 3;
@@ -1265,7 +1265,7 @@ uint8_t TCMDEXEC_adcs_set_tracking_controller_target_reference(const char *args_
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_tracking_controller_target_reference(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_tracking_controller_target_reference(const char *args_str,
                                                                 char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_tracking_controller_target_struct_t packed_struct;
     const uint8_t status = ADCS_get_tracking_controller_target_reference(&packed_struct);
@@ -1298,7 +1298,7 @@ uint8_t TCMDEXEC_adcs_get_tracking_controller_target_reference(const char *args_
 ///     - Arg 5: z_rate_offset (z-rate sensor offset) (double)
 ///     - Arg 6: rate_sensor_mult (multiplier of rate sensor measurement)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_set_rate_gyro_config(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_rate_gyro_config(const char *args_str,
                                            char *response_output_buf, uint16_t response_output_buf_len) {
     
     // parse axis select arguments into uint64s
@@ -1341,7 +1341,7 @@ uint8_t TCMDEXEC_adcs_set_rate_gyro_config(const char *args_str, TCMD_Telecomman
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_rate_gyro_config(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_rate_gyro_config(const char *args_str,
                                            char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_rate_gyro_config_struct_t packed_struct;
     const uint8_t status = ADCS_get_rate_gyro_config(&packed_struct);
@@ -1368,7 +1368,7 @@ uint8_t TCMDEXEC_adcs_get_rate_gyro_config(const char *args_str, TCMD_Telecomman
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_estimated_attitude_angles(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_estimated_attitude_angles(const char *args_str,
                                                 char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_estimated_attitude_angles_struct_t packed_struct;
     const uint8_t status = ADCS_get_estimated_attitude_angles(&packed_struct);
@@ -1395,7 +1395,7 @@ uint8_t TCMDEXEC_adcs_estimated_attitude_angles(const char *args_str, TCMD_Telec
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_magnetic_field_vector(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_magnetic_field_vector(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_magnetic_field_vector_struct_t packed_struct;
     const uint8_t status = ADCS_get_magnetic_field_vector(&packed_struct);
@@ -1422,7 +1422,7 @@ uint8_t TCMDEXEC_adcs_magnetic_field_vector(const char *args_str, TCMD_Telecomma
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_fine_sun_vector(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_fine_sun_vector(const char *args_str,
                                       char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_fine_sun_vector_struct_t packed_struct;
     const uint8_t status = ADCS_get_fine_sun_vector(&packed_struct);
@@ -1449,7 +1449,7 @@ uint8_t TCMDEXEC_adcs_fine_sun_vector(const char *args_str, TCMD_TelecommandChan
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_nadir_vector(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_nadir_vector(const char *args_str,
                                    char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_nadir_vector_struct_t packed_struct;
     const uint8_t status = ADCS_get_nadir_vector(&packed_struct);
@@ -1476,7 +1476,7 @@ uint8_t TCMDEXEC_adcs_nadir_vector(const char *args_str, TCMD_TelecommandChannel
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_commanded_wheel_speed(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_commanded_wheel_speed(const char *args_str,
                                             char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_wheel_speed_struct_t packed_struct;
     const uint8_t status = ADCS_get_commanded_wheel_speed(&packed_struct);
@@ -1503,7 +1503,7 @@ uint8_t TCMDEXEC_adcs_commanded_wheel_speed(const char *args_str, TCMD_Telecomma
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_igrf_magnetic_field_vector(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_igrf_magnetic_field_vector(const char *args_str,
                                                  char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_magnetic_field_vector_struct_t packed_struct;
     const uint8_t status = ADCS_get_igrf_magnetic_field_vector(&packed_struct);
@@ -1530,7 +1530,7 @@ uint8_t TCMDEXEC_adcs_igrf_magnetic_field_vector(const char *args_str, TCMD_Tele
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_quaternion_error_vector(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_quaternion_error_vector(const char *args_str,
                                               char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_quaternion_error_vector_struct_t packed_struct;
     const uint8_t status = ADCS_get_quaternion_error_vector(&packed_struct);
@@ -1557,7 +1557,7 @@ uint8_t TCMDEXEC_adcs_quaternion_error_vector(const char *args_str, TCMD_Telecom
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_estimated_gyro_bias(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_estimated_gyro_bias(const char *args_str,
                                           char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_estimated_gyro_bias_struct_t packed_struct;
     const uint8_t status = ADCS_get_estimated_gyro_bias(&packed_struct);
@@ -1584,7 +1584,7 @@ uint8_t TCMDEXEC_adcs_estimated_gyro_bias(const char *args_str, TCMD_Telecommand
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_estimation_innovation_vector(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_estimation_innovation_vector(const char *args_str,
                                                    char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_estimation_innovation_vector_struct_t packed_struct;
     const uint8_t status = ADCS_get_estimation_innovation_vector(&packed_struct);
@@ -1611,7 +1611,7 @@ uint8_t TCMDEXEC_adcs_estimation_innovation_vector(const char *args_str, TCMD_Te
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_raw_cam1_sensor(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_raw_cam1_sensor(const char *args_str,
                                       char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_raw_cam_sensor_struct_t packed_struct;
     const uint8_t status = ADCS_get_raw_cam1_sensor(&packed_struct);
@@ -1638,7 +1638,7 @@ uint8_t TCMDEXEC_adcs_raw_cam1_sensor(const char *args_str, TCMD_TelecommandChan
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_raw_cam2_sensor(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_raw_cam2_sensor(const char *args_str,
                                       char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_raw_cam_sensor_struct_t packed_struct;
     const uint8_t status = ADCS_get_raw_cam2_sensor(&packed_struct);
@@ -1665,7 +1665,7 @@ uint8_t TCMDEXEC_adcs_raw_cam2_sensor(const char *args_str, TCMD_TelecommandChan
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_raw_coarse_sun_sensor_1_to_6(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_raw_coarse_sun_sensor_1_to_6(const char *args_str,
                                      char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_raw_coarse_sun_sensor_1_to_6_struct_t packed_struct;
     const uint8_t status = ADCS_get_raw_coarse_sun_sensor_1_to_6(&packed_struct);
@@ -1692,7 +1692,7 @@ uint8_t TCMDEXEC_adcs_raw_coarse_sun_sensor_1_to_6(const char *args_str, TCMD_Te
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_raw_coarse_sun_sensor_7_to_10(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_raw_coarse_sun_sensor_7_to_10(const char *args_str,
                                       char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_raw_coarse_sun_sensor_7_to_10_struct_t packed_struct;
     const uint8_t status = ADCS_get_raw_coarse_sun_sensor_7_to_10(&packed_struct);
@@ -1719,7 +1719,7 @@ uint8_t TCMDEXEC_adcs_raw_coarse_sun_sensor_7_to_10(const char *args_str, TCMD_T
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_cubecontrol_current(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_cubecontrol_current(const char *args_str,
                                           char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_cubecontrol_current_struct_t packed_struct;
     const uint8_t status = ADCS_get_cubecontrol_current(&packed_struct);
@@ -1746,7 +1746,7 @@ uint8_t TCMDEXEC_adcs_cubecontrol_current(const char *args_str, TCMD_Telecommand
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_measurements(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_measurements(const char *args_str,
                                    char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_measurements_struct_t packed_struct;
     const uint8_t status = ADCS_get_measurements(&packed_struct); 
@@ -1774,7 +1774,7 @@ uint8_t TCMDEXEC_adcs_measurements(const char *args_str, TCMD_TelecommandChannel
 ///     - Arg 0: The number of files to get (should be less than 70 to avoid the watchdog)
 ///     - Arg 1: The offset index to start reading (starts at 0)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_download_index_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_download_index_file(const char *args_str,
                                    char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t num_to_read;
     uint64_t index_offset;
@@ -1797,7 +1797,7 @@ uint8_t TCMDEXEC_adcs_download_index_file(const char *args_str, TCMD_Telecommand
 /// @param args_str 
 ///     - Arg 0: The index of the file to download
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_download_sd_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_download_sd_file(const char *args_str,
                                    char *response_output_buf, uint16_t response_output_buf_len) {
 
     // parse file index argument
@@ -1815,7 +1815,7 @@ uint8_t TCMDEXEC_adcs_download_sd_file(const char *args_str, TCMD_TelecommandCha
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_acp_execution_state(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_acp_execution_state(const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_acp_execution_state_struct_t packed_struct;
     const uint8_t status = ADCS_get_acp_execution_state(&packed_struct); 
@@ -1843,7 +1843,7 @@ uint8_t TCMDEXEC_adcs_acp_execution_state(const char *args_str, TCMD_Telecommand
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_current_state_1(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_current_state_1(const char *args_str,
                                    char *response_output_buf, uint16_t response_output_buf_len) {
     ADCS_current_state_1_struct_t packed_struct;
     const uint8_t status = ADCS_get_current_state_1(&packed_struct); 
@@ -1871,7 +1871,7 @@ uint8_t TCMDEXEC_adcs_get_current_state_1(const char *args_str, TCMD_Telecommand
 ///     - Arg 0: (int) Which camera to save the image from; can be Camera 1 (0), Camera 2 (1), or Star (2)
 ///     - Arg 1: (int) Resolution of the image to save; can be 1024x1024 (0), 512x512 (1), 256x256 (2), 128x128 (3), or 64x64 (4)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_save_image_to_sd(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_save_image_to_sd(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     // parse arguments: first into int64_t, then convert to correct form for input
     const uint8_t num_args = 2;
@@ -1895,7 +1895,7 @@ uint8_t TCMDEXEC_adcs_save_image_to_sd(const char *args_str, TCMD_TelecommandCha
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_synchronize_unix_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_synchronize_unix_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     const uint8_t status = ADCS_synchronize_unix_time(); 
     return status;
@@ -1905,7 +1905,7 @@ uint8_t TCMDEXEC_adcs_synchronize_unix_time(const char *args_str, TCMD_Telecomma
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_current_unix_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_current_unix_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     
     uint64_t unix_time_ms;
@@ -1936,7 +1936,7 @@ uint8_t TCMDEXEC_adcs_get_current_unix_time(const char *args_str, TCMD_Telecomma
 ///     - Arg 2: log_period; Period to log data to the SD card; if zero, then disable logging
 ///     - Arg 3: which_sd; Which SD card to log to, 0 for primary, 1 for secondary 
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_set_sd_log_config(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_sd_log_config(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     
     uint64_t which_log;
@@ -1984,7 +1984,7 @@ uint8_t TCMDEXEC_adcs_set_sd_log_config(const char *args_str, TCMD_TelecommandCh
 /// @param args_str 
 ///     - Arg 0: which log to retrieve the configuration for (1 or 2)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_get_sd_log_config(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_get_sd_log_config(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     
     uint64_t which_log;
@@ -2022,7 +2022,7 @@ uint8_t TCMDEXEC_adcs_get_sd_log_config(const char *args_str, TCMD_TelecommandCh
 ///     - Arg 0: Which commissioning step to set the modes for (1-18)
 ///     - Arg 1: Timeout in seconds before reverting to no control (0 = indefinite)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_set_commissioning_modes(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_set_commissioning_modes(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     uint64_t arguments[2];
     for (uint8_t i = 0; i < 2; i++) {
@@ -2592,7 +2592,7 @@ uint8_t TCMDEXEC_adcs_set_commissioning_modes(const char *args_str, TCMD_Telecom
 ///     - Arg 1: Log number (1 or 2)
 ///     - Arg 2: Destination SD card (0 = primary, 1 = secondary)
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_request_commissioning_telemetry(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_request_commissioning_telemetry(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     // parse arguments: first into int64_t, then convert to correct form for input
     uint64_t arguments[3];
@@ -2790,7 +2790,7 @@ uint8_t TCMDEXEC_adcs_request_commissioning_telemetry(const char *args_str, TCMD
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_format_sd(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_format_sd(const char *args_str,
                                    char *response_output_buf, uint16_t response_output_buf_len) {
     const uint8_t status = ADCS_format_sd();
     return status;
@@ -2800,7 +2800,7 @@ uint8_t TCMDEXEC_adcs_format_sd(const char *args_str, TCMD_TelecommandChannel_en
 /// @param args_str 
 ///     - Arg 0: Index of the file to erase
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_erase_sd_file(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_erase_sd_file(const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len) {
     
     // parse file index argument
@@ -2817,7 +2817,7 @@ uint8_t TCMDEXEC_adcs_erase_sd_file(const char *args_str, TCMD_TelecommandChanne
 /// @param args_str 
 ///     - No arguments for this command
 /// @return 0 on success, >0 on error
-uint8_t TCMDEXEC_adcs_exit_bootloader(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_adcs_exit_bootloader(const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len) {
 
     const uint8_t run_status = ADCS_bootloader_run_program(); // we cannot verify this command with a return value, so check below

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -1316,5 +1316,5 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
 const int16_t TCMD_NUM_TELECOMMANDS = sizeof(TCMD_telecommand_definitions) / sizeof(TCMD_TelecommandDefinition_t);
 
 // Each telecommand function must have the following signature:
-// uint8_t <function_name>(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+// uint8_t <function_name>(const char *args_str,
 //                          char *response_output_buf, uint16_t response_output_buf_len)

--- a/firmware/Core/Src/telecommands/testing_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/testing_telecommand_defs.c
@@ -15,7 +15,7 @@
 /// @brief A demo telecommand that echoes back the argument it received.
 /// @param args_str
 /// - Arg 0: The string to echo back.
-uint8_t TCMDEXEC_echo_back_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_echo_back_args(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
 
     snprintf(response_output_buf, response_output_buf_len, "SUCCESS: Echo Args: '%s'\n", args_str);
@@ -29,7 +29,7 @@ uint8_t TCMDEXEC_echo_back_args(const char *args_str, TCMD_TelecommandChannel_en
 /// - Arg 1: The second integer to echo back.
 /// - Arg 2: The third integer to echo back.
 /// @return 0 if all ints are parsed successfully, otherwise the error code of the first failed parse.
-uint8_t TCMDEXEC_echo_back_uint32_args(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_echo_back_uint32_args(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     response_output_buf[0] = '\0'; // clear the response buffer
 
@@ -57,7 +57,7 @@ uint8_t TCMDEXEC_echo_back_uint32_args(const char *args_str, TCMD_TelecommandCha
 }
 
 
-uint8_t TCMDEXEC_run_all_unit_tests(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_run_all_unit_tests(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     TEST_run_all_unit_tests_and_log(response_output_buf, response_output_buf_len);
     return 0;
@@ -69,7 +69,7 @@ uint8_t TCMDEXEC_run_all_unit_tests(const char *args_str, TCMD_TelecommandChanne
 /// @return 0 on success, 1 on error
 /// @note This is most useful for testing/triggering the watchdog timer.
 uint8_t TCMDEXEC_demo_blocking_delay(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     uint64_t delay_ms;

--- a/firmware/Core/Src/telecommands/timekeeping_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/timekeeping_telecommand_defs.c
@@ -7,7 +7,7 @@
 #include <string.h>
 
 uint8_t TCMDEXEC_get_system_time(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     TIME_get_current_timestamp_str(response_output_buf, response_output_buf_len);
@@ -18,7 +18,7 @@ uint8_t TCMDEXEC_get_system_time(
 /// @param args_str
 /// - Arg 0: Unix epoch time in milliseconds (uint64_t)
 /// @return 0 if successful, 1 if error
-uint8_t TCMDEXEC_set_system_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_set_system_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
   
     uint64_t ms = 0;
@@ -38,7 +38,7 @@ uint8_t TCMDEXEC_set_system_time(const char *args_str, TCMD_TelecommandChannel_e
 /// @param args_str
 /// - Arg 0: Correction time in milliseconds (int64_t). Positive = forward in time, negative = backward in time.
 /// @return 0 if successful, 1 if error
-uint8_t TCMDEXEC_correct_system_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_correct_system_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len){
 
     int64_t correction_time_ms = 0;
@@ -60,7 +60,7 @@ uint8_t TCMDEXEC_correct_system_time(const char *args_str, TCMD_TelecommandChann
 
 /// @brief Sync's obc time to eps time (+/- 1 second)
 /// @return 0 on success, >0 on failure.
-uint8_t TCMDEXEC_set_obc_time_based_on_eps_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_set_obc_time_based_on_eps_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     const uint8_t result = EPS_set_obc_time_based_on_eps_time();
     if (result != 0 ) {
@@ -76,7 +76,7 @@ uint8_t TCMDEXEC_set_obc_time_based_on_eps_time(const char *args_str, TCMD_Telec
 
 /// @brief Sync's eps time to obc time (+/- 1 second)
 /// @return 0 on success, >0 on failure.
-uint8_t TCMDEXEC_set_eps_time_based_on_obc_time(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+uint8_t TCMDEXEC_set_eps_time_based_on_obc_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len) {
     const uint8_t result = EPS_set_eps_time_based_on_obc_time();
     if (result != 0 ) {

--- a/firmware/Core/Src/telecommands/uart_error_tracking_telecommands.c
+++ b/firmware/Core/Src/telecommands/uart_error_tracking_telecommands.c
@@ -2,7 +2,7 @@
 #include "uart_handler/uart_error_tracking.h"
 #include <stdio.h>
 
-uint8_t TCMDEXEC_uart_get_errors_json(const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel, char *response_output_buf, uint16_t response_output_buf_len)
+uint8_t TCMDEXEC_uart_get_errors_json(const char *args_str, char *response_output_buf, uint16_t response_output_buf_len)
 {
 
     const uint8_t ret = UART_get_errors_json(response_output_buf, response_output_buf_len);

--- a/firmware/Core/Src/telecommands/uart_telelecommand_defs.c
+++ b/firmware/Core/Src/telecommands/uart_telelecommand_defs.c
@@ -25,7 +25,6 @@ static uint8_t rx_buffer[5120];
 /// @param args_str 
 /// - Arg 0: UART port name to send data to: MPI, GNSS, CAMERA, EPS (case insensitive)
 /// - Arg 1: Data to be sent (bytes specified as hex - Max 5KiB buffer)
-/// @param tcmd_channel The channel on which the telecommand was received, and on which the response should be sent
 /// @param response_output_buf The buffer to write the response to
 /// @param response_output_buf_len The maximum length of the response_output_buf (its size)
 /// @return 0: Success, 1: Error parsing args, 2: Invalid uart port requested, 3: Error transmitting data, 
@@ -35,7 +34,7 @@ static uint8_t rx_buffer[5120];
 ///       using this function.
 /// @note The camera UART port does not support receiving data in the function. TX only.
 uint8_t TCMDEXEC_uart_send_hex_get_response_hex(
-    const char *args_str, TCMD_TelecommandChannel_enum_t tcmd_channel,
+    const char *args_str,
     char *response_output_buf, uint16_t response_output_buf_len
 ) {
     // Parse UART port argument
@@ -365,7 +364,6 @@ uint8_t TCMDEXEC_uart_send_hex_get_response_hex(
 /// @note Intended for debugging and testing purposes, but safe to use in flight also.
 uint8_t TCMDEXEC_uart_get_last_rx_times_json(
     const char *args_str,
-    TCMD_TelecommandChannel_enum_t tcmd_channel,
     char *response_output_buf,
     uint16_t response_output_buf_len
 ) {
@@ -413,7 +411,6 @@ uint8_t TCMDEXEC_uart_get_last_rx_times_json(
 ///        can be used to change the STM32's UART baud rate to match the GNSS receiver's default baud rate to recover it.
 uint8_t TCMDEXEC_uart_set_baud_rate(
     const char *args_str,
-    TCMD_TelecommandChannel_enum_t tcmd_channel,
     char *response_output_buf,
     uint16_t response_output_buf_len
 ) {

--- a/firmware/Core/Src/unit_tests/test_telecommand_parser.c
+++ b/firmware/Core/Src/unit_tests/test_telecommand_parser.c
@@ -209,36 +209,34 @@ uint8_t TEST_EXEC__TCMD_ascii_to_double() {
 uint8_t TEST_EXEC_TCMD_parse_full_telecommand() {
     TCMD_parsed_tcmd_to_execute_t parsed_tcmd;
     // Testing correct usage of 0 argument telecommand 
-    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+hello_world()!", TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd) == 0);
+    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+hello_world()!", &parsed_tcmd) == 0);
     TEST_ASSERT_TRUE(strcmp(parsed_tcmd.args_str_no_parens, "") == 0);
-    TEST_ASSERT_TRUE(parsed_tcmd.tcmd_channel == TCMD_TelecommandChannel_DEBUG_UART);
     TEST_ASSERT_TRUE(strcmp(TCMD_telecommand_definitions[parsed_tcmd.tcmd_idx].tcmd_name, "hello_world") == 0);
 
     // Tesing incorrect usage of 0 argument telecommand
-    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+hello_world(a)!", TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd) == 130);
-    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+hello_world(a,1)!", TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd) == 130);
-    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+hello_world(,)!", TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd) == 130);
+    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+hello_world(a)!", &parsed_tcmd) == 130);
+    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+hello_world(a,1)!", &parsed_tcmd) == 130);
+    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+hello_world(,)!", &parsed_tcmd) == 130);
 
     // Testing correct usage of 1 argument telecommand 
-    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+set_system_time(10)!", TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd) == 0); 
+    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+set_system_time(10)!", &parsed_tcmd) == 0); 
     TEST_ASSERT_TRUE(strcmp(parsed_tcmd.args_str_no_parens, "10") == 0);
-    TEST_ASSERT_TRUE(parsed_tcmd.tcmd_channel == TCMD_TelecommandChannel_DEBUG_UART);
     TEST_ASSERT_TRUE(strcmp(TCMD_telecommand_definitions[parsed_tcmd.tcmd_idx].tcmd_name, "set_system_time") == 0);
 
 
     // Tesing incorrect usage of 1 argument telecommand
-    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+set_system_time()!", TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd) == 130);
-    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+set_system_time(10,1)!", TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd) == 130);
-    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+set_system_time(10,)!", TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd) == 130);
-    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+set_system_time(,10)!", TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd) == 130);
-    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+set_system_time(,)!", TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd) == 130);
+    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+set_system_time()!", &parsed_tcmd) == 130);
+    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+set_system_time(10,1)!", &parsed_tcmd) == 130);
+    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+set_system_time(10,)!", &parsed_tcmd) == 130);
+    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+set_system_time(,10)!", &parsed_tcmd) == 130);
+    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+set_system_time(,)!", &parsed_tcmd) == 130);
 
     // Testing correct usage of 3 3 argument telecommand
-    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+flash_read_hex(0,0,0)!", TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd) == 0);
-    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+flash_read_hex(0,0,0,)!", TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd) == 130);
-    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+flash_read_hex(,0,0,0)!", TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd) == 130);
-    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+flash_read_hex(,0,0,0)!", TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd) == 130);
-    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+flash_read_hex(0,0)!", TCMD_TelecommandChannel_DEBUG_UART, &parsed_tcmd) == 130);
+    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+flash_read_hex(0,0,0)!", &parsed_tcmd) == 0);
+    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+flash_read_hex(0,0,0,)!", &parsed_tcmd) == 130);
+    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+flash_read_hex(,0,0,0)!", &parsed_tcmd) == 130);
+    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+flash_read_hex(,0,0,0)!", &parsed_tcmd) == 130);
+    TEST_ASSERT_TRUE(TCMD_parse_full_telecommand("CTS1+flash_read_hex(0,0)!", &parsed_tcmd) == 130);
 
     return 0;
 }


### PR DESCRIPTION
Removed all instances of `TCMD_TelecommandChannel_enum_t`, and any references to it. Build passes.