### PR TITLE
Timekeeping: Allow sub-50ms-precision time sync via telecommand

### DIFF
--- a/firmware/Core/Inc/telecommands/timekeeping_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/timekeeping_telecommand_defs.h
@@ -8,8 +8,15 @@
 uint8_t TCMDEXEC_get_system_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_set_system_time(const char *args_str,
-                        char *response_output_buf, uint16_t response_output_buf_len);
+uint8_t TCMDEXEC_set_system_time_approx(
+    const char *args_str,
+    char *response_output_buf, uint16_t response_output_buf_len
+);
+
+uint8_t TCMDEXEC_set_system_time(
+    const char *args_str,
+    char *response_output_buf, uint16_t response_output_buf_len
+);
 
 uint8_t TCMDEXEC_correct_system_time(const char *args_str,
                         char *response_output_buf, uint16_t response_output_buf_len);

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -77,6 +77,12 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
     {
+        .tcmd_name = "set_system_time_approx",
+        .tcmd_func = TCMDEXEC_set_system_time_approx,
+        .number_of_args = 1,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+    {
         .tcmd_name = "set_system_time",
         .tcmd_func = TCMDEXEC_set_system_time,
         .number_of_args = 1,

--- a/firmware/Core/Src/telecommands/timekeeping_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/timekeeping_telecommand_defs.c
@@ -4,6 +4,8 @@
 #include "timekeeping/timekeeping.h"
 #include "eps_drivers/eps_time.h"
 #include "gnss_receiver/gnss_time.h"
+#include "uart_handler/uart_handler.h"
+
 #include <stdio.h>
 #include <string.h>
 
@@ -15,25 +17,74 @@ uint8_t TCMDEXEC_get_system_time(
     return 0;
 }
 
+
 /// @brief Set the system time to the provided Unix epoch time in milliseconds
 /// @param args_str
 /// - Arg 0: Unix epoch time in milliseconds (uint64_t)
 /// @return 0 if successful, 1 if error
-uint8_t TCMDEXEC_set_system_time(const char *args_str,
-                        char *response_output_buf, uint16_t response_output_buf_len) {
-  
+/// @note This function accounts for the unpredictable delay between telecommand reception and execution.
+uint8_t TCMDEXEC_set_system_time(
+    const char *args_str,
+    char *response_output_buf, uint16_t response_output_buf_len
+) {
     uint64_t ms = 0;
 
-    uint8_t result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &ms);
+    const uint8_t result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &ms);
     if (result != 0) {
+        snprintf(response_output_buf, response_output_buf_len, "Invalid system time argument");
         return 1;
     }
+
+    // Apply correction between telecommand reception and execution.
+    // You could consider this a "hack" because of the random/unpredictable 0-250ms delay
+    // in executing queued telecommands.
+
+    // First, find whether it came from AX100 or Umbilical (based on last write/rx time),
+    // and pick that last time. That is, select the max of these two values.
+    const uint32_t tcmd_received_at_uptime_ms = (
+        UART_telecommand_last_write_time_ms > UART_ax100_last_write_time_ms ?
+        UART_telecommand_last_write_time_ms : UART_ax100_last_write_time_ms
+    );
+
+    // Move the reported "current time" forward by the delay between telecommand reception and execution.
+    ms += HAL_GetTick() - tcmd_received_at_uptime_ms;
+
     TIME_set_current_unix_epoch_time_ms(
         ms, TIME_SYNC_SOURCE_TELECOMMAND_ABSOLUTE
     );
     snprintf(response_output_buf, response_output_buf_len, "Updated system time");
+
     return 0;
 }
+
+
+/// @brief Set the system time to the provided Unix epoch time in milliseconds.
+/// @param args_str
+/// - Arg 0: Unix epoch time in milliseconds (uint64_t)
+/// @return 0 if successful, 1 if error
+/// @note This function is the naive/basic implementation that doesn't account for a delay
+///       between telecommand reception and execution.
+uint8_t TCMDEXEC_set_system_time_approx(
+    const char *args_str,
+    char *response_output_buf, uint16_t response_output_buf_len
+) {
+    uint64_t ms = 0;
+
+    const uint8_t result = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &ms);
+    if (result != 0) {
+        snprintf(response_output_buf, response_output_buf_len, "Invalid system time argument");
+        return 1;
+    }
+
+    TIME_set_current_unix_epoch_time_ms(
+        ms, TIME_SYNC_SOURCE_TELECOMMAND_ABSOLUTE
+    );
+    snprintf(response_output_buf, response_output_buf_len, "Updated system time");
+
+    return 0;
+}
+
+
 
 /// @brief Adjust the system time by a correction offset in ms.
 /// @param args_str


### PR DESCRIPTION
Modifies the `set_system_time` telecommand to set the time more precisely, even if there is a delay between telecommand reception and execution.

```
    // Apply correction between telecommand reception and execution.
    // You could consider this a "hack" because of the random/unpredictable 0-250ms delay
    // in executing queued telecommands.
```

To derisk this change, the old unmodified version is now in the `set_system_time_approx` telecommand.