### PR TITLE
Blob: Extended Beacon v4 (tiny fixes)

### DIFF
--- a/docs/Mission_Operations/Blobs_List.md
+++ b/docs/Mission_Operations/Blobs_List.md
@@ -151,6 +151,7 @@ CTS1+exec_blob_from_fs(blobs/extended_beacon_v4.blob,0,9000)!
     * Has packet ID `COMMS_PACKET_TYPE_BEACON_EXTENDED = 0x20`
     * Change 1 (fix): MPI temperature fetching now supports negative Celsius temperatures.
     * Change 2: Prevent bouncing in the `pending_queued_tcmd_count` field between extended and basic beacons.
+    * Improvement: Use error enum for error reporting.
 
 ## `blobs/adcs_get_latest_sd_file_v1.blob`
 

--- a/docs/Mission_Operations/Blobs_List.md
+++ b/docs/Mission_Operations/Blobs_List.md
@@ -87,7 +87,7 @@ CTS1+comms_bulk_file_downlink_start(adcs_data/your_file.run,0,0)@tsexec=123456@t
 CTS1+exec_blob_from_fs(blobs/bulk_downlink_start_v2.blob,0,adcs_data/your_file.run;0;0)@tsexec=123456@tssent=789!
 ```
 
-## `blobs/extended_beacon_v{2,3}.blob`
+## `blobs/extended_beacon_v{2,3,4}.blob`
 
 ### Description
 
@@ -105,8 +105,8 @@ Running this blob triggers the extended beacon.
 // that specified interval.
 //
 // Usage Example:
-// After uplinking the blob as "blobs/extended_beacon_v3.blob", run:
-// CTS1+exec_blob_from_fs(blobs/extended_beacon_v3.blob,0,9000)!
+// After uplinking the blob as "blobs/extended_beacon_v4.blob", run:
+// CTS1+exec_blob_from_fs(blobs/extended_beacon_v4.blob,0,9000)!
 ```
 
 ### Notes
@@ -122,7 +122,7 @@ Running this blob triggers the extended beacon.
     a command to run this blob on every uplink pass, whether or not it's already running.
 5. To stop the recurring rescheduling of this blob after starting it, you can use reboot, or
     use `CTS1+agenda_delete_by_name(exec_blob_from_fs)`, or `CTS1+agenda_delete_all()`, or
-    `CTS1+exec_blob_from_fs(blobs/extended_beacon_v3.blob,0,0)!` (which will run one last time,
+    `CTS1+exec_blob_from_fs(blobs/extended_beacon_v4.blob,0,0)!` (which will run one last time,
     then cancel itself).
 
 ### Example Usage
@@ -130,7 +130,7 @@ Running this blob triggers the extended beacon.
 To start the extended beacon, repeating every 9 seconds, run:
 
 ```
-CTS1+exec_blob_from_fs(blobs/extended_beacon_v3.blob,0,9000)!
+CTS1+exec_blob_from_fs(blobs/extended_beacon_v4.blob,0,9000)!
 ```
 
 ### Versions
@@ -140,11 +140,17 @@ CTS1+exec_blob_from_fs(blobs/extended_beacon_v3.blob,0,9000)!
     * Has version string ` X2\0`
     * Has packet ID `COMMS_PACKET_TYPE_BEACON_EXTENDED = 0x20`
 * v3
-    * Tiny upgrade to v2. No changes to format.
+    * Tiny upgrade to v2. No changes to the format.
     * Has version string ` X3\0`
     * Has packet ID `COMMS_PACKET_TYPE_BEACON_EXTENDED = 0x20`
     * Change 1: Disable the log message with the args_str. Changed to log level DEBUG.
     * Change 2: Don't increment the `total_tcmd_queued_count` counter (which is downlinked in all beacon packets) when enqueing the blob to re-run.
+* v4
+    * Tiny upgrade to v3. No changes to the format.
+    * Has version string ` X4\0`
+    * Has packet ID `COMMS_PACKET_TYPE_BEACON_EXTENDED = 0x20`
+    * Change 1 (fix): MPI temperature fetching now supports negative Celsius temperatures.
+    * Change 2: Prevent bouncing in the `pending_queued_tcmd_count` field between extended and basic beacons.
 
 ## `blobs/adcs_get_latest_sd_file_v1.blob`
 

--- a/firmware/Core/Src/rtos_tasks/rtos_mpi_tasks.c
+++ b/firmware/Core/Src/rtos_tasks/rtos_mpi_tasks.c
@@ -120,7 +120,7 @@ int32_t read_avg_temperature_cC_from_mpi_data_buffer(
             large_buffer[i + 2] == sync_pattern[2] &&
             large_buffer[i + 3] == sync_pattern[3]
         ) {
-            // Ensure temperature bytes are inside buffer.
+            // Ensure temperature bytes are inside buffer. // TODO: Remove this unnecessary if-statement.
             if (i + 7 < MPI_science_buffer_len) {
                 // Assumption: Negative values will be handled gracefully by C, just
                 // by storing the value in a signed int.
@@ -131,7 +131,7 @@ int32_t read_avg_temperature_cC_from_mpi_data_buffer(
                 // Convert to centi-Celsius (https://github.com/CalgaryToSpace/CTS-SAT-1-OBC-Firmware/issues/462):
                 // Celsius = raw_temp / 128.0
                 // centi-Celsius = (raw_temp * 100) / 128
-                const int32_t temp_centi = (raw_temp * 100U) / 128U;
+                const int32_t temp_centi = (raw_temp * 100U) / 128U; // TODO: Fix per https://github.com/CalgaryToSpace/CTS-SAT-1-OBC-Firmware/issues/667
 
                 temp_sum_centi += temp_centi;
                 temp_count++;

--- a/misc_tools/exec_blob/extended_beacon_blob/Makefile
+++ b/misc_tools/exec_blob/extended_beacon_blob/Makefile
@@ -36,10 +36,14 @@ LDFLAGS += -Wl,--just-symbols=$(FW_ELF)
 
 TARGET = extended_beacon_blob
 
+# Name the blob is uplinked as (see docs/Mission_Operations/Blobs_List.md).
+BLOB_NAME = extended_beacon_v4
+
 ELF = $(BUILD_DIR)/$(TARGET).elf
 BIN = $(BUILD_DIR)/$(TARGET).bin
+BLOB = $(BUILD_DIR)/$(BLOB_NAME).blob
 
-all: $(BIN)
+all: $(BIN) $(BLOB)
 
 # Ensure build directory exists
 $(BUILD_DIR):
@@ -55,6 +59,10 @@ $(ELF): extended_beacon_blob_main.c $(FW_ELF) | $(BUILD_DIR)
 
 $(BIN): $(ELF)
 	$(OBJCOPY) -O binary $< $@
+
+# Same bytes as the .bin, named as it should be uplinked.
+$(BLOB): $(BIN)
+	cp $< $@
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/misc_tools/exec_blob/extended_beacon_blob/extended_beacon_blob_main.c
+++ b/misc_tools/exec_blob/extended_beacon_blob/extended_beacon_blob_main.c
@@ -281,6 +281,7 @@ typedef struct {
     int16_t adcs_estimated_pitch_angle_cdeg;
     int16_t adcs_estimated_yaw_angle_cdeg;
 
+    // TODO: If adding more fields, then add "distinct_telecommands_pending" which counts the distinct (tcmd_idx, tcmd_args) pairs in the pending queue. Useful to confirm that all uplinks were successful.
 } COMMS_beacon_extended_packet_t;
 
 // Packet size limit:
@@ -559,7 +560,7 @@ static void COMMS_fill_beacon_extended_packet(
     beacon_packet->is_fs_mounted = LFS_is_lfs_mounted;
 
     beacon_packet->total_tcmd_queued_count = TCMD_total_tcmd_queued_count;
-    beacon_packet->pending_queued_tcmd_count = TCMD_get_agenda_used_slots_count();
+    beacon_packet->pending_queued_tcmd_count = TCMD_get_agenda_used_slots_count() + 1; // Since v4, add 1 for the currently executing tcmd. Prevents bouncing between basic and extended beacons.
 
     beacon_packet->total_beacon_count_since_boot = COMMS_total_beacon_count_since_boot;
 

--- a/misc_tools/exec_blob/extended_beacon_blob/extended_beacon_blob_main.c
+++ b/misc_tools/exec_blob/extended_beacon_blob/extended_beacon_blob_main.c
@@ -68,7 +68,7 @@ static const uint32_t LOG_SYSTEM_TELECOMMAND = 1 << 12;
 static const uint32_t LOG_SINK_ALL = (1 << 4) - 1;
 
 static const char ARG_DELIM = ';';
-static const char BLOB_NAME[] = "extended_beacon_blob_v3";
+static const char BLOB_NAME[] = "extended_beacon_blob_v4";
 
 // Global variables defined in the firmware ELF (CTS-SAT-1_FW_rc3.elf).
 extern lfs_t LFS_filesystem;
@@ -99,7 +99,6 @@ extern uint8_t ADCS_i2c_request_telemetry_and_check(uint8_t id, uint8_t* data, u
 extern uint8_t ADCS_get_raw_coarse_sun_sensor_1_to_6(ADCS_raw_coarse_sun_sensor_1_to_6_struct_t *output_struct);
 extern uint8_t ADCS_get_raw_coarse_sun_sensor_7_to_10(ADCS_raw_coarse_sun_sensor_7_to_10_struct_t *output_struct);
 
-extern int32_t read_avg_temperature_cC_from_mpi_data_buffer(volatile uint8_t* large_buffer);
 extern volatile uint32_t MPI_buffer_one_last_filled_uptime_ms;
 extern volatile uint32_t MPI_buffer_two_last_filled_uptime_ms;
 
@@ -188,6 +187,7 @@ typedef struct {
     // "END\0" on basic packets.
     // " X2\0" on extended packets (v2).
     // " X3\0" on extended packets (v3).
+    // " X4\0" on extended packets (v4).
     char end_message[4];
 
     // ====== END OF BASIC BEACON PACKET (DUPLICATED) ========
@@ -358,6 +358,55 @@ static uint16_t integer_sqrt_u32(uint32_t value) {
     return (uint16_t)hi;
 }
 
+
+/// @brief Scan an MPI data buffer, averaging all temperature reports in it.
+/// @param large_buffer MPI data buffer input.
+/// @return Average temperature in 100ths of a degree Celsius (cC). Returns special value -9999 on error.
+/// @note The original version of this function in the CTS-SAT-1 firmware has a bug with negative temperatures
+///      (https://github.com/CalgaryToSpace/CTS-SAT-1-OBC-Firmware/issues/667).
+///      This vendored version fixes the bug.
+static int32_t read_avg_temperature_cC_from_mpi_data_buffer_NEW(
+    volatile uint8_t* large_buffer
+) {
+    const uint8_t sync_pattern[4] = {0x0c, 0xff, 0xff, 0x0c};
+
+    int64_t temp_sum_centi = 0;  // Use int64 to prevent overflow.
+    uint32_t temp_count = 0;
+
+    for (uint32_t i = 0; i + 7 < MPI_science_buffer_len; i++) {
+        // Check sync pattern.
+        if (large_buffer[i + 0] == sync_pattern[0] &&
+            large_buffer[i + 1] == sync_pattern[1] &&
+            large_buffer[i + 2] == sync_pattern[2] &&
+            large_buffer[i + 3] == sync_pattern[3]
+        ) {
+            // Ensure temperature bytes are inside buffer.
+            if (i + 7 < MPI_science_buffer_len) {
+                // Assumption: Negative values will be handled gracefully by C, just
+                // by storing the value in a signed int.
+                const int16_t raw_temp =
+                    ((int16_t)large_buffer[i + 6] << 8) |
+                    (int16_t)large_buffer[i + 7];
+
+                // Convert to centi-Celsius (https://github.com/CalgaryToSpace/CTS-SAT-1-OBC-Firmware/issues/462):
+                // Celsius = raw_temp / 128.0
+                // centi-Celsius = (raw_temp * 100) / 128
+                const int32_t temp_centi = (raw_temp * 100) / 128;
+
+                temp_sum_centi += temp_centi;
+                temp_count++;
+            }
+        }
+    }
+
+    if (temp_count == 0) {
+        return -9999;
+    }
+
+    return (int32_t)(temp_sum_centi / temp_count);
+}
+
+
 /// @brief Dig the current MPI temperature from the data buffer.
 /// @note Based heavily on the inline logic in `rtos_mpi_tasks.c`.
 /// @return Temperature in C, or -99 if MPI never active, or -98 if error calculating temperature.
@@ -367,12 +416,12 @@ static int8_t get_last_mpi_temperature_C() {
 
     // Pick the buffer with the most recent data.
     if (MPI_buffer_one_last_filled_uptime_ms > MPI_buffer_two_last_filled_uptime_ms) {
-        last_mpi_temperature_cC = read_avg_temperature_cC_from_mpi_data_buffer(
+        last_mpi_temperature_cC = read_avg_temperature_cC_from_mpi_data_buffer_NEW(
             MPI_science_buffer_one
         );
     }
     else if (MPI_buffer_two_last_filled_uptime_ms > MPI_buffer_one_last_filled_uptime_ms) {
-        last_mpi_temperature_cC = read_avg_temperature_cC_from_mpi_data_buffer(
+        last_mpi_temperature_cC = read_avg_temperature_cC_from_mpi_data_buffer_NEW(
             MPI_science_buffer_two
         );
     }
@@ -555,7 +604,7 @@ static void COMMS_fill_beacon_extended_packet(
         COMMS_beacon_friendly_message_str,
         strlen(COMMS_beacon_friendly_message_str)
     );
-    memcpy(beacon_packet->end_message, " X3", 4); // Extended beacon packet version.
+    memcpy(beacon_packet->end_message, " X4", 4); // Extended beacon packet version.
 
     // Set the extended beacon packet fields.
 

--- a/misc_tools/exec_blob/extended_beacon_blob/extended_beacon_blob_main.c
+++ b/misc_tools/exec_blob/extended_beacon_blob/extended_beacon_blob_main.c
@@ -9,8 +9,8 @@
 // that specified interval.
 //
 // Usage Example:
-// After uplinking the blob as "blobs/extended_beacon_v3.blob", run:
-// CTS1+exec_blob_from_fs(blobs/extended_beacon_v3.blob,0,9000)!
+// After uplinking the blob as "blobs/extended_beacon_v4.blob", run:
+// CTS1+exec_blob_from_fs(blobs/extended_beacon_v4.blob,0,9000)!
 //
 // Notes:
 //  1. Always use "0" as the second argument (i.e., always run with malloc).
@@ -24,7 +24,7 @@
 //      a command to run this blob on every uplink pass, whether or not it's already running.
 //  5. To stop the recurring rescheduling of this blob after starting it, you can use reboot, or
 //      use `CTS1+agenda_delete_by_name(exec_blob_from_fs)`, or `CTS1+agenda_delete_all()`, or
-//      `CTS1+exec_blob_from_fs(blobs/extended_beacon_v3.blob,0,0)!` (which will run one last time,
+//      `CTS1+exec_blob_from_fs(blobs/extended_beacon_v4.blob,0,0)!` (which will run one last time,
 //      then cancel itself).
 
 #include <stdint.h>

--- a/misc_tools/exec_blob/extended_beacon_blob/extended_beacon_blob_main.c
+++ b/misc_tools/exec_blob/extended_beacon_blob/extended_beacon_blob_main.c
@@ -380,22 +380,19 @@ static int32_t read_avg_temperature_cC_from_mpi_data_buffer_NEW(
             large_buffer[i + 2] == sync_pattern[2] &&
             large_buffer[i + 3] == sync_pattern[3]
         ) {
-            // Ensure temperature bytes are inside buffer.
-            if (i + 7 < MPI_science_buffer_len) {
-                // Assumption: Negative values will be handled gracefully by C, just
-                // by storing the value in a signed int.
-                const int16_t raw_temp =
-                    ((int16_t)large_buffer[i + 6] << 8) |
-                    (int16_t)large_buffer[i + 7];
+            // Assumption: Negative values will be handled gracefully by C, just
+            // by storing the value in a signed int.
+            const int16_t raw_temp =
+                ((int16_t)large_buffer[i + 6] << 8) |
+                (int16_t)large_buffer[i + 7];
 
-                // Convert to centi-Celsius (https://github.com/CalgaryToSpace/CTS-SAT-1-OBC-Firmware/issues/462):
-                // Celsius = raw_temp / 128.0
-                // centi-Celsius = (raw_temp * 100) / 128
-                const int32_t temp_centi = (raw_temp * 100) / 128;
+            // Convert to centi-Celsius (https://github.com/CalgaryToSpace/CTS-SAT-1-OBC-Firmware/issues/462):
+            // Celsius = raw_temp / 128.0
+            // centi-Celsius = (raw_temp * 100) / 128
+            const int32_t temp_centi = (raw_temp * 100) / 128;
 
-                temp_sum_centi += temp_centi;
-                temp_count++;
-            }
+            temp_sum_centi += temp_centi;
+            temp_count++;
         }
     }
 

--- a/misc_tools/exec_blob/extended_beacon_blob/extended_beacon_blob_main.c
+++ b/misc_tools/exec_blob/extended_beacon_blob/extended_beacon_blob_main.c
@@ -127,6 +127,39 @@ extern void LOG_message(
 //     #endif
 // }
 
+// MARK: Error Enum
+
+// All named status/error codes returned by this blob's functions, including the values
+// `blob_main()` itself returns to the telecommand executor (0 = success).
+typedef enum {
+    BLOB_ERR_OK = 0,
+    BLOB_ERR_DOWNLINK_FAILED = 60, // AX100_downlink_bytes() failed to send the beacon packet.
+    BLOB_ERR_PERIPHERAL_COMMS_FAILURES = 117, // Beacon was sent, but >=1 peripheral query failed.
+    BLOB_ERR_MISSING_ARGS = 135, // One or more required args_str tokens were empty.
+    BLOB_ERR_INVALID_INT_ARGS = 136, // One or more args_str tokens failed integer parsing.
+    BLOB_ERR_CANCEL_RERUNS_FAILED = 137, // cancel_other_scheduled_reruns_of_this_blob() failed.
+    BLOB_ERR_NO_EXECUTING_AGENDA_SLOT = 163, // Couldn't find our own agenda slot to reschedule.
+    BLOB_ERR_AGENDA_ADD_FAILED = 164, // TCMD_add_tcmd_to_agenda() failed while rescheduling.
+} BLOB_ext_beacon_error_enum_t;
+
+/// @brief Convert a BLOB_ext_beacon_error_enum_t into a short human-readable name, for use in log
+///     messages and output strings.
+/// @return Static string; never NULL. "UNKNOWN_ERROR" for values not in the enum.
+static const char *ext_beacon_blob_error_to_str(BLOB_ext_beacon_error_enum_t err) {
+    switch (err) {
+        case BLOB_ERR_OK: return "OK";
+        case BLOB_ERR_DOWNLINK_FAILED: return "DOWNLINK_FAILED";
+        case BLOB_ERR_PERIPHERAL_COMMS_FAILURES: return "PERIPHERAL_COMMS_FAILURES";
+        case BLOB_ERR_MISSING_ARGS: return "MISSING_ARGS";
+        case BLOB_ERR_INVALID_INT_ARGS: return "INVALID_INT_ARGS";
+        case BLOB_ERR_CANCEL_RERUNS_FAILED: return "CANCEL_RERUNS_FAILED";
+        case BLOB_ERR_NO_EXECUTING_AGENDA_SLOT: return "NO_EXECUTING_AGENDA_SLOT";
+        case BLOB_ERR_AGENDA_ADD_FAILED: return "AGENDA_ADD_FAILED";
+        default: return "UNKNOWN_ERROR";
+    }
+}
+
+
 #pragma pack(push, 1)
 
 typedef struct {
@@ -511,10 +544,10 @@ static int16_t cancel_other_scheduled_reruns_of_this_blob(int16_t current_slot_n
 
 /// @brief Enqueue a copy of the currently executing tcmd, with a new time into the future to execute.
 /// @note This function avoids incrementing the "total telecommands" counter. Goal: Allow that counter to assess how many uplinked commands were successful.
-static uint8_t reschedule_current_blob_tcmd(uint32_t time_into_future_to_execute_ms) {
+static BLOB_ext_beacon_error_enum_t reschedule_current_blob_tcmd(uint32_t time_into_future_to_execute_ms) {
     const int16_t slot_num = get_current_executing_tcmd_agenda_slot_num();
     if (slot_num < 0) {
-        return 163;
+        return BLOB_ERR_NO_EXECUTING_AGENDA_SLOT;
     }
 
     TCMD_parsed_tcmd_to_execute_t new_tcmd;
@@ -524,14 +557,14 @@ static uint8_t reschedule_current_blob_tcmd(uint32_t time_into_future_to_execute
     new_tcmd.timestamp_to_execute = TIME_get_current_unix_epoch_time_ms() + time_into_future_to_execute_ms;
 
     if (TCMD_add_tcmd_to_agenda(&new_tcmd) != 0) {
-        return 164;
+        return BLOB_ERR_AGENDA_ADD_FAILED;
     }
 
     // Added in v3+.
     // Undo the counter increase in `TCMD_add_tcmd_to_agenda()`.
     TCMD_total_tcmd_queued_count--;
 
-    return 0;
+    return BLOB_ERR_OK;
 }
 
 // MARK: Fill Packet
@@ -936,10 +969,11 @@ uint8_t blob_main(
         // Missing args error.
         snprintf(
             response_buf, response_buf_len,
-            "%s error: missing args!",
-            BLOB_NAME
+            "%s error: missing args! (%s)",
+            BLOB_NAME,
+            ext_beacon_blob_error_to_str(BLOB_ERR_MISSING_ARGS)
         );
-        return 135;
+        return BLOB_ERR_MISSING_ARGS;
     }
 
     bool arg0_beacon_interval_ms_ok;
@@ -948,10 +982,11 @@ uint8_t blob_main(
     if (!arg0_beacon_interval_ms_ok) {
         snprintf(
             response_buf, response_buf_len,
-            "%s error: invalid int args!",
-            BLOB_NAME
+            "%s error: invalid int args! (%s)",
+            BLOB_NAME,
+            ext_beacon_blob_error_to_str(BLOB_ERR_INVALID_INT_ARGS)
         );
-        return 136;
+        return BLOB_ERR_INVALID_INT_ARGS;
     }
 
     // Protect the minimum repeat interval! Too low of value would make it so we can't uplink to
@@ -968,11 +1003,12 @@ uint8_t blob_main(
     if (cancel_result < 0) {
         snprintf(
             response_buf, response_buf_len,
-            "%s error: cancel_other_scheduled_reruns_of_this_blob() -> %d",
+            "%s error: cancel_other_scheduled_reruns_of_this_blob() -> %d (%s)",
             BLOB_NAME,
-            cancel_result
+            cancel_result,
+            ext_beacon_blob_error_to_str(BLOB_ERR_CANCEL_RERUNS_FAILED)
         );
-        return 137;
+        return BLOB_ERR_CANCEL_RERUNS_FAILED;
     }
     else if (cancel_result > 0) {
         snprintf(
@@ -992,29 +1028,32 @@ uint8_t blob_main(
     COMMS_fill_beacon_extended_packet(&beacon_packet, &peripheral_comms_error_count);
 
     // Downlink the beacon packet.
-    const uint8_t tx_success = AX100_downlink_bytes(
+    const uint8_t tx_status = AX100_downlink_bytes(
         (uint8_t *)(&beacon_packet), 
         sizeof(COMMS_beacon_extended_packet_t)
     );
-    if (tx_success != 0) {
+    if (tx_status != 0) {
         snprintf(
             response_buf, response_buf_len,
-            "%s error: downlink failed (AX100_downlink_bytes() -> %d)%s",
+            "%s error: downlink failed (AX100_downlink_bytes() -> %d) (%s)%s",
             BLOB_NAME,
-            tx_success,
+            tx_status,
+            ext_beacon_blob_error_to_str(BLOB_ERR_DOWNLINK_FAILED),
             cancel_msg
         );
-        return tx_success;
+        return BLOB_ERR_DOWNLINK_FAILED;
     }
 
     if (beacon_interval_ms > 0) {
-        const uint8_t reexec_result = reschedule_current_blob_tcmd(beacon_interval_ms);
-        if (reexec_result != 0) {
+        const BLOB_ext_beacon_error_enum_t reexec_result = reschedule_current_blob_tcmd(
+            (uint32_t)beacon_interval_ms
+        );
+        if (reexec_result != BLOB_ERR_OK) {
             snprintf(
                 response_buf, response_buf_len,
-                "%s error: reschedule_current_blob_tcmd() -> %d%s",
+                "%s error: reschedule_current_blob_tcmd() -> %s%s",
                 BLOB_NAME,
-                reexec_result,
+                ext_beacon_blob_error_to_str(reexec_result),
                 cancel_msg
             );
             return reexec_result;
@@ -1024,12 +1063,13 @@ uint8_t blob_main(
     if (peripheral_comms_error_count > 0) {
         snprintf(
             response_buf, response_buf_len,
-            "%s error: peripheral comms error count: %d%s",
+            "%s error: peripheral comms error count: %d (%s)%s",
             BLOB_NAME,
             peripheral_comms_error_count,
+            ext_beacon_blob_error_to_str(BLOB_ERR_PERIPHERAL_COMMS_FAILURES),
             cancel_msg
         );
-        return 117;
+        return BLOB_ERR_PERIPHERAL_COMMS_FAILURES;
     }
 
     snprintf(
@@ -1039,5 +1079,5 @@ uint8_t blob_main(
         cancel_msg
     );
 
-    return 0;
+    return BLOB_ERR_OK;
 }


### PR DESCRIPTION
Tiny improvements to the extended beacon blob.

### Change Log/Summary

* v4
    * Tiny upgrade to v3. No changes to the format.
    * Has version string ` X4\0`
    * Has packet ID `COMMS_PACKET_TYPE_BEACON_EXTENDED = 0x20`
    * Change 1 (fix): MPI temperature fetching now supports negative Celsius temperatures.
    * Change 2: Prevent bouncing in the `pending_queued_tcmd_count` field between extended and basic beacons.
    * Improvement: Use error enum for error reporting.