### PR TITLE
Fix: LFS return value is the wrong size in return from logging

### DIFF
--- a/firmware/Core/Src/littlefs/littlefs_helper.c
+++ b/firmware/Core/Src/littlefs/littlefs_helper.c
@@ -584,8 +584,7 @@ int8_t LFS_write_file_with_offset(const char file_name[], lfs_soff_t offset, uin
             }
         }
     }
-    else 
-    {
+    else {
         // Seek to the specified offset
         const lfs_soff_t seek_result_2 = lfs_file_seek(&LFS_filesystem, &file, offset, LFS_SEEK_SET);
         if (seek_result_2 < 0)
@@ -601,8 +600,7 @@ int8_t LFS_write_file_with_offset(const char file_name[], lfs_soff_t offset, uin
 
     // Write data to file at the specified offset
     const lfs_ssize_t write_result = lfs_file_write(&LFS_filesystem, &file, write_buffer, write_buffer_len);
-    if (write_result < 0)
-    {
+    if (write_result < 0) {
         LOG_message(LOG_SYSTEM_LFS, LOG_SEVERITY_WARNING, LOG_all_sinks_except(LOG_SINK_FILE), 
                    "Error writing to file: %s at offset %ld (error: %ld)", file_name, offset, write_result);
         

--- a/firmware/Core/Src/log/lazy_file_log_sink.c
+++ b/firmware/Core/Src/log/lazy_file_log_sink.c
@@ -87,11 +87,21 @@ static int8_t LOG_ensure_current_log_file_is_open() {
 
 
 /// @brief Writes to the current log file.
+/// @return 0 on success, negative LFS error codes on failure.
 static int8_t LOG_write_to_current_log_file(const char *msg, uint16_t msg_length) {
     LFS_ensure_mounted();
     LOG_ensure_current_log_file_is_open();
 
-    return lfs_file_write(&LFS_filesystem, &LOG_current_log_file_ctx.file, msg, msg_length);
+    const lfs_ssize_t write_result = lfs_file_write(
+        &LFS_filesystem, &LOG_current_log_file_ctx.file, msg, msg_length
+    );
+
+    if (write_result < 0) {
+        LOG_log_a_logging_error_if_file_is_broken("Log write: lfs_file_write() failed.");
+        return write_result;
+    }
+
+    return 0; // 0 on success.
 }
 
 


### PR DESCRIPTION
Fixes #574

Turns out the issue was completely inconsequential. Still is a good fix.