### PR TITLE
Add `freertos_heap_stats_json` telecommand

### DIFF
--- a/firmware/Core/Inc/telecommands/freertos_telecommand_defs.h
+++ b/firmware/Core/Inc/telecommands/freertos_telecommand_defs.h
@@ -14,4 +14,10 @@ uint8_t TCMDEXEC_freertos_demo_stack_usage(
     char *response_output_buf, uint16_t response_output_buf_len
 );
 
+uint8_t TCMDEXEC_freertos_heap_stats_json(
+    const char *args_str,
+    char *response_output_buf, uint16_t response_output_buf_len
+);
+
+
 #endif // INCLUDE_GUARD__FREERTOS_TELECOMMAND_DEFINITIONS_H

--- a/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
@@ -110,3 +110,44 @@ uint8_t TCMDEXEC_freertos_demo_stack_usage(
     
     return 0;
 }
+
+/// @brief Telecommand that returns FreeRTOS heap statistics as JSON.
+/// @param args_str No arguments.
+/// @param response_output_buf The buffer to write the response to
+/// @param response_output_buf_len The maximum length of the response_output_buf (its size)
+/// @return 0 if successful, >0 if an error occurred
+/// @note Added after CTS-SAT-1 launch. Not available on FrontierSat.
+uint8_t TCMDEXEC_freertos_heap_stats_json(
+    const char *args_str,
+    char *response_output_buf, uint16_t response_output_buf_len
+) {
+    HeapStats_t heap_stats;
+    vPortGetHeapStats(&heap_stats);
+
+    const UBaseType_t outstanding_allocations =
+        heap_stats.xNumberOfSuccessfulAllocations - heap_stats.xNumberOfSuccessfulFrees;
+
+    snprintf(
+        response_output_buf, response_output_buf_len,
+        "{"
+            "\"available_heap_bytes\":%zu,"
+            "\"largest_free_block_bytes\":%zu,"
+            "\"smallest_free_block_bytes\":%zu,"
+            "\"num_free_blocks\":%zu,"
+            "\"min_ever_free_bytes\":%zu,"
+            "\"num_successful_allocs\":%zu,"
+            "\"num_successful_frees\":%zu,"
+            "\"outstanding_allocations\":%lu"
+        "}",
+        heap_stats.xAvailableHeapSpaceInBytes,
+        heap_stats.xSizeOfLargestFreeBlockInBytes,
+        heap_stats.xSizeOfSmallestFreeBlockInBytes,
+        heap_stats.xNumberOfFreeBlocks,
+        heap_stats.xMinimumEverFreeBytesRemaining,
+        heap_stats.xNumberOfSuccessfulAllocations,
+        heap_stats.xNumberOfSuccessfulFrees,
+        (uint32_t)outstanding_allocations
+    );
+
+    return 0;
+}

--- a/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
+++ b/firmware/Core/Src/telecommands/freertos_telecommand_defs.c
@@ -130,13 +130,13 @@ uint8_t TCMDEXEC_freertos_heap_stats_json(
     snprintf(
         response_output_buf, response_output_buf_len,
         "{"
-            "\"available_heap_bytes\":%zu,"
-            "\"largest_free_block_bytes\":%zu,"
-            "\"smallest_free_block_bytes\":%zu,"
-            "\"num_free_blocks\":%zu,"
-            "\"min_ever_free_bytes\":%zu,"
-            "\"num_successful_allocs\":%zu,"
-            "\"num_successful_frees\":%zu,"
+            "\"available_heap_bytes\":%u,"
+            "\"largest_free_block_bytes\":%u,"
+            "\"smallest_free_block_bytes\":%u,"
+            "\"num_free_blocks\":%u,"
+            "\"min_ever_free_bytes\":%u,"
+            "\"num_successful_allocs\":%u,"
+            "\"num_successful_frees\":%u,"
             "\"outstanding_allocations\":%lu"
         "}",
         heap_stats.xAvailableHeapSpaceInBytes,

--- a/firmware/Core/Src/telecommands/telecommand_definitions.c
+++ b/firmware/Core/Src/telecommands/telecommand_definitions.c
@@ -1049,6 +1049,13 @@ const TCMD_TelecommandDefinition_t TCMD_telecommand_definitions[] = {
         .readiness_level = TCMD_READINESS_LEVEL_FLIGHT_TESTING, // Can cause crash via stack overflow.
     },
 
+    { // Note: Added after CTS-SAT-1 launch.
+        .tcmd_name = "freertos_heap_stats_json",
+        .tcmd_func = TCMDEXEC_freertos_heap_stats_json,
+        .number_of_args = 0,
+        .readiness_level = TCMD_READINESS_LEVEL_FOR_OPERATION,
+    },
+
     // ****************** END SECTION: freertos_telecommand_defs ******************
 
 


### PR DESCRIPTION
Used in debugging an anomaly during CTS-SAT-1 operations where >20 attempted bulk downlinks caused LFS error `LFS_ERR_NOMEM (-12)`.