### PR TITLE
Telecommand: Write file contents to STM32 internal flash bank

### DIFF
--- a/docs/Non-Critical_Notes/Deployment_Final_Checks.md
+++ b/docs/Non-Critical_Notes/Deployment_Final_Checks.md
@@ -36,12 +36,12 @@ The following checks involve executing code and/or telecommands.
 2. Are there any large VLA allocations? Can/should any be replaced with static allocations?
     * Maybe enable `-Wvla` or `-Wstack-usage`? Not sure what they are yet.
 3. Maybe enable compiler optimizations?
-4. Ensure that the Golden Copy is mapped in STM32L4R5ZITx_FLASH.ld file as such:
+4. Ensure that the Golden Copy is mapped in STM32L4R5XX_FLASH.ld file as such:
     ```
-    GOLDEN_COPY (xrw) : ORIGIN = 0x8100000, LENGTH = 1024K
+    FLASH_BANK_2 (xrw) : ORIGIN = 0x8100000, LENGTH = 1024K
     ```
     This is the linker script. The length can change.
-5. Ensure that we have flashed the golden copy of the OS to the GOLDEN_COPY address defined in the linker script ```STM32L4R5ZITx_FLASH.ld```
+5. Ensure that we have flashed the golden copy of the OS to the `FLASH_BANK_2` address defined in the linker script ```STM32L4R5XX_FLASH.ld```
 6. Ensure all tasks are registered in the `FREERTOS_task_info_struct_t FREERTOS_task_handles_array []` array. Consider a unit test for this check, maybe.
 7. Ensure the BOOT0 pin configuration is applied using STM32CubeProgrammer.
     * nSWBOOT0 = Unchecked (use software config)

--- a/firmware/Core/Inc/stm32/stm32_internal_flash_drivers.h
+++ b/firmware/Core/Inc/stm32/stm32_internal_flash_drivers.h
@@ -6,6 +6,12 @@
 #include "stm32l4xx_hal.h"
 #include "stm32l4xx_hal_flash.h"
 
+#define FLASH_BANK_1_START_PAGE 0u
+#define FLASH_BANK_1_END_PAGE 255u
+#define FLASH_BANK_2_START_PAGE 256u
+#define FLASH_BANK_2_END_PAGE 511u
+#define NUMBER_OF_PAGES_PER_FLASH_BANK 256u
+
 /// @brief  Flash Partitions
 /// @note look in the STM32L4R5XX_FLASH.ld file
 /// to see the address of each partition, update this as needed
@@ -14,8 +20,8 @@ typedef enum
     STM32_INTERNAL_FLASH_MEMORY_REGION_RAM_ADDRESS = 0x20000000,
     STM32_INTERNAL_FLASH_MEMORY_REGION_RAM_2_ADDRESS = 0x10000000,
     STM32_INTERNAL_FLASH_MEMORY_REGION_RAM_3_ADDRESS = 0x20040000,
-    STM32_INTERNAL_FLASH_MEMORY_REGION_FLASH_ADDRESS = 0x8000000, // default boot address
-    STM32_INTERNAL_FLASH_MEMORY_REGION_GOLDEN_COPY_ADDRESS = 0x08100000
+    STM32_INTERNAL_FLASH_MEMORY_REGION_FLASH_BANK_1_ADDRESS = 0x08000000, // default boot address
+    STM32_INTERNAL_FLASH_MEMORY_REGION_FLASH_BANK_2_ADDRESS = 0x08100000
 } STM32_INTERNAL_FLASH_memory_region_addresses_t;
 
 typedef struct
@@ -23,13 +29,26 @@ typedef struct
     HAL_StatusTypeDef lock_status;
     HAL_StatusTypeDef unlock_status;
     HAL_StatusTypeDef write_status;
-} STM32_Internal_Flash_Write_Status_t;
+} STM32_internal_flash_write_status_t;
 
-uint8_t STM32_internal_flash_write(uint32_t address, uint8_t *data, uint32_t length, STM32_Internal_Flash_Write_Status_t *status);
+typedef enum
+{
+    STM32_INTERNAL_FLASH_WRITE_SUCCESS,
+    STM32_INTERNAL_FLASH_WRITE_ADDRESS_TOO_LOW,
+    STM32_INTERNAL_FLASH_WRITE_ADDRESS_TOO_HIGH,
+    STM32_INTERNAL_FLASH_WRITE_ADDRESS_OVERLAPS_BOTH_FLASH_BANKS,
+    STM32_INTERNAL_FLASH_WRITE_UNLOCK_FAILED,
+    STM32_INTERNAL_FLASH_WRITE_LOCK_FAILED,
+    STM32_INTERNAL_FLASH_WRITE_OPERATION_FAILED,
+} STM32_internal_flash_write_return_t;
+
+STM32_internal_flash_write_return_t STM32_internal_flash_write(uint32_t address, uint8_t *data, uint32_t length, STM32_internal_flash_write_status_t *status);
 
 uint8_t STM32_internal_flash_read(uint32_t address, uint8_t *buffer, uint32_t length);
 
-uint8_t STM32_internal_flash_erase(uint16_t start_page_erase, uint16_t number_of_pages_to_erase, uint32_t *page_error);
+uint8_t STM32_internal_flash_page_erase(uint8_t flash_bank, uint16_t start_page_erase, uint16_t number_of_pages_to_erase, uint32_t *page_error);
+
+uint8_t STM32_internal_flash_bank_erase(uint8_t flash_bank, uint32_t *bank_erase_error);
 
 uint8_t STM32_internal_flash_get_option_bytes(FLASH_OBProgramInitTypeDef *ob_data);
 

--- a/firmware/Core/Inc/telecommands/stm32_internal_flash_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/stm32_internal_flash_telecommand_defs.h
@@ -9,14 +9,17 @@ uint8_t TCMDEXEC_stm32_internal_flash_write(const char *args_str,
 uint8_t TCMDEXEC_stm32_internal_flash_read(const char *args_str,
                                            char *response_output_buf, uint16_t response_output_buf_len);
 
-uint8_t TCMDEXEC_stm32_internal_flash_erase(const char *args_str,
-                                            char *response_output_buf, uint16_t response_output_buf_len);
+uint8_t TCMDEXEC_stm32_internal_flash_page_erase(const char *args_str,
+                                                 char *response_output_buf, uint16_t response_output_buf_len);
+
+uint8_t TCMDEXEC_stm32_internal_flash_bank_erase(const char *args_str,
+                                                 char *response_output_buf, uint16_t response_output_buf_len);
 
 uint8_t TCMDEXEC_stm32_internal_flash_get_option_bytes(const char *args_str,
                                                        char *response_output_buf, uint16_t response_output_buf_len);
 
 uint8_t TCMDEXEC_stm32_internal_flash_set_active_flash_bank(const char *args_str,
-                                                       char *response_output_buf, uint16_t response_output_buf_len);
+                                                            char *response_output_buf, uint16_t response_output_buf_len);
 
 uint8_t TCMDEXEC_stm32_internal_flash_get_active_flash_bank(const char *args_str,
                                                        char *response_output_buf, uint16_t response_output_buf_len);
@@ -27,5 +30,7 @@ uint8_t TCMDEXEC_stm32_internal_flash_calculate_sha256(
     uint16_t response_output_buf_len
 );
 
+uint8_t TCMDEXEC_stm32_internal_flash_write_file_to_internal_flash(const char *args_str,
+                                                                   char *response_output_buf, uint16_t response_output_buf_len);
 
 #endif /* INCLUDE_GUARD_STM32_INTERNAL_FLASH_TELECOMMAND_DEFS_H */

--- a/firmware/Core/Src/stm32/stm32_internal_flash_drivers.c
+++ b/firmware/Core/Src/stm32/stm32_internal_flash_drivers.c
@@ -13,68 +13,86 @@
 /// @param data uint8_t buffer containing the data to be written.
 /// @param length Length of the data to be written.
 /// @return 0 on success, > 0 on error
-/// @note Currently, only allowed to write to golden copy region
 /// @note Writes data in chunks of 8 bytes.
 /// Ex: Suppose we wanted to write to address 0x00, and suppose that at address 0x00, the first 8 bytes looks like the following:
 /// [1,2,3,4,5,6,7,8]. If we wanted to write [25,26,27,28], it would result in the following: [25,26,27,28,0,0,0,0], clearing the rest of the bytes.
-uint8_t STM32_internal_flash_write(uint32_t address, uint8_t *data, uint32_t length, STM32_Internal_Flash_Write_Status_t *status)
-{
+STM32_internal_flash_write_return_t STM32_internal_flash_write(
+    uint32_t address, uint8_t *data, uint32_t length, STM32_internal_flash_write_status_t *status
+) {
     status->lock_status = HAL_OK;
     status->unlock_status = HAL_OK;
     status->write_status = HAL_OK;
 
-    if (address < STM32_INTERNAL_FLASH_MEMORY_REGION_GOLDEN_COPY_ADDRESS)
+    if (address < STM32_INTERNAL_FLASH_MEMORY_REGION_FLASH_BANK_1_ADDRESS)
     {
-        return 1;
+        return STM32_INTERNAL_FLASH_WRITE_ADDRESS_TOO_LOW;
     }
 
     const uint32_t end_address = address + length;
-
+    if ((address < STM32_INTERNAL_FLASH_MEMORY_REGION_FLASH_BANK_2_ADDRESS)
+     && (end_address > STM32_INTERNAL_FLASH_MEMORY_REGION_FLASH_BANK_2_ADDRESS))
+    {
+        return STM32_INTERNAL_FLASH_WRITE_ADDRESS_OVERLAPS_BOTH_FLASH_BANKS; // Address range overlaps both flash banks, which we should not allow
+    }
     if (end_address > FLASH_BANK2_END)
     {
-        return 2;
+        return STM32_INTERNAL_FLASH_WRITE_ADDRESS_TOO_HIGH;
     }
 
     status->unlock_status = HAL_FLASH_Unlock();
     if (status->unlock_status != HAL_OK)
     {
-        return 3;
+        return STM32_INTERNAL_FLASH_WRITE_UNLOCK_FAILED;
     }
 
     // Clear all FLASH flags before starting the operation
     __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS);
 
-    for (uint32_t current_address = address; current_address < end_address; current_address += 8)
+    uint32_t offset = 0;
+
+    while (offset < length)
     {
-        uint8_t data_to_write[8] = {0};
+        uint8_t double_word_buf[8];
+        
+        uint32_t bytes_to_copy = (length - offset >= 8) ? 8 : (length - offset);
 
         // If data is not 8 bytes long, it will set the rest of the values to 0.
+        
+        memcpy(double_word_buf, data + offset, bytes_to_copy);
+        if (bytes_to_copy < 8)
+        {
+            // Pad the rest with 0xFF (safe default for flash)
+            memset(double_word_buf + bytes_to_copy, 0xFF, 8 - bytes_to_copy);
+        }
 
-        // current_address - address is the number of bytes we have written
-        // since the beginning of the function
-        memcpy(data_to_write, data + (current_address - address), 8);
+        uint64_t double_word = *(uint64_t *)double_word_buf;
 
-        const uint64_t double_word = *(uint64_t *)(data_to_write);
+        status->write_status = HAL_FLASH_Program(
+            FLASH_TYPEPROGRAM_DOUBLEWORD,
+            address + offset,
+            double_word
+        );
 
-        status->write_status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, current_address, double_word);
         if (status->write_status != HAL_OK)
         {
             break;
         }
+
+        offset += 8;
     }
 
     status->lock_status = HAL_FLASH_Lock();
     if (status->lock_status != HAL_OK)
     {
-        return 4;
+        return STM32_INTERNAL_FLASH_WRITE_LOCK_FAILED;
     }
 
     if (status->write_status != HAL_OK)
     {
-        return 5;
+        return STM32_INTERNAL_FLASH_WRITE_OPERATION_FAILED;
     }
 
-    return 0;
+    return STM32_INTERNAL_FLASH_WRITE_SUCCESS;
 }
 
 /// @brief Reads data from the flash memory
@@ -97,26 +115,56 @@ uint8_t STM32_internal_flash_read(uint32_t address, uint8_t *buffer, uint32_t le
     return 0; // Return success
 }
 
-/// @brief Erase pages from bank 2 of flash memory which is located at 0x08100000
-/// @param start_page_erase what page to start erasing from
-/// @param number_of_pages_to_erase how many pages to erase
+/// @brief Erase pages from provided flash bank of flash memory
+/// @param flash_bank 1 or 2, which flash bank to erase 
+/// @param start_page_erase what page to start erasing from (0-255 for bank 1, 256-511 for bank 2, inclusive)
+/// @param number_of_pages_to_erase how many pages to erase. MAX is 256, MIN is 1.
 /// @param page_error address of page which failed on error, defaults to UINT32_MAX on success
 /// @return 0 on success, 1 if HAL_FLASH_Unlock() failed, 2 if HAL_FLASH_Lock() failed
-uint8_t STM32_internal_flash_erase(uint16_t start_page_erase, uint16_t number_of_pages_to_erase, uint32_t *page_error)
+uint8_t STM32_internal_flash_page_erase(uint8_t flash_bank, uint16_t start_page_erase, uint16_t number_of_pages_to_erase, uint32_t *page_error)
 {
+    if (flash_bank != 1 && flash_bank != 2)
+    {
+        return 1; // Invalid flash bank
+    }
+
+    if (flash_bank == 1 && (start_page_erase > FLASH_BANK_1_END_PAGE))
+    {
+        return 2; // Invalid page range for flash bank 1
+    }
+    
+    if (flash_bank == 2 && (start_page_erase < FLASH_BANK_2_START_PAGE || start_page_erase > FLASH_BANK_2_END_PAGE))
+    {
+        return 3; // Invalid page range for flash bank 2
+    }
+    // Start page and flash bank are valid from this point
+    if ((number_of_pages_to_erase < 1)
+     || (number_of_pages_to_erase > NUMBER_OF_PAGES_PER_FLASH_BANK))
+    {
+        return 4; // Trying to erase more pages than available in the bank
+    }
+
+    const uint16_t end_page = start_page_erase + number_of_pages_to_erase - 1;
+    if ((flash_bank == 1 && end_page > FLASH_BANK_1_END_PAGE)
+     || (flash_bank == 2 && end_page > FLASH_BANK_2_END_PAGE))
+    {
+        return 5; // Trying to erase pages that are out of range for the flash bank
+    }
+    
     __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS);
 
     if (HAL_FLASH_Unlock() != HAL_OK)
     {
-        return 1;
+        return 6;
     }
 
     FLASH_EraseInitTypeDef EraseInitStruct =
         {
             .TypeErase = FLASH_TYPEERASE_PAGES,
-            .Banks = FLASH_BANK_2,
+            .Banks = flash_bank == 1 ? FLASH_BANK_1 : FLASH_BANK_2,
             .Page = start_page_erase,
-            .NbPages = number_of_pages_to_erase};
+            .NbPages = number_of_pages_to_erase
+        };
 
     // page error is uint32_t max on success, contains address of page which failed on error, check
     // stm32l4xx_hal_flash_ex.h for more information or the docs for HAL_FLASHEx_Erase
@@ -124,17 +172,72 @@ uint8_t STM32_internal_flash_erase(uint16_t start_page_erase, uint16_t number_of
 
     if (HAL_FLASH_Lock() != HAL_OK)
     {
-        return 2;
+        return 7;
     }
 
     switch (erase_status)
     {
     case HAL_ERROR:
-        return 3;
+        return 8;
     case HAL_BUSY:
-        return 4;
+        return 9;
     case HAL_TIMEOUT:
+        return 10;
+    // must be HAL_OK
+    default:
+        return 0;
+    }
+}
+
+/// @brief Erase flash bank
+/// @param flash_bank 1 or 2, which flash bank to erase 
+/// @param page_error address of page which failed on error, defaults to UINT32_MAX on success
+/// @return 0 on success, more than 0 on error
+uint8_t STM32_internal_flash_bank_erase(uint8_t flash_bank, uint32_t *bank_erase_error)
+{
+    const uint8_t current_active_flash_bank = STM32_internal_flash_get_active_flash_bank();
+
+    if (flash_bank == current_active_flash_bank)
+    {
+        return 1; // Cannot erase the active flash bank
+    }
+    if (flash_bank != 1 && flash_bank != 2)
+    {
+        return 2; // Invalid flash bank
+    }
+
+    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS);
+
+    if (HAL_FLASH_Unlock() != HAL_OK)
+    {
+        return 3;
+    }
+
+    FLASH_EraseInitTypeDef EraseInitStruct =
+        {
+            .TypeErase = FLASH_TYPEERASE_MASSERASE,
+            .Banks = flash_bank == 1 ? FLASH_BANK_1 : FLASH_BANK_2,
+            .Page = 0,
+            .NbPages = NUMBER_OF_PAGES_PER_FLASH_BANK
+        };
+
+    // page error is uint32_t max on success, contains address of page which failed on error, check
+    // stm32l4xx_hal_flash_ex.h for more information or the docs for HAL_FLASHEx_Erase
+    const HAL_StatusTypeDef erase_status = HAL_FLASHEx_Erase(&EraseInitStruct, bank_erase_error);
+
+    if (HAL_FLASH_Lock() != HAL_OK)
+    {
+        return 4;
+    }
+
+    switch (erase_status)
+    {
+    case HAL_ERROR:
         return 5;
+    case HAL_BUSY:
+        return 6;
+    case HAL_TIMEOUT:
+        return 7;
     // must be HAL_OK
     default:
         return 0;
@@ -198,11 +301,13 @@ uint8_t STM32_internal_flash_set_active_flash_bank(uint8_t wanted_active_flash_b
     }
 
     // Launch the option byte loading to apply changes
+    // This will reset the device and load the application in the desired flash bank
     if (HAL_FLASH_OB_Launch() != HAL_OK)
     {
         return 40;
     }
 
+    // Only reachable if loading flash bank was unnsuccessful
     if (HAL_FLASH_OB_Lock() != HAL_OK)
     {
         return 50;

--- a/firmware/Core/Src/telecommands/stm32_internal_flash_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/stm32_internal_flash_telecommand_defs.c
@@ -1,40 +1,51 @@
 #include "telecommands/stm32_internal_flash_telecommand_defs.h"
+
 #include "telecommand_exec/telecommand_args_helpers.h"
 #include "stm32/stm32_internal_flash_drivers.h"
 #include "transforms/arrays.h"
+#include "littlefs/littlefs_helper.h"
+#include "log/log.h"
 
 #include "stm32l4xx_hal.h"
+
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 
 /// @brief Write data to the internal flash bank starting from address 0x08100000
 /// @param args_str
-/// - Arg 0: The data in hex format to write
-/// - Arg 1: The offset to start writing from
+/// - Arg 0: Address to start writing from in hex format 
+/// - Arg 1: The data in hex format to write up to PAGESIZE bytes (0x1000 bytes)
 /// @note This telecommand is only for testing purposes, it is purposfully not fully fleshed out
 /// as there is no intention on using this. Update as needed
 //// @return 0 on success, > 0 on error
 uint8_t TCMDEXEC_stm32_internal_flash_write(const char *args_str, char *response_output_buf, uint16_t response_output_buf_len)
 {
+    uint8_t address_buf[4] = {0};
+    uint16_t address_len = 0;
+    const uint8_t parse_address_res = TCMD_extract_hex_array_arg(args_str, 0, address_buf, sizeof(address_buf), &address_len);
+    if (parse_address_res != 0)
+    {
+        snprintf(response_output_buf, response_output_buf_len, "Error Parsing Arg 0: %u", parse_address_res);
+        return 1;
+    }
+
     uint8_t write_hex_buffer[PAGESIZE] = {0};
     uint16_t write_hex_buffer_len = 0;
-    const uint8_t parse_hex_buffer_res = TCMD_extract_hex_array_arg(args_str, 0, write_hex_buffer, sizeof(write_hex_buffer), &write_hex_buffer_len);
+    const uint8_t parse_hex_buffer_res = TCMD_extract_hex_array_arg(args_str, 1, write_hex_buffer, sizeof(write_hex_buffer), &write_hex_buffer_len);
     if (parse_hex_buffer_res != 0)
     {
-        snprintf(response_output_buf, response_output_buf_len, "Error Parsing Arg 0: %u", parse_hex_buffer_res);
-        return 1;
+        snprintf(response_output_buf, response_output_buf_len, "Error Parsing Arg 1: %u", parse_hex_buffer_res);
+        return 2;
     }
+    
+    const uint32_t address = (address_buf[0] << 24) |
+                             (address_buf[1] << 16) |
+                             (address_buf[2] << 8) |
+                             address_buf[3]; // Convert to 32-bit address
 
-    uint64_t offset = 0;
-    const uint8_t parse_offset_res = TCMD_extract_uint64_arg(args_str, strlen(args_str), 1, &offset);
-    if (parse_offset_res != 0)
-    {
-        snprintf(response_output_buf, response_output_buf_len, "Error Parsing Arg 1: %u", parse_offset_res);
-        return 1;
-    }
-
-    STM32_Internal_Flash_Write_Status_t status;
-    const uint8_t write_res = STM32_internal_flash_write(STM32_INTERNAL_FLASH_MEMORY_REGION_GOLDEN_COPY_ADDRESS + offset, write_hex_buffer, write_hex_buffer_len, &status);
+    STM32_internal_flash_write_status_t status;
+    const STM32_internal_flash_write_return_t write_res = STM32_internal_flash_write(address, write_hex_buffer, write_hex_buffer_len, &status);
     if (write_res != 0)
     {
         snprintf(response_output_buf, response_output_buf_len, "Error writing to flash: %u\nLock Status: %u\nUnlock Status: %u\nWrite Status: %u", write_res, status.lock_status, status.unlock_status, status.write_status);
@@ -45,14 +56,15 @@ uint8_t TCMDEXEC_stm32_internal_flash_write(const char *args_str, char *response
 
 /// @brief Read data from the internal flash bank
 /// @param args_str
-/// - Arg 0: The address to start reading from
+/// - Arg 0: The address to start reading from in hex
 /// - Arg 1: The number of bytes to read as a uint64_t
 //// @return 0 on success, > 0 on error
 uint8_t TCMDEXEC_stm32_internal_flash_read(const char *args_str, char *response_output_buf, uint16_t response_output_buf_len)
 {
+    uint8_t address_buf[4] = {0};
+    uint16_t address_len = 0;
+    const uint8_t parse_address_res = TCMD_extract_hex_array_arg(args_str, 0, address_buf, sizeof(address_buf), &address_len);
 
-    uint64_t address = 0;
-    const uint8_t parse_address_res = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &address);
     if (parse_address_res != 0)
     {
         snprintf(response_output_buf, response_output_buf_len, "Error Parsing Arg 0: %u", parse_address_res);
@@ -64,58 +76,106 @@ uint8_t TCMDEXEC_stm32_internal_flash_read(const char *args_str, char *response_
     if (parse_res != 0)
     {
         snprintf(response_output_buf, response_output_buf_len, "Error Parsing Arg 1: %u", parse_res);
-        return 1;
+        return 2;
     }
 
     uint8_t read_buffer[number_of_bytes_to_read];
+    const uint32_t address = (address_buf[0] << 24) |
+                             (address_buf[1] << 16) |
+                             (address_buf[2] << 8) |
+                             address_buf[3]; // Convert to 32-bit address
     const uint8_t res = STM32_internal_flash_read(address, read_buffer, sizeof(read_buffer));
     if (res != 0)
     {
         snprintf(response_output_buf, response_output_buf_len, "Error: %u", res);
-        return 1;
+        return 3;
     }
-    for (uint64_t i = 0; i < number_of_bytes_to_read; i++)
+    char *p = response_output_buf;
+    for (uint64_t i = 0; i < number_of_bytes_to_read && (p - response_output_buf + 2 < response_output_buf_len); i++)
     {
-        snprintf(response_output_buf + (i * 2), response_output_buf_len - (i * 2), "%02X", read_buffer[i]);
+        p += snprintf(p, response_output_buf_len - (p - response_output_buf), "%02X", read_buffer[i]);
     }
 
     return 0;
 }
 
 /// @brief Erase a range of pages in the internal flash bank.
-/// Only Erases for Flash Bank 2.
 /// @param args_str
-/// - Arg 0: The starting page to erase as a uint64_t
-/// - Arg 1: The number of pages to erase as a uint64_t
+/// - Arg 0: Flash Bank to erase (1 or 2)
+/// - Arg 1: The starting page to erase (0-255 for bank 1, 256-511 for bank 2)
+/// - Arg 2: The number of pages to erase (1-256)
 //// @return 0 on success, > 0 on error
-uint8_t TCMDEXEC_stm32_internal_flash_erase(const char *args_str, char *response_output_buf, uint16_t response_output_buf_len)
+uint8_t TCMDEXEC_stm32_internal_flash_page_erase(const char *args_str, char *response_output_buf, uint16_t response_output_buf_len)
 {
+    uint64_t flash_bank_to_erase = 0;
+    const uint8_t flash_bank_to_erase_parse_res = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &flash_bank_to_erase);
+    if (flash_bank_to_erase_parse_res != 0)
+    {
+        snprintf(response_output_buf, response_output_buf_len, "Error Parsing arg 0: %u", flash_bank_to_erase_parse_res);
+        return 1;
+    }
+    if (flash_bank_to_erase != 1 && flash_bank_to_erase != 2)
+    {
+        snprintf(response_output_buf, response_output_buf_len, "Error: Only valid options for flash banks: 1 or 2, got: %u", (uint8_t)flash_bank_to_erase);
+        return 1;
+    }
     uint64_t start_page_erase = 0;
 
-    const uint8_t start_page_erase_parse_res = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &start_page_erase);
+    const uint8_t start_page_erase_parse_res = TCMD_extract_uint64_arg(args_str, strlen(args_str), 1, &start_page_erase);
     if (start_page_erase_parse_res != 0)
     {
-        snprintf(response_output_buf, response_output_buf_len, "Error Parsing arg 0: %u", start_page_erase_parse_res);
+        snprintf(response_output_buf, response_output_buf_len, "Error Parsing arg 1: %u", start_page_erase_parse_res);
         return 1;
     }
 
     uint64_t number_of_pages_to_erase = 0;
-    const uint8_t number_of_pages_to_erase_parse_res = TCMD_extract_uint64_arg(args_str, strlen(args_str), 1, &number_of_pages_to_erase);
+    const uint8_t number_of_pages_to_erase_parse_res = TCMD_extract_uint64_arg(args_str, strlen(args_str), 2, &number_of_pages_to_erase);
     if (number_of_pages_to_erase_parse_res != 0)
     {
-        snprintf(response_output_buf, response_output_buf_len, "Error Parsing arg 1: %u", number_of_pages_to_erase_parse_res);
+        snprintf(response_output_buf, response_output_buf_len, "Error Parsing arg 2: %u", number_of_pages_to_erase_parse_res);
         return 1;
     }
 
     uint32_t page_error = 0;
-    const uint8_t erase_res = STM32_internal_flash_erase((uint16_t)start_page_erase, (uint16_t)number_of_pages_to_erase, &page_error);
+    const uint8_t erase_res = STM32_internal_flash_page_erase((uint8_t)flash_bank_to_erase, (uint16_t)start_page_erase, (uint16_t)number_of_pages_to_erase, &page_error);
     if (erase_res != 0)
     {
-        snprintf(response_output_buf, response_output_buf_len, "Error erasing pages: %u - %u, error: %u, page error: %lu", (uint16_t)start_page_erase, (uint16_t)start_page_erase + (uint16_t)number_of_pages_to_erase, erase_res, page_error);
+        snprintf(response_output_buf, response_output_buf_len, "Error erasing pages: %u -> %u, error: %u, page error: %lu", (uint16_t)start_page_erase, (uint16_t)start_page_erase + (uint16_t)number_of_pages_to_erase, erase_res, page_error);
         return 1;
     }
     return 0;
 }
+
+/// @brief Erase an entire flash bank
+/// @param args_str
+/// - Arg 0: Flash Bank to erase (1 or 2)
+/// @return 0 on success, > 0 on error
+uint8_t TCMDEXEC_stm32_internal_flash_bank_erase(const char *args_str, char *response_output_buf, uint16_t response_output_buf_len)
+{
+    uint64_t flash_bank_to_erase = 0;
+    const uint8_t flash_bank_to_erase_parse_res = TCMD_extract_uint64_arg(args_str, strlen(args_str), 0, &flash_bank_to_erase);
+    if (flash_bank_to_erase_parse_res != 0)
+    {
+        snprintf(response_output_buf, response_output_buf_len, "Error Parsing arg 0: %u", flash_bank_to_erase_parse_res);
+        return 1;
+    }
+
+    if (flash_bank_to_erase != 1 && flash_bank_to_erase != 2)
+    {
+        snprintf(response_output_buf, response_output_buf_len, "Error: Only valid options for flash banks: 1 or 2, got: %u", (uint8_t)flash_bank_to_erase);
+        return 2;
+    }
+    uint32_t bank_erase_error = 0;
+    const uint8_t erase_res = STM32_internal_flash_bank_erase((uint8_t)flash_bank_to_erase, &bank_erase_error);
+    if (erase_res != 0)
+    {
+        snprintf(response_output_buf, response_output_buf_len, "Error erasing bank: %u", (uint8_t)flash_bank_to_erase);
+        return 3;
+    }
+    snprintf(response_output_buf, response_output_buf_len, "Successfully erased flash bank: %u", (uint8_t)flash_bank_to_erase);
+    return 0;
+}
+
 
 /// @brief Get the option bytes configuration from the stm32 internal flash memory
 /// @param args_str No args
@@ -260,4 +320,135 @@ uint8_t TCMDEXEC_stm32_internal_flash_calculate_sha256(
         bank_num
     );
     return 0;
+}
+/// @brief Telecommand: Write a file to internal flash memory from LittleFS.
+/// @param args_str
+/// - Arg 0: File name to read from LittleFS
+/// - Arg 1: Length to read from the file (in bytes). The maximum length to read is 4096 bytes (4kB).
+/// - Arg 2: Offset within the file to start reading (in bytes)
+/// - Arg 3: Address in internal flash memory to write to (in base 10)
+/// @note To use properly:
+///       - The internal flash memory region must be erased before writing.
+///       - The address must be in the main flash memory region (0x08000000 to 0x081FFFFF).
+uint8_t TCMDEXEC_stm32_internal_flash_write_file_to_internal_flash(const char *args_str, char *response_output_buf, uint16_t response_output_buf_len)
+{
+    const uint32_t args_str_len = strlen(args_str);
+
+    char arg_file_name[LFS_MAX_PATH_LENGTH];
+    const uint8_t parse_file_name_result = TCMD_extract_string_arg(args_str, 0, arg_file_name, sizeof(arg_file_name));
+    if (parse_file_name_result != 0) {
+        snprintf(
+            response_output_buf,
+            response_output_buf_len,
+            "Error parsing file name arg: Error %d", parse_file_name_result);
+        return 1;
+    }
+
+    // Get length of data to read
+    uint64_t read_length = 0;
+    const uint8_t parse_length_result = TCMD_extract_uint64_arg(args_str, args_str_len, 1, &read_length);
+    if (parse_length_result != 0) {
+        snprintf(
+            response_output_buf,
+            response_output_buf_len,
+            "Error parsing write length arg: Error %d", parse_length_result);
+        return 2;
+    }
+
+    // Ensure the read length is not too large
+    // Limiting it to 4kB (4096 bytes)
+    // because the smallest amount of flash memory we can erase is a page, which is 1kB
+    if (read_length > FLASH_PAGE_SIZE) { // 4kB max
+        snprintf(
+            response_output_buf,
+            response_output_buf_len,
+            "Error: Write length too large. Max is %lu bytes.", (unsigned long)FLASH_PAGE_SIZE);
+        return 3;
+    }
+    // Get offset to read from in file
+    uint64_t read_offset = 0;
+    const uint8_t parse_offset_result = TCMD_extract_uint64_arg(args_str, args_str_len, 2, &read_offset);
+    if (parse_offset_result != 0) {
+        snprintf(
+            response_output_buf,
+            response_output_buf_len,
+            "Error parsing read offset arg: Error %d", parse_offset_result);
+        return 4;
+    }
+
+    // Get address to write to
+    uint64_t write_address = 0;
+    const uint8_t parse_address_result = TCMD_extract_uint64_arg(args_str, args_str_len, 3, &write_address);
+    
+    if (parse_address_result != 0) {
+        snprintf(
+            response_output_buf,
+            response_output_buf_len,
+            "Error parsing write address arg: Error %d", parse_address_result);
+        return 5;
+    }
+
+    if (IS_FLASH_MAIN_MEM_ADDRESS(write_address) == false) {
+        // Address is not in the main flash memory region
+        snprintf(
+            response_output_buf, response_output_buf_len,
+            "Error: Address 0x%08lX is not in the main flash memory region.",
+            (unsigned long)write_address
+        );
+        return 6;
+    }
+
+    LOG_message(LOG_SYSTEM_ALL, LOG_SEVERITY_DEBUG, LOG_SINK_ALL,
+                "TCMDEXEC_fs_write_file_to_internal_flash: Writing %lu bytes from file '%s' to internal flash at address 0x%08lX, read_offset %lu",
+                (unsigned long)read_length, arg_file_name, (unsigned long)write_address, (unsigned long)read_offset);
+
+    // Read the file from LittleFS
+    static uint8_t file_content[FLASH_PAGE_SIZE]; // Max size is 4kB
+    memset(file_content, 0, sizeof(file_content));
+    const int32_t bytes_read = LFS_read_file(arg_file_name, read_offset, file_content, read_length);
+    if (bytes_read <= 0) { // consider empty file as invalid
+        snprintf(response_output_buf, response_output_buf_len, "Error reading file: %ld", bytes_read);
+        return 7;
+    }
+
+    // If region is not erased, it will fail
+    STM32_internal_flash_write_status_t write_status = {0};
+    const STM32_internal_flash_write_return_t write_result = STM32_internal_flash_write(write_address, file_content, bytes_read, &write_status);
+    LOG_message(LOG_SYSTEM_ALL, LOG_SEVERITY_DEBUG, LOG_SINK_ALL,
+                "Write Status=%d, Lock Status=%d, Unlock Status=%d",
+        write_status.write_status, write_status.lock_status, write_status.unlock_status);
+    // Handle specific error codes
+    switch (write_result)
+    {
+        case STM32_INTERNAL_FLASH_WRITE_SUCCESS:
+            snprintf(response_output_buf,
+                     response_output_buf_len,
+                     "Successfully wrote %lu (0x%08lX) bytes from file '%s' to internal flash at address 0x%08lX",
+                     (uint32_t)bytes_read, (uint32_t)bytes_read, arg_file_name, (uint32_t)write_address);
+            return 0;
+        case STM32_INTERNAL_FLASH_WRITE_ADDRESS_TOO_LOW:
+            snprintf(response_output_buf, response_output_buf_len, "Error: Address too low for internal flash write.");
+            break;
+        case STM32_INTERNAL_FLASH_WRITE_ADDRESS_OVERLAPS_BOTH_FLASH_BANKS:
+            snprintf(response_output_buf, response_output_buf_len, "Error: Write address overlaps both flash banks, which is not allowed.");
+            break;
+        case STM32_INTERNAL_FLASH_WRITE_ADDRESS_TOO_HIGH:
+            snprintf(response_output_buf, response_output_buf_len, "Error: Write exceeds internal flash memory bounds.");
+            break;
+        case STM32_INTERNAL_FLASH_WRITE_UNLOCK_FAILED:
+            snprintf(response_output_buf, response_output_buf_len, "Error: Failed to unlock internal flash for writing.");
+            break;
+        case STM32_INTERNAL_FLASH_WRITE_LOCK_FAILED:
+            snprintf(response_output_buf, response_output_buf_len, "Error: Failed to lock internal flash after writing.");
+            break;
+        case STM32_INTERNAL_FLASH_WRITE_OPERATION_FAILED:
+            snprintf(response_output_buf, response_output_buf_len, "Error: Internal flash write operation failed.");
+            break;
+        default:
+            snprintf(response_output_buf, response_output_buf_len, "Error: Unknown error during internal flash write.");
+            break;
+    }
+    // Must be error
+    return 8;
+
 }

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -1247,7 +1247,7 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .tcmd_name = "stm32_internal_flash_read",
         .tcmd_func = TCMDEXEC_stm32_internal_flash_read,
         .number_of_args = 2,
-        .readiness_level = TCMD_READINESS_LEVEL_GROUND_USAGE_ONLY,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
     },
 
     {
@@ -1258,31 +1258,42 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
     },
 
     {
-        .tcmd_name = "stm32_internal_flash_erase",
-        .tcmd_func = TCMDEXEC_stm32_internal_flash_erase,
-        .number_of_args = 2,
+        .tcmd_name = "stm32_internal_flash_page_erase",
+        .tcmd_func = TCMDEXEC_stm32_internal_flash_page_erase,
+        .number_of_args = 3,
         .readiness_level = TCMD_READINESS_LEVEL_GROUND_USAGE_ONLY,
     },
-
+    {
+        .tcmd_name = "stm32_internal_flash_bank_erase",
+        .tcmd_func = TCMDEXEC_stm32_internal_flash_bank_erase,
+        .number_of_args = 1,
+        .readiness_level = TCMD_READINESS_LEVEL_GROUND_USAGE_ONLY,
+    },
     {
         .tcmd_name = "stm32_internal_flash_get_option_bytes",
         .tcmd_func = TCMDEXEC_stm32_internal_flash_get_option_bytes,
         .number_of_args = 0,
-        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+        .readiness_level = TCMD_READINESS_LEVEL_GROUND_USAGE_ONLY,
     },
 
     {
         .tcmd_name = "stm32_internal_flash_get_active_flash_bank",
         .tcmd_func = TCMDEXEC_stm32_internal_flash_get_active_flash_bank,
         .number_of_args = 0,
-        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+        .readiness_level = TCMD_READINESS_LEVEL_GROUND_USAGE_ONLY,
     },
     
     {
         .tcmd_name = "stm32_internal_flash_set_active_flash_bank",
         .tcmd_func = TCMDEXEC_stm32_internal_flash_set_active_flash_bank,
         .number_of_args = 1,
-        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+        .readiness_level = TCMD_READINESS_LEVEL_GROUND_USAGE_ONLY,
+    },
+    {
+        .tcmd_name = "stm32_internal_flash_write_file_to_internal_flash",
+        .tcmd_func = TCMDEXEC_stm32_internal_flash_write_file_to_internal_flash,
+        .number_of_args = 4,
+        .readiness_level = TCMD_READINESS_LEVEL_GROUND_USAGE_ONLY,
     },
 
     {

--- a/firmware/STM32L4R5XX_FLASH.ld
+++ b/firmware/STM32L4R5XX_FLASH.ld
@@ -64,7 +64,8 @@ MEMORY
 RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 640K
 RAM2 (xrw)      : ORIGIN = 0x10000000, LENGTH = 64K
 RAM3 (xrw)      : ORIGIN = 0x20040000, LENGTH = 384K
-FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 2048K
+FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 1024K
+FLASH_BANK_2 (xrw) : ORIGIN = 0x8100000, LENGTH = 1024K /* Starts from FLASH origin + Flash length */
 }
 
 /* Define output sections */


### PR DESCRIPTION
Related to Issue #25 (OTA upgrades). Resolves #504.

Supersedes PR #514, which contains a not-yet-rebased version of this code.

This code isn't really intended to be used in orbit, but is reasonable to include as a backup, and/or in case we need to hook into it using the `exec_blob` arbitrary code functionality (unlikely).

Credit: This code was written by @NuclearTea - thank you :) 

Blast radius: Very small. This PR updates isolated telecommands that had a 0% chance of being used before, and have a 1% chance of being used now. 