### PR TITLE
Config: Set the log timestamp format

### DIFF
--- a/firmware/Core/Src/config/configuration.c
+++ b/firmware/Core/Src/config/configuration.c
@@ -23,6 +23,7 @@ extern uint32_t STM32_system_reset_interval_sec;
 extern uint32_t STM32_system_reset_no_uplink_interval_sec;
 extern uint32_t COMMS_beacon_interval_ms;
 extern uint32_t GNSS_write_cmd_mode_data_to_firehose_file;
+extern uint32_t LOG_timestamp_prefix_format;
 
 extern uint32_t LOG_file_flush_interval_sec;
 extern uint32_t LOG_file_rotation_interval_sec;
@@ -91,6 +92,10 @@ CONFIG_integer_config_entry_t CONFIG_int_config_variables[] = {
     {
         .variable_name = "COMMS_beacon_interval_ms",
         .num_config_var = &COMMS_beacon_interval_ms,
+    },
+    {
+        .variable_name = "LOG_timestamp_prefix_format",
+        .num_config_var = &LOG_timestamp_prefix_format,
     },
     // ******** AX100 Configuration ********
     {

--- a/firmware/Core/Src/log/log.c
+++ b/firmware/Core/Src/log/log.c
@@ -13,6 +13,16 @@
 
 // Inspired by uLog: https://github.com/rdpoor/ulog
 
+/// @brief Format for the timestamp prefix.
+/// @details Options:
+///   - 0=synctime+offset
+///   - 1=ISO8601-like datetime with ms
+///   - 2=ISO8601-like datetime without ms
+///   - other=synctime+offset (fallback)
+/// @note Configurable with the configuration telecommand.
+/// @note Could be an enum in a perfect world, but using int for speed of implementation.
+uint32_t LOG_timestamp_prefix_format = 0;
+
 // Internal interfaces and variables
 #define LOG_TIMESTAMP_MAX_LENGTH 30
 #define LOG_SINK_NAME_MAX_LENGTH 10
@@ -151,8 +161,21 @@ void LOG_message(LOG_system_enum_t system, LOG_severity_enum_t severity, uint32_
         }
     }
 
-    // Get the system time
-    TIME_get_current_timestamp_str(LOG_timestamp_string, LOG_TIMESTAMP_MAX_LENGTH);
+    // Get the system time.
+    switch (LOG_timestamp_prefix_format) {
+        case 0:
+            TIME_get_current_timestamp_str(LOG_timestamp_string, LOG_TIMESTAMP_MAX_LENGTH);
+            break;
+        case 1:
+            TIME_get_current_utc_datetime_str(LOG_timestamp_string, LOG_TIMESTAMP_MAX_LENGTH);
+            break;
+        case 2:
+            TIME_get_current_utc_datetime_str_no_ms(LOG_timestamp_string, LOG_TIMESTAMP_MAX_LENGTH);
+            break;
+        default:
+            TIME_get_current_timestamp_str(LOG_timestamp_string, LOG_TIMESTAMP_MAX_LENGTH);
+            break;
+    }
 
     // Get pointer to next storage slot in circular memory table
     LOG_memory_index_of_current_log_entry++;


### PR DESCRIPTION
Resolves #564

Config variable: LOG_timestamp_prefix_format (acts as an enum, but is an int)

### Testing Examples

```
2026-03-19T031703Z [T:TCMD:INFO]: 🚀 Executing telecommand 'config_set_int_var'.

2026-03-19T031643.924Z_T [T:TCMD:INFO]: 🚀 Executing telecommand 'config_set_int_var'.

2026-03-19T031636.538Z_T [A:EPS:ERR]: EPS->OBC: timeout before first byte received

0000000000000+0000016382_N [A:OBC:INFO]: Heartbeat: Datetime: 1970-01-01T000016.381Z_N, Uptime: 16382 ms
```