### PR TITLE
LFS: Force `LFS_ensure_unmounted` to set state variable to unmounted

### DIFF
--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -157,7 +157,13 @@ int8_t LFS_ensure_unmounted() {
         return 0;
     }
     
-    return LFS_unmount();
+    const int8_t result = LFS_unmount();
+
+    // Even if "unmounting fails" (e.g., due to corruption, due to an implicit unmount earlier),
+    // we can reasonably confidently say it's unmounted here, and thus update the state variable.
+    LFS_is_lfs_mounted = 0;
+
+    return result;
 }
 
 /// @brief Lists contents of LittleFS Directory, where each entry is sent as a log message.

--- a/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/lfs_telecommand_defs.c
@@ -14,11 +14,21 @@
 #include "telecommand_exec/telecommand_args_helpers.h"
 #include "transforms/arrays.h"
 
+/// @brief Format the LittleFS storage. ERASES ALL FILES. Unmounts the filesystem if necessary.
+/// @return LFS errror code from LFS_format().
 uint8_t TCMDEXEC_fs_format_storage(
     const char *args_str,
         char *response_output_buf, uint16_t response_output_buf_len
 ) {
-    LFS_ensure_unmounted();
+    const int8_t unmount_result = LFS_ensure_unmounted();
+    if (unmount_result != 0) {
+        LOG_message(
+            LOG_SYSTEM_LFS, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE),
+            "Error unmounting LittleFS before format. LFS_ensure_unmounted() -> %d. Steamrolling.",
+            unmount_result
+        );
+        // Steamroll.
+    }
 
     const int8_t result = LFS_format();
     if (result != 0) {


### PR DESCRIPTION
Fixes #543